### PR TITLE
chore: exporting all symbols from bin/cli

### DIFF
--- a/bin/cli/src/commands/bench.rs
+++ b/bin/cli/src/commands/bench.rs
@@ -38,7 +38,7 @@ pub struct CommonArgs {
     pub mode: ProofMode,
 }
 
-fn parse_proof_mode(s: &str) -> Result<ProofMode> {
+pub fn parse_proof_mode(s: &str) -> Result<ProofMode> {
     ProofMode::from_str_name(&s.to_ascii_uppercase())
         .ok_or_else(|| eyre::eyre!("Invalid proof mode"))
 }

--- a/bin/cli/src/lib.rs
+++ b/bin/cli/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod commands;
 
-pub use commands::bench::BenchCommand;
-pub use commands::bench::CommonArgs;
+pub use commands::bench::*;


### PR DESCRIPTION
for cluster-private to use all needed methods\structs.

tested by local build