### PR TITLE
fix: include basic proto types in build script

### DIFF
--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &["../../proto/worker.proto", "../../proto/cluster.proto"],
-            &["../../proto/"],
+            &["../../proto/", "/usr/include"],
         )?;
 
     println!("cargo:rerun-if-env-changed=BUILD_GIT_SHA");


### PR DESCRIPTION
This seems to be needed in certain operating systems