### PR TITLE
fixing lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Install cargo shear and cargo sort
         run: |
           # Ignore error if it's installed already
-          cargo shear --help || cargo install cargo-shear --locked
+          # NOTE: cargo-shear@v1.5.2 requires rustc 1.88
+          cargo shear --help || cargo install cargo-shear@1.5.1 --locked
           cargo sort --help || cargo install cargo-sort --locked
 
       - name: Run cargo shear


### PR DESCRIPTION
a recent cargo-shear release requires rustc 1.88 which we don't setup for now: https://github.com/succinctlabs/sp1-cluster/actions/runs/18015964425/job/51260788823

a quick fix to fix it to the previous release of it to unblock lint.yml