### PR TITLE
fix: `cd cluster` -> `cd sp1-cluster`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To get started, you will need to have the following installed:
 
 ```bash
 git clone https://github.com/succinctlabs/sp1-cluster.git
-cd cluster
+cd sp1-cluster
 
 # Build
 cargo build --release


### PR DESCRIPTION
This PR fixes a typo in the cd command right after cloning the repo: `cd sp1-cluster` rather than `cd cluster`.
