### PR TITLE
fix(infra): increase cpu-node memory to 96Gi, reduce redis to 10Gi

### DIFF
--- a/infra/charts/redis-store/values.yaml
+++ b/infra/charts/redis-store/values.yaml
@@ -35,7 +35,7 @@ redis:
       acllog-max-len 128
 
       io-threads 16
-      maxmemory 30gb
+      maxmemory 8gb
       maxmemory-policy allkeys-lru
       hz 100
 

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -22,9 +22,9 @@ redis-store:
     master:
       resources:
         limits:
-          memory: "30Gi"
+          memory: "10Gi"
         requests:
-          memory: "30Gi"
+          memory: "10Gi"
     # Recommended to place on a non-worker machine.
     # nodeSelector: {}
     # tolerations: []
@@ -61,13 +61,13 @@ cpu-node:
           name: cluster-secrets
           key: REDIS_NODES
   resources:
-    # At least 48 GB of RAM to fit Controller + PlonkWrap concurrently.
+    # At least 96 GB of RAM to fit Controller + PlonkWrap concurrently with overhead.
     requests:
       cpu: 4
-      memory: 48Gi
+      memory: 96Gi
     limits:
       cpu: 8
-      memory: 48Gi
+      memory: 96Gi
   image:
     tag: "base-v2.0.3"
   imagePullSecrets:


### PR DESCRIPTION
## Summary
- Increase cpu-node memory request/limit from 48Gi to 96Gi to prevent OOMKilled during Controller + PlonkWrap co-scheduling
- Reduce redis memory request/limit from 30Gi to 10Gi (actual usage is ~26Mi)
- Reduce redis maxmemory from 30gb to 8gb to fit within new limit

## Context
cpu-node was OOMKilled repeatedly (5 restarts in 2.5 days). Root cause: Controller (~19GB) + PlonkWrap (~32GB) + overhead (~10GB) = ~61GB exceeded the 64Gi pod limit. The 96Gi value matches `docker-compose.manager.yml` and the op-succinct docs recommendation.

Redis was over-provisioned at 30Gi request despite only using ~26Mi. On a 128GB node (120.3Gi allocatable), 30Gi redis + 96Gi cpu-node wouldn't fit. Reducing redis to 10Gi brings total allocation to ~107Gi (89%).

## Test plan
- [x] Applied via kubectl — cpu-node (96Gi) and redis (10Gi) both Running
- [ ] Monitor for OOMKilled recurrence over 2-3 days