### PR TITLE
feat(fulfiller): make polling interval configurable, default to 3s

### DIFF
--- a/crates/fulfillment/src/config.rs
+++ b/crates/fulfillment/src/config.rs
@@ -33,10 +33,18 @@ pub struct FulfillerSettings {
     /// filtered on submit/fail, preventing cross-submission when multiple fulfillers share
     /// a coordinator. Set via EXECUTOR_NAME or FULFILLER_NAME env var.
     pub name: Option<String>,
+    /// How often (in seconds) the fulfiller polls for new/completed requests.
+    /// Lower values reduce E2E latency but increase query volume.
+    #[serde(default = "default_refresh_interval_sec")]
+    pub refresh_interval_sec: u64,
 }
 
 fn default_request_probability() -> f64 {
     1.0
+}
+
+fn default_refresh_interval_sec() -> u64 {
+    1
 }
 
 impl FulfillerSettings {

--- a/crates/fulfillment/src/config.rs
+++ b/crates/fulfillment/src/config.rs
@@ -44,7 +44,7 @@ fn default_request_probability() -> f64 {
 }
 
 fn default_refresh_interval_sec() -> u64 {
-    1
+    3
 }
 
 impl FulfillerSettings {

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -91,7 +91,10 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 
     /// Runs the fulfiller loop.
     pub async fn run(self: Arc<Self>) -> Result<()> {
-        info!("starting the fulfiller with refresh interval {}s", self.refresh_interval.as_secs());
+        info!(
+            "starting the fulfiller with refresh interval {}s",
+            self.refresh_interval.as_secs()
+        );
 
         // Get the prover.
         // TODO: Use backoff here.

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -91,7 +91,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 
     /// Runs the fulfiller loop.
     pub async fn run(self: Arc<Self>) -> Result<()> {
-        info!("starting the fulfiller with refresh interval {:?}", self.refresh_interval);
+        info!("starting the fulfiller with refresh interval {}s", self.refresh_interval.as_secs());
 
         // Get the prover.
         // TODO: Use backoff here.

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -23,11 +23,6 @@ pub mod metrics;
 pub mod network;
 pub mod run;
 
-/// How long to wait between checking for requesters to start proving on and fulfilling proofs.
-///
-/// Lower values will result in faster E2E latency for the user, but more outgoing requests to the
-/// cluster.
-const REFRESH_INTERVAL_SEC: u64 = 3;
 /// The maximum number of requests to handle in a single refresh loop.
 const REQUEST_LIMIT: u32 = 1000;
 /// The error strings that should trigger a VERIFICATION_KEY_MISMATCH error.
@@ -56,6 +51,8 @@ pub struct Fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork
     /// filtered on submit/fail, preventing cross-submission when multiple fulfillers share
     /// a coordinator.
     name: Option<String>,
+    /// How often the fulfiller polls for new/completed requests.
+    refresh_interval: Duration,
 }
 
 impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N> {
@@ -73,6 +70,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         disable_fulfillment: bool,
         request_probability: f64,
         name: Option<String>,
+        refresh_interval_sec: u64,
     ) -> Self {
         Self {
             network,
@@ -87,12 +85,13 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             disable_fulfillment,
             request_probability,
             name,
+            refresh_interval: Duration::from_secs(refresh_interval_sec),
         }
     }
 
     /// Runs the fulfiller loop.
     pub async fn run(self: Arc<Self>) -> Result<()> {
-        info!("starting the fulfiller");
+        info!("starting the fulfiller with refresh interval {:?}", self.refresh_interval);
 
         // Get the prover.
         // TODO: Use backoff here.
@@ -121,7 +120,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                 self.metrics.main_loop_errors.increment(1);
             }
             // Wait for the next interval.
-            sleep(Duration::from_secs(REFRESH_INTERVAL_SEC)).await;
+            sleep(self.refresh_interval).await;
         }
     }
 

--- a/crates/fulfillment/src/run.rs
+++ b/crates/fulfillment/src/run.rs
@@ -96,6 +96,7 @@ pub async fn run_fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentN
         settings.disable_fulfillment,
         settings.request_probability,
         settings.name.clone(),
+        settings.refresh_interval_sec,
     );
     let fulfiller = Arc::new(fulfiller);
 


### PR DESCRIPTION
## Summary
- Make fulfiller polling interval configurable via `FULFILLER_REFRESH_INTERVAL_SEC` env var
- Default stays at 3s. Saves ~2s avg e2e latency once set to 1s (poll hit twice per request)

## Context
- For low-cycle requests (~6M), proving finishes in ~2s but the hardcoded 3s poll loop adds 0-6s of pure wait