### PR TITLE
feat: add V6 fulfiller unexecuted request metrics

### DIFF
--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -409,7 +409,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         self: &Arc<Self>,
         fulfiller_address: Vec<u8>,
         cluster_requests: &HashSet<String>,
-    ) -> Result<usize> {
+    ) -> Result<(usize, usize)> {
         let network_requests = self
             .network
             .get_schedulable_requests(
@@ -419,6 +419,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                 REQUEST_LIMIT,
             )
             .await?;
+        let network_request_count = network_requests.len();
 
         // Filter requested requests that are in the network but not in the cluster. Requests are
         // returned in order of oldest first, so we also reverse to schedule newest requests first
@@ -467,7 +468,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         self.metrics.schedulable_requests.set(requests.len() as f64);
 
         if requests.is_empty() {
-            return Ok(0);
+            return Ok((network_request_count, 0));
         }
 
         let num_requests = requests.len();
@@ -497,7 +498,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         });
 
         join_all(schedule_tasks).await;
-        Ok(num_requests)
+        Ok((network_request_count, num_requests))
     }
 
     /// Checks for assigned requests that are in the network but not in the cluster, and schedules
@@ -526,6 +527,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         // Schedule the requests in parallel for each fulfiller.
         let mut join_set = JoinSet::new();
         let cluster_requests_len = cluster_requests_resp.len();
+        self.metrics.cluster_unexecuted_requests.set(cluster_requests_len as f64);
         let cluster_requests: HashSet<_> =
             cluster_requests_resp.into_iter().map(|r| r.id).collect();
         let cluster_requests = Arc::new(cluster_requests);
@@ -540,13 +542,17 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             });
         }
 
-        let mut total = 0;
-        while let Some(request) = join_set.join_next().await {
-            total += request.unwrap()?;
+        let mut total_network = 0;
+        let mut total_scheduled = 0;
+        while let Some(result) = join_set.join_next().await {
+            let (network_count, scheduled_count) = result.unwrap()?;
+            total_network += network_count;
+            total_scheduled += scheduled_count;
         }
+        self.metrics.network_unexecuted_requests.set(total_network as f64);
         tracing::info!(
             "scheduled {} requests, {} in cluster",
-            total,
+            total_scheduled,
             cluster_requests_len
         );
 

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -526,13 +526,25 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 
         // Schedule the requests in parallel for each fulfiller.
         let mut join_set = JoinSet::new();
-        let cluster_requests_len = cluster_requests_resp.len();
-        self.metrics
-            .cluster_unexecuted_requests
-            .set(cluster_requests_len as f64);
         let cluster_requests: HashSet<_> =
             cluster_requests_resp.into_iter().map(|r| r.id).collect();
         let cluster_requests = Arc::new(cluster_requests);
+
+        // Count unexecuted requests in the cluster (pending + not yet handled by coordinator).
+        let unexecuted_requests = self
+            .cluster
+            .get_proof_requests(ProofRequestListRequest {
+                proof_status: vec![ProofRequestStatus::Pending.into()],
+                handled: Some(false),
+                minimum_deadline: Some(time_now()),
+                limit: Some(REQUEST_LIMIT),
+                ..Default::default()
+            })
+            .map_err(|e| anyhow!("failed to get unexecuted requests: {}", e))
+            .await?;
+        self.metrics
+            .cluster_unexecuted_requests
+            .set(unexecuted_requests.len() as f64);
         for address in fulfiller_addresses {
             let self_clone = self.clone();
             let address = address.clone();
@@ -557,7 +569,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         tracing::info!(
             "scheduled {} requests, {} in cluster",
             total_scheduled,
-            cluster_requests_len
+            cluster_requests.len()
         );
 
         Ok(())

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -527,7 +527,9 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         // Schedule the requests in parallel for each fulfiller.
         let mut join_set = JoinSet::new();
         let cluster_requests_len = cluster_requests_resp.len();
-        self.metrics.cluster_unexecuted_requests.set(cluster_requests_len as f64);
+        self.metrics
+            .cluster_unexecuted_requests
+            .set(cluster_requests_len as f64);
         let cluster_requests: HashSet<_> =
             cluster_requests_resp.into_iter().map(|r| r.id).collect();
         let cluster_requests = Arc::new(cluster_requests);
@@ -549,7 +551,9 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             total_network += network_count;
             total_scheduled += scheduled_count;
         }
-        self.metrics.network_unexecuted_requests.set(total_network as f64);
+        self.metrics
+            .network_unexecuted_requests
+            .set(total_network as f64);
         tracing::info!(
             "scheduled {} requests, {} in cluster",
             total_scheduled,

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -524,27 +524,20 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             .map(|v| v.clone().into_iter().map(|a| a.to_vec()).collect())
             .unwrap_or(vec![prover.to_vec()]);
 
+        // Count unexecuted requests (pending + not yet handled by coordinator).
+        let unexecuted_count = cluster_requests_resp
+            .iter()
+            .filter(|r| r.proof_status == ProofRequestStatus::Pending as i32 && !r.handled)
+            .count();
+        self.metrics
+            .cluster_unexecuted_requests
+            .set(unexecuted_count as f64);
+
         // Schedule the requests in parallel for each fulfiller.
         let mut join_set = JoinSet::new();
         let cluster_requests: HashSet<_> =
             cluster_requests_resp.into_iter().map(|r| r.id).collect();
         let cluster_requests = Arc::new(cluster_requests);
-
-        // Count unexecuted requests in the cluster (pending + not yet handled by coordinator).
-        let unexecuted_requests = self
-            .cluster
-            .get_proof_requests(ProofRequestListRequest {
-                proof_status: vec![ProofRequestStatus::Pending.into()],
-                handled: Some(false),
-                minimum_deadline: Some(time_now()),
-                limit: Some(REQUEST_LIMIT),
-                ..Default::default()
-            })
-            .map_err(|e| anyhow!("failed to get unexecuted requests: {}", e))
-            .await?;
-        self.metrics
-            .cluster_unexecuted_requests
-            .set(unexecuted_requests.len() as f64);
         for address in fulfiller_addresses {
             let self_clone = self.clone();
             let address = address.clone();
@@ -559,7 +552,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         let mut total_network = 0;
         let mut total_scheduled = 0;
         while let Some(result) = join_set.join_next().await {
-            let (network_count, scheduled_count) = result.unwrap()?;
+            let (network_count, scheduled_count) =
+                result.map_err(|e| anyhow!("schedule task panicked: {e}"))??;
             total_network += network_count;
             total_scheduled += scheduled_count;
         }

--- a/crates/fulfillment/src/metrics.rs
+++ b/crates/fulfillment/src/metrics.rs
@@ -48,4 +48,10 @@ pub struct FulfillerMetrics {
 
     /// The current number of schedulable proof requests found in the last check.
     pub schedulable_requests: Gauge,
+
+    /// The current number of unexecuted, unexpired requests in the network.
+    pub network_unexecuted_requests: Gauge,
+
+    /// The current number of unexecuted, unexpired requests in the cluster.
+    pub cluster_unexecuted_requests: Gauge,
 }


### PR DESCRIPTION
## Summary
- Adds `network_unexecuted_requests` and `cluster_unexecuted_requests` gauges to `FulfillerMetrics`, mirroring the V5 executor metrics
- Emits `spn_fulfiller_cluster_unexecuted_requests` (cluster backlog) and `spn_fulfiller_network_unexecuted_requests` (network backlog) in Prometheus
- These are needed to set up V6 Grafana alerts equivalent to the existing V5 "Too Many Unexecuted Requests" alert

## Test plan
- [x] `cargo build --release -p sp1-cluster-fulfillment` compiles successfully
- [ ] Deploy to staging, verify metrics appear at `/metrics` endpoint
- [ ] Confirm `spn_fulfiller_cluster_unexecuted_requests` and `spn_fulfiller_network_unexecuted_requests` appear in Grafana Prometheus explorer