### PR TITLE
chore: bump SP1 to v6.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7476,16 +7476,16 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7494,8 +7494,8 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7504,8 +7504,8 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7518,8 +7518,8 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7540,8 +7540,8 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7566,8 +7566,8 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7581,8 +7581,8 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7593,8 +7593,8 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7603,8 +7603,8 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7616,16 +7616,16 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7638,8 +7638,8 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "futures",
@@ -7671,16 +7671,16 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7693,24 +7693,24 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "ff 0.13.1",
@@ -7736,8 +7736,8 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "futures",
@@ -7756,24 +7756,24 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "futures",
@@ -7794,8 +7794,8 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -7811,16 +7811,16 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -7838,16 +7838,16 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -7856,8 +7856,8 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "derive-where",
  "futures",
@@ -7924,8 +7924,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8229,8 +8229,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8268,8 +8268,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8289,8 +8289,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8303,8 +8303,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8350,8 +8350,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8371,8 +8371,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8381,8 +8381,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-air"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",
@@ -8400,8 +8400,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-basefold"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8433,8 +8433,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-challenger"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8448,8 +8448,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-commit"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8476,8 +8476,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-cudart"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8505,8 +8505,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-assist"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8531,8 +8531,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8553,8 +8553,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8581,8 +8581,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-logup-gkr"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8617,8 +8617,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-merkle-tree"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8642,8 +8642,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-prover"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "clap",
  "serde",
@@ -8676,8 +8676,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-shard-prover"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8710,8 +8710,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-sys"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8726,8 +8726,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracegen"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "futures",
  "rayon",
@@ -8751,8 +8751,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracing"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -8761,8 +8761,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-utils"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8774,8 +8774,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-zerocheck"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8805,8 +8805,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -8852,8 +8852,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -8867,8 +8867,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "bincode",
  "blake3",
@@ -8890,8 +8890,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8953,8 +8953,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8973,8 +8973,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9012,8 +9012,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9032,8 +9032,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9055,8 +9055,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9079,8 +9079,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9101,8 +9101,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9129,16 +9129,6 @@ dependencies = [
  "rustls 0.23.36",
  "serde",
  "sha2",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-commit",
- "slop-jagged",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-tensor",
  "sp1-build",
  "sp1-core-executor",
  "sp1-core-executor-runner",
@@ -9162,8 +9152,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.0.2"
-source = "git+https://github.com/succinctlabs/sp1?branch=main#d9c031d723f3d6e4386ed85eb5b2edc0c0a769e5"
+version = "6.1.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.1.0#d454975ac7c1126097e36eceda9bce2cb9899da4"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,20 @@ spn-network-types = { git = "https://github.com/succinctlabs/network", branch = 
 spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 
 # SP1 (git source required — sp1-gpu-sys crates.io tarball lacks CMake sibling dirs)
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", branch = "main", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", branch = "main", features = ["network"] }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", branch = "main" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", tag = "v6.1.0" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }


### PR DESCRIPTION
## Summary

Bumps SP1 dependencies from `branch = "main"` to `tag = "v6.1.0"` to pick up the patch for [GHSA-63x8-x938-vx33](https://github.com/succinctlabs/sp1/security/advisories/GHSA-63x8-x938-vx33).

A high-severity soundness vulnerability was discovered in the V6 recursive shard verifier: the recursive jagged verifier was missing a consistency check between commitment-side and evaluation-side witnesses, allowing a malicious prover to pass invalid recursive proofs. Affected versions: 6.0.0–6.0.2. Fixed in v6.1.0.

Phase 1 of multi-repo rollout (**sp1-cluster (this)** → tagged as [v2.1.0](https://github.com/succinctlabs/sp1-cluster/releases/tag/v2.1.0) → network-services succinctlabs/network-services#1122 → sp1-cluster-private succinctlabs/sp1-cluster-private#92 → infra).

## Changes

- `Cargo.toml`: all `sp1-*` and `sp1-gpu-*` workspace deps pinned to `tag = "v6.1.0"`
- `Cargo.lock`: regenerated via targeted `cargo update -p` for each changed package
- `# SPN` deps (network repo) untouched
- `vergen = "=9.0.6"` pin preserved (avoids vergen-lib 9.x conflict with vergen-git2)

## Verification

- [x] `# SPN` deps unchanged from main
- [x] Every `sp1-*` / `sp1-gpu-*` dep on `tag = "v6.1.0"`
- [x] No sp1 crate from crates.io in `Cargo.lock`
- [x] `vergen = 9.0.6`, `vergen-lib = 0.1.6` in `Cargo.lock`
- [x] `git diff origin/main -- Cargo.toml` shows only sp1/sp1-gpu tag changes

## Test plan

- [x] CI green
- [x] Merged → tagged as v2.1.0 at adf0bd7
- [ ] Downstream bumps in progress (network-services, sp1-cluster-private, infra)