### PR TITLE
chore: increased recursion limit

### DIFF
--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use eyre::Result;


### PR DESCRIPTION
Increase the recursion limit in the utils crate to 256 to support deeply nested macro expansions.