### PR TITLE
fix: avoid UnknownTask panic cascade when proof state is dropped

### DIFF
--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -1171,6 +1171,18 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                     )));
                 }
             }
+            // Deliver a terminal TaskResult to each task's subscribers so they drain
+            // via the normal completion path once the proof is gone.
+            for task in proof.tasks.values() {
+                if !task.subscribers.is_empty() {
+                    self.notify_subscribers(
+                        &task.subscribers,
+                        proof_id.clone(),
+                        task.id.clone(),
+                        TaskStatus::FailedFatal,
+                    );
+                }
+            }
             for task in proof.tasks.values() {
                 if task.status == TaskStatus::Running {
                     if let Some(worker_id) = &task.worker {
@@ -1377,15 +1389,18 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 .await;
             let proof = state.proofs.get_mut(&proof_id);
             if proof.is_none() {
-                let _ = tx.send(ServerSubMessage {
-                    msg_id: "msg".create_type_id::<V7>().to_string(),
-                    message: Some(server_sub_message::Message::UnknownTask(
-                        proto::UnknownTask {
-                            proof_id: proof_id.clone(),
-                            task_id: task_ids.first().unwrap().clone(),
-                        },
-                    )),
-                });
+                // Emit UnknownTask for every stale task_id the subscriber sent.
+                for task_id in &task_ids {
+                    let _ = tx.send(ServerSubMessage {
+                        msg_id: "msg".create_type_id::<V7>().to_string(),
+                        message: Some(server_sub_message::Message::UnknownTask(
+                            proto::UnknownTask {
+                                proof_id: proof_id.clone(),
+                                task_id: task_id.clone(),
+                            },
+                        )),
+                    });
+                }
                 return Ok(());
             }
             let proof = proof.unwrap();

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -351,7 +351,20 @@ impl WorkerClient for WorkerServiceClient {
                                             break;
                                         }
                                         Some(server_sub_message::Message::UnknownTask(unknown_task)) => {
-                                            panic!("Unknown task {} {}", unknown_task.task_id, unknown_task.proof_id);
+                                            // Report the task as fatally failed and keep serving the subscriber's
+                                            // other tasks.
+                                            tracing::error!(
+                                                "Received UnknownTask from coordinator: task={} proof={}",
+                                                unknown_task.task_id,
+                                                unknown_task.proof_id,
+                                            );
+                                            let mut lock = tasks_set.lock().await;
+                                            lock.remove(&unknown_task.task_id);
+                                            drop(lock);
+                                            let _ = res_tx.send((
+                                                TaskId::new(unknown_task.task_id),
+                                                proto::TaskStatus::FailedFatal,
+                                            ));
                                         }
                                         Some(server_sub_message::Message::ServerHeartbeat(_)) => {
                                             // Send empty UpdateSub message to keep the subscriber alive.


### PR DESCRIPTION
## Summary

When a worker's subscriber receives `UnknownTask` from the coordinator, `crates/worker/src/client.rs:354` panics. On single-worker deployments (external operators running vanilla docker-compose) this orphans the task, the fulfiller's 3s sweeper fires `FailFulfillment(None)`, and the network records `UnknownFailure`. Requester is billed, no proof delivered.

```
thread 'tokio-runtime-worker' panicked at /app/crates/worker/src/client.rs:354:
Unknown task <task_id> <proof_id>
```

The `UnknownTask` itself is emitted by `bin/coordinator/src/lib.rs:1378` when `state.proofs` (an in-memory `DashMap`, no persistence) no longer has the proof a subscriber is asking about. Several paths can leave this inconsistent: the claimer sweep at `bin/coordinator/src/cluster.rs:147-165`, `fail_proof_internal` from controller-no-more-retries / deadline expiry / explicit RPC, and proof cleanup on `active_tasks == 0`.

## Root cause

Sampled 6 `Unknown task` panics in `/aws/ecs/mainnet-v6-hosted-prover-services` and traced each to the coordinator log around the same `proof_id`. 5 of 6 were preceded by:

```
  WARN cluster.rs:151: Running proof  is no longer in cluster DB list
  INFO lib.rs:1226: Failed proof  task_id=None notify_sender=false
  … 1–8 seconds later (next heartbeat) …
  panicked at crates/worker/src/client.rs:354:45: Unknown task
```

Our hosted prover absorbs these silently because worker redundancy + `MAX_TASK_RETRIES=3` + `complete_task` RPC running independently of the subscriber stream completes the orphaned tasks before the fulfiller sweeper catches a `Failed` row. External operators don't have that buffer, so the same mechanism is visible at the network boundary.
