### PR TITLE
perf(worker): gpu-node parity with sp1-gpu (shard config + cgroup-aware max weight)

### DIFF
--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -2,16 +2,41 @@ use sp1_core_executor::{SP1CoreOpts, ELEMENT_THRESHOLD};
 use sp1_core_machine::riscv::RiscvAir;
 use sp1_prover::worker::SP1WorkerConfig;
 
+/// Default `log2(shard_size)` for the cluster, matching sp1-gpu's
+/// `local_gpu_opts()` for the 24GB GPU tier. Override with
+/// `SP1_CLUSTER_LOG2_SHARD_SIZE`.
+const DEFAULT_LOG2_SHARD_SIZE: u32 = 24;
+
+/// Sharding `element_threshold` offset below `ELEMENT_THRESHOLD`, matching
+/// sp1-gpu's 24GB tier. Sizing this above the tier produces shards smaller
+/// than the GPU can fill, adding per-shard overhead. Override with
+/// `SP1_CLUSTER_SHARD_THRESHOLD`.
+const DEFAULT_SHARD_THRESHOLD_OFFSET: u64 = (1 << 26) + (1 << 25);
+
+fn read_env<T: std::str::FromStr>(name: &str) -> Option<T> {
+    std::env::var(name).ok().and_then(|s| s.parse().ok())
+}
+
 /// The core opts for the cluster.
+///
+/// Hand-maintained copy of `local_gpu_opts()`'s ≤30GB GPU tier; can drift from
+/// upstream. Can't import it directly — it does a CUDA memory probe and panics
+/// off-GPU, but this config also runs on CPU workers. TODO: upstream a pure tier
+/// table (no hardware probe) in `sp1-gpu` that both can share.
 pub fn cluster_opts() -> SP1CoreOpts {
     let mut opts = SP1CoreOpts::default();
 
-    let shard_threshold = ELEMENT_THRESHOLD - (1 << 27) - (1 << 26);
+    let log2_shard_size =
+        read_env("SP1_CLUSTER_LOG2_SHARD_SIZE").unwrap_or(DEFAULT_LOG2_SHARD_SIZE);
+    opts.shard_size = 1 << log2_shard_size;
 
-    println!("Shard threshold: {shard_threshold}");
+    let shard_threshold = read_env("SP1_CLUSTER_SHARD_THRESHOLD")
+        .unwrap_or(ELEMENT_THRESHOLD - DEFAULT_SHARD_THRESHOLD_OFFSET);
     opts.sharding_threshold.element_threshold = shard_threshold;
+
     opts.global_dependencies_opt = option_env!("SP1_CLUSTER_CPU_ONLY").is_none();
 
+    tracing::info!(log2_shard_size, shard_threshold, "cluster_opts configured");
     opts
 }
 

--- a/crates/worker/src/limiter.rs
+++ b/crates/worker/src/limiter.rs
@@ -1,16 +1,21 @@
 use crate::MAX_WEIGHT_OVERRIDE;
 
-/// `/dev/shm` size in GiB, or `None` if it can't be read or looks degenerate.
+/// Per-worker concurrency budget: the smaller of the RAM- and `/dev/shm`-derived limits.
 ///
-/// Execution children mmap their buffers into this tmpfs, so its size bounds concurrent execution
-/// independently of total RAM.
-fn dev_shm_gb() -> Option<u64> {
-    let stat = rustix::fs::statvfs("/dev/shm").ok()?;
-    // total bytes = blocks × fragment size; a 0 in either means "unknown", not a 0-GiB budget.
-    if stat.f_frsize == 0 || stat.f_blocks == 0 {
-        return None;
-    }
-    Some(stat.f_blocks.saturating_mul(stat.f_frsize) / 1024 / 1024 / 1024)
+/// `WORKER_MAX_WEIGHT_OVERRIDE` bypasses the cap for workers whose weight doesn't track host RAM
+/// (e.g. GPU workers).
+pub fn get_max_weight() -> usize {
+    let total_ram_gb = total_memory_gb();
+    let shm_gb = dev_shm_gb();
+    let max_weight = compute_max_weight(total_ram_gb, shm_gb, *MAX_WEIGHT_OVERRIDE);
+    // Surface the inputs so operators can see what /dev/shm was read and whether the cap fired.
+    tracing::info!(
+        total_ram_gb,
+        ?shm_gb,
+        max_weight,
+        "computed worker max_weight"
+    );
+    max_weight
 }
 
 /// Pure budget logic, split from the I/O in [`get_max_weight`]. Weight ≈ GiB of working set per task.
@@ -46,22 +51,107 @@ fn compute_max_weight(
     }
 }
 
-/// Per-worker concurrency budget: the smaller of the RAM- and `/dev/shm`-derived limits.
+/// Total memory budget in GiB, cgroup-aware.
 ///
-/// `WORKER_MAX_WEIGHT_OVERRIDE` bypasses the cap for workers whose weight doesn't track host RAM
-/// (e.g. GPU workers).
-pub fn get_max_weight() -> usize {
-    let total_ram_gb = sys_info::mem_info().unwrap().total / 1024 / 1024;
-    let shm_gb = dev_shm_gb();
-    let max_weight = compute_max_weight(total_ram_gb, shm_gb, *MAX_WEIGHT_OVERRIDE);
-    // Surface the inputs so operators can see what /dev/shm was read and whether the cap fired.
-    tracing::info!(
-        total_ram_gb,
-        ?shm_gb,
-        max_weight,
-        "computed worker max_weight"
-    );
-    max_weight
+/// Resolution order:
+///   1. Cgroup memory limit — the correct answer inside Docker / k8s pods.
+///   2. `/proc/meminfo` — the correct answer on bare hosts.
+///
+/// The cgroup step matters because `/proc/meminfo` inside a container reports
+/// the host's RAM, not the cgroup limit; without it, memory-limited workers
+/// detect host RAM and the coordinator over-schedules them.
+///
+/// Only a *hard* limit is read (`memory.max` / `memory.limit_in_bytes`, set by
+/// Docker `--memory` or k8s `limits`). Soft reservations (k8s `requests`, ECS
+/// `memoryReservation`) live in a cgroup file this does not read, so the hard
+/// file reads "unlimited" and resolution falls back to host RAM. Deployments
+/// that set only soft reservations must bound the budget via `/dev/shm`
+/// ([`dev_shm_gb`]) or `WORKER_MAX_WEIGHT_OVERRIDE`.
+fn total_memory_gb() -> u64 {
+    let (total_bytes, source) = match cgroup_memory_limit_bytes() {
+        Some(b) => (b, MemorySource::Cgroup),
+        // sys_info::MemInfo::total is in KB.
+        None => match sys_info::mem_info() {
+            Ok(info) => (info.total * 1024, MemorySource::ProcMeminfo),
+            Err(e) => {
+                tracing::error!(error = %e, "failed to read /proc/meminfo; memory budget = 0");
+                (0, MemorySource::Unavailable)
+            }
+        },
+    };
+    let total_gb = total_bytes / (1024 * 1024 * 1024);
+    if total_gb == 0 {
+        tracing::error!(
+            ?source,
+            total_bytes,
+            "memory budget resolved to 0 GiB; worker will accept no work"
+        );
+    }
+    tracing::debug!(?source, total_gb, "resolved total memory budget");
+    total_gb
+}
+
+/// Where [`total_memory_gb`] read its figure, for operator-facing logs.
+#[derive(Clone, Copy, Debug)]
+enum MemorySource {
+    Cgroup,
+    ProcMeminfo,
+    Unavailable,
+}
+
+/// Read the cgroup memory limit (in bytes) for the current process.
+///
+/// Returns `None` when there is no limit, the cgroup files don't exist, or
+/// the value is the kernel's "unlimited" sentinel. Tries cgroup v2 first
+/// (default on modern Linux), then falls back to v1.
+fn cgroup_memory_limit_bytes() -> Option<u64> {
+    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+        if let Some(v) = parse_cgroup_v2(&s) {
+            return Some(v);
+        }
+    }
+    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
+        if let Some(v) = parse_cgroup_v1(&s) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// cgroup v2 memory.max: either a byte count or the literal string `max`
+/// for "no limit".
+fn parse_cgroup_v2(content: &str) -> Option<u64> {
+    let s = content.trim();
+    if s == "max" {
+        return None;
+    }
+    s.parse().ok()
+}
+
+/// cgroup v1 memory.limit_in_bytes: always a byte count. The kernel writes
+/// a sentinel value (typically `0x7FFFFFFFFFFFF000`) for "no limit". Treat
+/// anything above 1 PiB as effectively unlimited so we fall back to
+/// `/proc/meminfo`, which gives a more useful answer on bare hosts than
+/// "we have 8 exabytes of RAM."
+fn parse_cgroup_v1(content: &str) -> Option<u64> {
+    let v: u64 = content.trim().parse().ok()?;
+    if v >= (1 << 50) {
+        return None;
+    }
+    Some(v)
+}
+
+/// `/dev/shm` size in GiB, or `None` if it can't be read or looks degenerate.
+///
+/// Execution children mmap their buffers into this tmpfs, so its size bounds concurrent execution
+/// independently of total RAM.
+fn dev_shm_gb() -> Option<u64> {
+    let stat = rustix::fs::statvfs("/dev/shm").ok()?;
+    // total bytes = blocks × fragment size; a 0 in either means "unknown", not a 0-GiB budget.
+    if stat.f_frsize == 0 || stat.f_blocks == 0 {
+        return None;
+    }
+    Some(stat.f_blocks.saturating_mul(stat.f_frsize) / 1024 / 1024 / 1024)
 }
 
 #[cfg(test)]
@@ -77,7 +167,9 @@ mod tests {
 
     #[test]
     fn ram_budget_when_shm_unknown() {
-        assert_eq!(compute_max_weight(64, None, NO_OVERRIDE), 64);
+        // 60 (not a multiple of 16) must pass through unchanged — the budget is the
+        // measured RAM, never rounded.
+        assert_eq!(compute_max_weight(60, None, NO_OVERRIDE), 60);
     }
 
     #[test]
@@ -97,8 +189,38 @@ mod tests {
     }
 
     #[test]
-    fn ram_budget_never_exceeds_measured() {
-        // 60 (not a multiple of 16) must stay 60, not snap up to 64.
-        assert_eq!(compute_max_weight(60, None, NO_OVERRIDE), 60);
+    fn cgroup_v2_max_means_no_limit() {
+        assert_eq!(parse_cgroup_v2("max\n"), None);
+        assert_eq!(parse_cgroup_v2("  max "), None);
+    }
+
+    #[test]
+    fn cgroup_v2_byte_count_parses() {
+        assert_eq!(parse_cgroup_v2("51539607552\n"), Some(51_539_607_552));
+        assert_eq!(parse_cgroup_v2("0"), Some(0));
+    }
+
+    #[test]
+    fn cgroup_v2_garbage_is_none() {
+        assert_eq!(parse_cgroup_v2("garbage"), None);
+        assert_eq!(parse_cgroup_v2(""), None);
+    }
+
+    #[test]
+    fn cgroup_v1_byte_count_parses() {
+        assert_eq!(parse_cgroup_v1("51539607552\n"), Some(51_539_607_552));
+    }
+
+    #[test]
+    fn cgroup_v1_unlimited_sentinel_is_none() {
+        // 0x7FFFFFFFFFFFF000 — what the kernel writes for "no limit" on
+        // 4k-page x86_64. Anything past 1 PiB should be treated as
+        // unlimited.
+        assert_eq!(parse_cgroup_v1("9223372036854771712\n"), None);
+        assert_eq!(parse_cgroup_v1(&format!("{}", 1u64 << 50)), None);
+        assert_eq!(
+            parse_cgroup_v1(&format!("{}", (1u64 << 50) - 1)),
+            Some((1u64 << 50) - 1)
+        );
     }
 }

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -46,13 +46,22 @@ cpu-node:
         # Change this to any desired path on the host where circuit artifacts should be stored.
         path: /tmp/.sp1/circuits
         type: DirectoryOrCreate
+    # Memory-backed /dev/shm. Without it, k8s gives /dev/shm a tiny default that
+    # floors the worker's auto-detected max_weight = min(RAM, /dev/shm) to ~0.
+    # Size this to the memory limit.
+    - name: dshm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 96Gi
   volumeMounts:
     - name: sp1-circuits
       mountPath: /root/.sp1/circuits
+    - name: dshm
+      mountPath: /dev/shm
   extraEnv:
     NODE_COORDINATOR_RPC: http://coordinator-grpc:50051
-    # Set this based on how many GB of RAM is available.
-    WORKER_MAX_WEIGHT_OVERRIDE: "96"
+    # WORKER_MAX_WEIGHT_OVERRIDE is auto-detected from the pod's cgroup
+    # memory limit; only set it if the auto-detect picks the wrong value.
     NODE_ARTIFACT_STORE: redis
     NODE_REDIS_NODES:
       valueFrom:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -62,8 +62,6 @@ services:
     image: ghcr.io/succinctlabs/sp1-cluster:base-v2.3.2
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
-      # Must be <= container memory in GB (see deploy.resources.limits.memory below).
-      - WORKER_MAX_WEIGHT_OVERRIDE=96
       - NODE_ARTIFACT_STORE=redis
       - NODE_REDIS_NODES=redis://:redispassword@redis:6379/0
       - WORKER_TYPE=CPU
@@ -88,8 +86,6 @@ services:
     image: ghcr.io/succinctlabs/sp1-cluster:base-v2.3.2
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
-      # Must be <= container memory in GB (see deploy.resources.limits.memory below).
-      - WORKER_MAX_WEIGHT_OVERRIDE=96
       - NODE_ARTIFACT_STORE=redis
       - NODE_REDIS_NODES=redis://:redispassword@redis:6379/0
       - WORKER_TYPE=ALL


### PR DESCRIPTION
End-state: cluster gpu-node prove time matches sp1-gpu's local prover. Two parity fixes for self-hosted GPU workers.

## 1. Shard config

[crates/worker/src/config.rs](crates/worker/src/config.rs): defaults now match sp1-gpu's `local_gpu_opts()` 24GB tier:
- `shard_size = 1 << 24`
- `element_threshold = ELEMENT_THRESHOLD - 96M`

The previous values (`ELEMENT_THRESHOLD - 192M`) were a tier more conservative — shards came out smaller than the GPU's actual allocation, paying extra per-shard overhead. `SP1_CLUSTER_LOG2_SHARD_SIZE` / `SP1_CLUSTER_SHARD_THRESHOLD` env vars override for tuning. `TODO` to import directly from sp1-gpu so the cluster automatically tracks SP1's tuning.

## 2. Cgroup-aware max weight

[crates/worker/src/limiter.rs](crates/worker/src/limiter.rs): `sys_info::mem_info()` reads `/proc/meminfo`, which inside a Docker container reports the **host's** RAM, not the cgroup limit. On a 256G host with `deploy.resources.limits.memory=48G`, the worker auto-detected `max_weight=256` and the coordinator over-scheduled it → OOM unless `WORKER_MAX_WEIGHT_OVERRIDE` was set manually.

New resolution order:
1. `WORKER_MAX_WEIGHT_OVERRIDE` (explicit operator override)
2. cgroup v2 `/sys/fs/cgroup/memory.max` or v1 `memory.limit_in_bytes`
3. `/proc/meminfo` (correct on bare hosts)

Round-up to nearest 16 GB removed (would overshoot a 24G container). `WORKER_MAX_WEIGHT_OVERRIDE` is no longer required in `infra/docker-compose.yml` or `infra/charts/sp1-cluster/values-example.yaml`; auto-detect produces the exact values that were previously hard-coded.

## Test plan

- [x] `cargo test -p sp1-cluster-worker limiter` — 5 unit tests on cgroup parsers
- [ ] Live: rebuild gpu0 container, verify startup log shows `cluster_opts configured log2_shard_size=24 shard_threshold=301989888` and `worker max weight max_weight=24 source=cgroup`
- [ ] Live: bench with sp1-perf, confirm cluster prove time matches sp1-gpu local

🤖 Generated with [Claude Code](https://claude.com/claude-code)