### PR TITLE
fix(fulfiller): cancel requests the network marked Unfulfillable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
         "runner=32cpu-linux-x64",
         "run-id=${{ github.run_id }}",
         "spot=false",
+        "disk=large",
         "tag=lint",
       ]
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1857,7 +1857,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4118,7 +4118,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6079,8 +6079,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6126,7 +6126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -9190,7 +9190,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#81be73ca2ca8439684b773ee5a9344cc92c7ca81"
+source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#81be73ca2ca8439684b773ee5a9344cc92c7ca81"
+source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#81be73ca2ca8439684b773ee5a9344cc92c7ca81"
+source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#81be73ca2ca8439684b773ee5a9344cc92c7ca81"
+source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#81be73ca2ca8439684b773ee5a9344cc92c7ca81"
+source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -209,9 +209,7 @@ impl FulfillmentNetwork for MainnetFulfiller {
                 let assigned = spn_network_types::GetFilteredProofRequestsRequest {
                     version: Some(version.to_string()),
                     fulfillment_status: Some(spn_network_types::FulfillmentStatus::Assigned.into()),
-                    execution_status: Some(
-                        spn_network_types::ExecutionStatus::Unexecutable.into(),
-                    ),
+                    execution_status: Some(spn_network_types::ExecutionStatus::Unexecutable.into()),
                     minimum_deadline: Some(minimum_deadline),
                     fulfiller: Some(address.clone()),
                     limit: Some(limit),

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -198,28 +198,37 @@ impl FulfillmentNetwork for MainnetFulfiller {
         minimum_deadline: u64,
         limit: u32,
     ) -> Result<Vec<Self::NetworkRequest>> {
+        // Two terminal shapes the network writes for an assigned request:
+        //   1. `Assigned + Unexecutable`     — oracle reported an exec failure; the
+        //                                      cluster still owes a `fail_fulfillment`.
+        //   2. `Unfulfillable` (any exec)    — network already flipped it terminal
+        //                                      (e.g. gas-limit, validation failure).
         let queries: Vec<_> = fulfiller_addresses
             .into_iter()
-            .map(
-                |address| spn_network_types::GetFilteredProofRequestsRequest {
+            .flat_map(|address| {
+                let assigned = spn_network_types::GetFilteredProofRequestsRequest {
                     version: Some(version.to_string()),
                     fulfillment_status: Some(spn_network_types::FulfillmentStatus::Assigned.into()),
-                    execution_status: Some(spn_network_types::ExecutionStatus::Unexecutable.into()),
-                    execute_fail_cause: None,
+                    execution_status: Some(
+                        spn_network_types::ExecutionStatus::Unexecutable.into(),
+                    ),
                     minimum_deadline: Some(minimum_deadline),
-                    vk_hash: None,
-                    requester: None,
+                    fulfiller: Some(address.clone()),
+                    limit: Some(limit),
+                    ..Default::default()
+                };
+                let unfulfillable = spn_network_types::GetFilteredProofRequestsRequest {
+                    version: Some(version.to_string()),
+                    fulfillment_status: Some(
+                        spn_network_types::FulfillmentStatus::Unfulfillable.into(),
+                    ),
+                    minimum_deadline: Some(minimum_deadline),
                     fulfiller: Some(address),
                     limit: Some(limit),
-                    page: None,
-                    from: None,
-                    to: None,
-                    mode: None,
-                    not_bid_by: None,
-                    settlement_status: None,
-                    error: None,
-                },
-            )
+                    ..Default::default()
+                };
+                [assigned, unfulfillable]
+            })
             .collect();
 
         let responses = join_all(queries.into_iter().map(|request| {
@@ -228,10 +237,16 @@ impl FulfillmentNetwork for MainnetFulfiller {
         }))
         .await;
 
+        // Dedupe in case a status transition races the parallel queries.
+        let mut seen = std::collections::HashSet::new();
         let mut requests = Vec::new();
         for response in responses {
             let response = response?;
-            requests.extend(response.into_inner().requests);
+            for request in response.into_inner().requests {
+                if seen.insert(request.request_id.clone()) {
+                    requests.push(request);
+                }
+            }
         }
 
         Ok(requests.into_iter().map(NetworkProofRequest).collect())


### PR DESCRIPTION
The fulfiller's cancel loop only matched Assigned + Unexecutable, missing requests the network flipped directly to Unfulfillable (gas-limit-exceeded via execute_proof.rs:38-73, and the public-values-hash mismatch path). 
Those stayed claimed on the cluster forever.