### PR TITLE
fix(fulfillment): forward prover failure cause to fail_fulfillment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
+source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
+source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9289,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
+source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
+source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
+source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1857,7 +1857,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4118,7 +4118,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6079,8 +6079,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6126,7 +6126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -8013,6 +8013,7 @@ dependencies = [
  "prost 0.13.5",
  "rustls 0.23.36",
  "serde",
+ "serde_json",
  "sp1-prover-types",
  "tokio-blocked",
  "tonic 0.12.3",
@@ -8096,6 +8097,7 @@ dependencies = [
  "hex",
  "rustls 0.23.36",
  "serde",
+ "serde_json",
  "sp1-cluster-artifact",
  "sp1-cluster-common",
  "sp1-sdk",
@@ -9254,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9266,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9287,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9306,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9324,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#3df3ca07a10a44ab7ae2bcf63ff6625b02c8c355"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fproof-request-error-proving-failure#01694344dc9d4e5fab90176e4baa12bf386cc078"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure", features = ["network"] }
-spn-utils = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "main", features = ["network"] }
+spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 
 # SP1
 sp1-core-executor = "=6.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "main" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "main", features = ["network"] }
-spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure", features = ["network"] }
+spn-utils = { git = "https://github.com/succinctlabs/network", branch = "farhad/proof-request-error-proving-failure" }
 
 # SP1
 sp1-core-executor = "=6.2.1"

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -5,7 +5,10 @@ use futures::future::join_all;
 use prost::Message;
 use sp1_cluster_artifact::ArtifactType;
 use sp1_cluster_common::proto::ProofRequest;
-use sp1_cluster_fulfillment::network::{FulfillmentNetwork, NetworkRequest};
+use sp1_cluster_fulfillment::{
+    network::{FulfillmentNetwork, NetworkRequest},
+    request_error_from_extra_data,
+};
 use sp1_sdk::network::signer::NetworkSigner;
 use spn_artifacts::Artifact;
 
@@ -88,8 +91,8 @@ impl FulfillmentNetwork for MainnetFulfiller {
         _domain: &[u8],
         signer: &NetworkSigner,
     ) -> Result<()> {
-        self.cancel_request(&request.id, signer).await?;
-        Ok(())
+        let error = request_error_from_extra_data(request.extra_data.as_deref());
+        self.fail_request_with_error(&request.id, error, &[], signer).await
     }
 
     async fn cancel_request(&self, request_id: &str, signer: &NetworkSigner) -> Result<()> {

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -92,7 +92,8 @@ impl FulfillmentNetwork for MainnetFulfiller {
         signer: &NetworkSigner,
     ) -> Result<()> {
         let error = request_error_from_extra_data(request.extra_data.as_deref());
-        self.fail_request_with_error(&request.id, error, &[], signer).await
+        self.fail_request_with_error(&request.id, error, &[], signer)
+            .await
     }
 
     async fn cancel_request(&self, request_id: &str, signer: &NetworkSigner) -> Result<()> {

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -347,9 +347,7 @@ impl RedisArtifactClient {
                 .get::<_, Option<Vec<u8>>>(&key)
                 .await
                 .map_err(|e| backoff::Error::transient(e.into()))?
-                .ok_or_else(|| {
-                    backoff::Error::permanent(anyhow!("artifact not found in redis: {}", key))
-                })?;
+                .ok_or_else(|| backoff::Error::permanent(anyhow!("artifact not found: {}", key)))?;
             tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
             return Ok(result);
         }

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -344,9 +344,12 @@ impl RedisArtifactClient {
 
         if total_chunks == 0 {
             let result = conn
-                .get::<_, Vec<u8>>(key)
+                .get::<_, Option<Vec<u8>>>(&key)
                 .await
-                .map_err(|e| backoff::Error::transient(e.into()))?;
+                .map_err(|e| backoff::Error::transient(e.into()))?
+                .ok_or_else(|| {
+                    backoff::Error::permanent(anyhow!("artifact not found in redis: {}", key))
+                })?;
             tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
             return Ok(result);
         }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -24,6 +24,7 @@ opentelemetry_sdk = { workspace = true, features = ["logs", "logs_level_enabled"
 prost.workspace = true
 rustls = { workspace = true, features = ["ring"] }
 serde.workspace = true
+serde_json.workspace = true
 sp1-prover-types = { workspace = true }
 tokio-blocked = { workspace = true, optional = true }
 tonic.workspace = true

--- a/crates/common/src/failure.rs
+++ b/crates/common/src/failure.rs
@@ -16,4 +16,16 @@ impl ProvingFailure {
     pub fn to_extra_data(&self) -> String {
         serde_json::json!({ "proving_failure": self }).to_string()
     }
+
+    /// Parse from the `extra_data` wire string. Returns `None` if the string
+    /// isn't a proving-failure payload.
+    pub fn from_extra_data(s: &str) -> Option<Self> {
+        #[derive(Deserialize)]
+        struct Envelope {
+            proving_failure: ProvingFailure,
+        }
+        serde_json::from_str::<Envelope>(s)
+            .ok()
+            .map(|e| e.proving_failure)
+    }
 }

--- a/crates/common/src/failure.rs
+++ b/crates/common/src/failure.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use crate::proto::TaskType;
+
+/// `extra_data` payload for post-execute task failures.
+/// On the wire as `{"proving_failure": <ProvingFailure>}` to coexist with
+/// the `ExecutionResult` shape written by execute_only.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ProvingFailure {
+    pub task_type: TaskType,
+    pub reason: String,
+}
+
+impl ProvingFailure {
+    /// Render as the `extra_data` wire string.
+    pub fn to_extra_data(&self) -> String {
+        serde_json::json!({ "proving_failure": self }).to_string()
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod consts;
+pub mod failure;
 pub mod logger;
 pub mod proto;
 pub mod util;

--- a/crates/fulfillment/Cargo.toml
+++ b/crates/fulfillment/Cargo.toml
@@ -27,6 +27,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -6,12 +6,14 @@ use futures::{future::join_all, TryFutureExt};
 use sp1_cluster_artifact::{ArtifactClient, ArtifactType, CompressedUpload};
 use sp1_cluster_common::{
     client::ClusterServiceClient,
+    failure::ProvingFailure,
     proto::{
         ProofRequest, ProofRequestCancelRequest, ProofRequestCreateRequest,
         ProofRequestListRequest, ProofRequestStatus, ProofRequestUpdateRequest,
     },
 };
 use sp1_sdk::network::signer::NetworkSigner;
+use spn_network_types::ProofRequestError;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::{task::JoinSet, time::sleep};
@@ -31,6 +33,31 @@ const VK_MISMATCH_STRINGS: &[&str] = &[
     "sp1 vk hash mismatch",
     "vk hash from syscall does not match vkey from input",
 ];
+
+/// View over the two `extra_data` shapes the fulfillment loop reads:
+///   - `ExecutionResult` from execute_only (uses `failure_cause`).
+///   - `try_unclaim_proof` proving-failure payload (uses `proving_failure`).
+/// Fields are independent; either or both may be absent.
+#[derive(serde::Deserialize)]
+struct ExtraDataView {
+    #[serde(default)]
+    proving_failure: Option<ProvingFailure>,
+    #[serde(default)]
+    failure_cause: Option<u64>,
+}
+
+/// Derive the network's `ProofRequestError` from the worker's `extra_data`.
+/// A populated `failure_cause` means execute_only itself faulted -> `EXECUTION_FAILURE`.
+/// A `proving_failure` payload means a post-execute task failed -> `PROVING_FAILURE`.
+pub fn request_error_from_extra_data(extra_data: Option<&str>) -> Option<i32> {
+    let view: ExtraDataView = serde_json::from_str(extra_data?).ok()?;
+    if matches!(view.failure_cause, Some(c) if c != 0) {
+        return Some(ProofRequestError::ExecutionFailure as i32);
+    }
+    view.proving_failure
+        .is_some()
+        .then_some(ProofRequestError::ProvingFailure as i32)
+}
 
 #[derive(Clone)]
 pub struct Fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> {

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -8,7 +8,7 @@ use sp1_cluster_common::{
     client::ClusterServiceClient,
     failure::ProvingFailure,
     proto::{
-        ProofRequest, ProofRequestCancelRequest, ProofRequestCreateRequest,
+        ExecutionResult, ProofRequest, ProofRequestCancelRequest, ProofRequestCreateRequest,
         ProofRequestListRequest, ProofRequestStatus, ProofRequestUpdateRequest,
     },
 };
@@ -34,29 +34,18 @@ const VK_MISMATCH_STRINGS: &[&str] = &[
     "vk hash from syscall does not match vkey from input",
 ];
 
-/// View over the two `extra_data` shapes the fulfillment loop reads:
-///   - `ExecutionResult` from execute_only (uses `failure_cause`).
-///   - `try_unclaim_proof` proving-failure payload (uses `proving_failure`).
-/// Fields are independent; either or both may be absent.
-#[derive(serde::Deserialize)]
-struct ExtraDataView {
-    #[serde(default)]
-    proving_failure: Option<ProvingFailure>,
-    #[serde(default)]
-    failure_cause: Option<u64>,
-}
-
 /// Derive the network's `ProofRequestError` from the worker's `extra_data`.
-/// A populated `failure_cause` means execute_only itself faulted -> `EXECUTION_FAILURE`.
-/// A `proving_failure` payload means a post-execute task failed -> `PROVING_FAILURE`.
+/// An `ExecutionResult` with non-zero `failure_cause` means execute_only itself
+/// faulted -> `EXECUTION_FAILURE`. A `ProvingFailure` payload means a
+/// post-execute task failed -> `PROVING_FAILURE`.
 pub fn request_error_from_extra_data(extra_data: Option<&str>) -> Option<i32> {
-    let view: ExtraDataView = serde_json::from_str(extra_data?).ok()?;
-    if matches!(view.failure_cause, Some(c) if c != 0) {
-        return Some(ProofRequestError::ExecutionFailure as i32);
+    let s = extra_data?;
+    if let Ok(er) = serde_json::from_str::<ExecutionResult>(s) {
+        if er.failure_cause != 0 {
+            return Some(ProofRequestError::ExecutionFailure as i32);
+        }
     }
-    view.proving_failure
-        .is_some()
-        .then_some(ProofRequestError::ProvingFailure as i32)
+    ProvingFailure::from_extra_data(s).map(|_| ProofRequestError::ProvingFailure as i32)
 }
 
 #[derive(Clone)]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 use opentelemetry::Context;
 use opentelemetry::{global, trace::TraceContextExt};
 use sp1_cluster_artifact::ArtifactClient;
+use sp1_cluster_common::failure::ProvingFailure;
 use sp1_cluster_common::proto::{ProofRequestStatus, TaskStatus, TaskType, WorkerTask};
 use sp1_prover::worker::{ProofId, SP1Worker, TaskId, TaskMetadata, WorkerClient};
 use sp1_prover_types::network_base_types::ProofMode;
@@ -220,6 +221,8 @@ impl<W: WorkerClient, A: ArtifactClient> SP1ClusterWorker<W, A> {
                         self.worker.worker_client(),
                         ProofId::new(data.proof_id.clone()),
                         Some(TaskId::new(task.task_id.clone())),
+                        task_type,
+                        err,
                     )
                     .await;
 
@@ -237,6 +240,8 @@ impl<W: WorkerClient, A: ArtifactClient> SP1ClusterWorker<W, A> {
                         self.worker.worker_client(),
                         ProofId::new(data.proof_id.clone()),
                         Some(TaskId::new(task.task_id.clone())),
+                        task_type,
+                        err,
                     )
                     .await;
 
@@ -254,16 +259,25 @@ impl<W: WorkerClient, A: ArtifactClient> SP1ClusterWorker<W, A> {
     }
 }
 
-/// Unclaims a proof request and sets all associated tasks to FAILED_FATAL.
-pub async fn try_unclaim_proof<W: WorkerClient>(
+/// Unclaim a proof and stamp `extra_data` with a `proving_failure` payload
+/// so the fulfiller can surface a real `ProofRequestError`.
+pub async fn try_unclaim_proof<W: WorkerClient, E: std::fmt::Debug>(
     cluster_client: &W,
     proof_id: ProofId,
     task_id: Option<TaskId>,
+    task_type: TaskType,
+    err: &E,
 ) {
     log::info!("Unclaiming proof {proof_id}");
 
+    let payload = ProvingFailure {
+        task_type,
+        reason: format!("{err:?}"),
+    }
+    .to_extra_data();
+
     if let Err(err) = cluster_client
-        .complete_proof(proof_id, task_id, ProofRequestStatus::Failed, "")
+        .complete_proof(proof_id, task_id, ProofRequestStatus::Failed, payload)
         .await
     {
         log::error!("while unclaiming proof: {err:?}");


### PR DESCRIPTION
Two fixes:

1. **fulfillment**: forward the cause through. Worker's `try_unclaim_proof` now writes a typed `ProvingFailure { task_type, reason }` payload to `extra_data` via `sp1-cluster-common::failure`. Fulfiller decodes it and maps:
-  execute_only fault (`failure_cause != 0`) → `EXECUTION_FAILURE`
- post-execute task fault (`proving_failure` payload) → `PROVING_FAILURE`

2. **artifact**: `par_download_file` was returning `Ok(empty_vec)` for missing Redis keys (the redis crate maps `nil → Vec::new()`). Downstream mis-read this as a corrupt artifact via "zstd: incomplete frame". Now returns `Err("artifact not found: <key>")` so the cause carried through the chain above is accurate.
