### PR TITLE
fix(infra): align redis maxmemory-policy (noeviction)

### DIFF
--- a/infra/charts/redis-store/Chart.yaml
+++ b/infra/charts/redis-store/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
     version: 20.13.1 # uses Redis version 7.4.2
     repository: "oci://registry-1.docker.io/bitnamicharts"
 
-version: 0.1.3
+version: 0.1.4

--- a/infra/charts/redis-store/values.yaml
+++ b/infra/charts/redis-store/values.yaml
@@ -36,7 +36,7 @@ redis:
 
       io-threads 16
       maxmemory 30gb
-      maxmemory-policy allkeys-lru
+      maxmemory-policy noeviction
       hz 100
 
       latency-monitor-threshold 100

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -20,7 +20,7 @@ services:
       - REDIS_PASSWORD=redispassword
       - REDIS_AOF_ENABLED=no
       - REDIS_MAXMEMORY=25gb
-      - REDIS_MAXMEMORY_POLICY=volatile-lru
+      - REDIS_MAXMEMORY_POLICY=noeviction
 
   postgresql:
     extends:


### PR DESCRIPTION
##  Summary

Set redis maxmemory-policy to noeviction across all sp1-cluster redis configs. Aligns with hosted prod default.

## Why

Artifacts in redis carry a 4h TTL (crates/artifact/src/redis.rs:16) — every shard proof, recursion input, and execution trace is an eviction candidate under memory pressure. Both allkeys-lru (in the published redis-store Helm chart) and volatile-lru (in docker-compose.local.yml) silently evict in-use keys mid-proof → ProveShard reads → missing → corrupted state.
Under noeviction, writes fail loudly when full → TaskError::Fatal → PROVING_FAILURE.