### PR TITLE
fix(coordinator): recover terminal proof-status writes lost during cluster-DB outages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8015,6 +8015,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-prover-types",
+ "tokio",
  "tokio-blocked",
  "tonic 0.12.3",
  "tonic-build",

--- a/bin/api/src/service.rs
+++ b/bin/api/src/service.rs
@@ -232,7 +232,7 @@ impl ClusterService for ClusterServiceImpl {
                 Ok(Response::new(()))
             }
             Err(e) => {
-                error!("Failed to update proof request: {:?}", e);
+                error!("Failed to update proof request {}: {:?}", req.proof_id, e);
                 Err(Status::internal("Failed to update proof request"))
             }
         }

--- a/bin/api/src/service.rs
+++ b/bin/api/src/service.rs
@@ -162,6 +162,11 @@ impl ClusterService for ClusterServiceImpl {
         let req = request.into_inner();
         info!("Updating proof request with ID: {}", req.proof_id);
 
+        // A proof_status write is the Pending→terminal completion; guard the whole UPDATE (below) on
+        // `proof_status = Pending` so a re-issue can't clobber a row that moved on (e.g. Cancelled).
+        // Guards every field in the request — but only the completion writer sets proof_status today.
+        let guard_pending = req.proof_status.is_some();
+
         // If we're not updating anything return an error.
         if req
             == (ProofRequestUpdateRequest {
@@ -216,12 +221,27 @@ impl ClusterService for ClusterServiceImpl {
 
         query.push(" WHERE id = ");
         query.push_bind(&req.proof_id);
+        // Only land a completion write from Pending, so it can't clobber a row that's moved on
+        // (e.g. Cancelled) or a gone row.
+        if guard_pending {
+            query.push(" AND proof_status = ");
+            query.push_bind(ProofRequestStatus::Pending as i16);
+        }
 
         let result = query.build().execute(&*self.db_pool).await;
 
         match result {
             Ok(result) => {
                 if result.rows_affected() == 0 {
+                    if guard_pending {
+                        // Row is no longer Pending (already terminal / cancelled / gone) — the
+                        // completion write is moot. Succeed idempotently so the caller stops tracking it.
+                        info!(
+                            "Proof request {} no longer Pending; completion write skipped",
+                            req.proof_id
+                        );
+                        return Ok(Response::new(()));
+                    }
                     warn!("Proof request {} not found", req.proof_id);
                     return Err(Status::not_found(format!(
                         "Proof request {} not found",

--- a/bin/coordinator/src/cluster.rs
+++ b/bin/coordinator/src/cluster.rs
@@ -1,7 +1,8 @@
 use std::{collections::HashSet, sync::Arc, time::SystemTime};
 
+use crate::metrics::CoordinatorMetrics;
 use crate::{AssignmentPolicy, Coordinator, ProofResult};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use hex;
 use sp1_cluster_common::{
     client::ClusterServiceClient,
@@ -11,6 +12,50 @@ use sp1_cluster_common::{
 };
 use sp1_prover::worker::ControllerInputMetadata;
 use tokio::{sync::mpsc, task::JoinHandle};
+
+/// For a row the DB still reports PENDING: if we already hold a *terminal* status (Completed/Failed)
+/// in memory, the original completion write was lost (e.g. a cluster-DB outage) — return it to
+/// re-write. Otherwise (still proving) `None`.
+fn lost_status_write(in_memory: ProofRequestStatus) -> Option<ProofRequestStatus> {
+    match in_memory {
+        ProofRequestStatus::Completed | ProofRequestStatus::Failed => Some(in_memory),
+        _ => None,
+    }
+}
+
+/// Re-write a proof's lost terminal status to the cluster API. Spawned fire-and-forget so a slow
+/// write never stalls the claimer loop, and deduped via `inflight` so a still-PENDING row on the
+/// next poll doesn't start a second write while the first runs.
+fn reissue_lost_status_write(
+    api_client: &Arc<ClusterServiceClient>,
+    metrics: &Arc<CoordinatorMetrics>,
+    inflight: &Arc<DashSet<String>>,
+    proof_id: String,
+    status: ProofRequestStatus,
+) {
+    if !inflight.insert(proof_id.clone()) {
+        return; // a re-issue for this proof is already running
+    }
+    tracing::warn!("re-issuing lost {:?} status write for proof {}", status, proof_id);
+
+    let api_client = api_client.clone();
+    let metrics = metrics.clone();
+    let inflight = inflight.clone();
+    tokio::task::spawn(async move {
+        let update = ProofRequestUpdateRequest {
+            proof_id: proof_id.clone(),
+            proof_status: Some(status.into()),
+            ..Default::default()
+        };
+        match api_client.update_proof_request(update).await {
+            Ok(()) => metrics.increment_reissued_status_writes(),
+            Err(e) => {
+                tracing::warn!("re-issue of lost status write for {} failed: {}", proof_id, e)
+            }
+        }
+        inflight.remove(&proof_id);
+    });
+}
 
 /// Spawn a task to update proof statuses with the cluster API given a channel of proof completions.
 pub fn spawn_proof_status_task<P: AssignmentPolicy>(
@@ -67,9 +112,12 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
     api_client: Arc<ClusterServiceClient>,
     coordinator: Arc<Coordinator<P>>,
     task_map: Arc<DashMap<String, ProofRequestStatus>>,
+    metrics: Arc<CoordinatorMetrics>,
 ) -> JoinHandle<()> {
     tokio::task::spawn({
         async move {
+            // Proof ids whose re-issue is in flight, so the next poll doesn't spawn a duplicate.
+            let reissue_inflight: Arc<DashSet<String>> = Arc::new(DashSet::new());
             loop {
                 match api_client
                     .get_proof_requests(ProofRequestListRequest {
@@ -90,7 +138,18 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                         let mut seen_set = HashSet::new();
                         for proof in response.into_iter().rev() {
                             seen_set.insert(proof.id.clone());
-                            if task_map.contains_key(&proof.id) {
+                            if let Some(in_memory) = task_map.get(&proof.id).map(|s| *s) {
+                                // Tracked already. Terminal in memory but still PENDING here → its
+                                // completion write was lost; re-issue it.
+                                if let Some(status) = lost_status_write(in_memory) {
+                                    reissue_lost_status_write(
+                                        &api_client,
+                                        &metrics,
+                                        &reissue_inflight,
+                                        proof.id.clone(),
+                                        status,
+                                    );
+                                }
                                 continue;
                             }
                             let Some(options_artifact_id) = proof.options_artifact_id else {

--- a/bin/coordinator/src/cluster.rs
+++ b/bin/coordinator/src/cluster.rs
@@ -36,7 +36,11 @@ fn reissue_lost_status_write(
     if !inflight.insert(proof_id.clone()) {
         return; // a re-issue for this proof is already running
     }
-    tracing::warn!("re-issuing lost {:?} status write for proof {}", status, proof_id);
+    tracing::warn!(
+        "re-issuing lost {:?} status write for proof {}",
+        status,
+        proof_id
+    );
 
     let api_client = api_client.clone();
     let metrics = metrics.clone();
@@ -50,7 +54,11 @@ fn reissue_lost_status_write(
         match api_client.update_proof_request(update).await {
             Ok(()) => metrics.increment_reissued_status_writes(),
             Err(e) => {
-                tracing::warn!("re-issue of lost status write for {} failed: {}", proof_id, e)
+                tracing::warn!(
+                    "re-issue of lost status write for {} failed: {}",
+                    proof_id,
+                    e
+                )
             }
         }
         inflight.remove(&proof_id);

--- a/bin/coordinator/src/cluster.rs
+++ b/bin/coordinator/src/cluster.rs
@@ -22,13 +22,13 @@ pub enum TaskState {
     Terminal(ProofRequestUpdateRequest),
 }
 
-/// Re-write a proof's lost terminal write to the cluster API, preserving its full payload (status +
-/// metadata + `extra_data`). Spawned fire-and-forget so a slow write never stalls the claimer loop,
-/// and deduped via `inflight` so a still-PENDING row on the next poll doesn't start a second write.
+/// Re-issue a proof's lost terminal write. Fire-and-forget so it never stalls the claimer loop,
+/// deduped via `inflight`, and drops the `task_map` entry once the write lands or is moot.
 fn reissue_lost_status_write(
     api_client: &Arc<ClusterServiceClient>,
     metrics: &Arc<CoordinatorMetrics>,
     inflight: &Arc<DashSet<String>>,
+    task_map: &Arc<DashMap<String, TaskState>>,
     update: ProofRequestUpdateRequest,
 ) {
     let proof_id = update.proof_id.clone();
@@ -40,9 +40,14 @@ fn reissue_lost_status_write(
     let api_client = api_client.clone();
     let metrics = metrics.clone();
     let inflight = inflight.clone();
+    let task_map = task_map.clone();
     tokio::task::spawn(async move {
         match api_client.update_proof_request(update).await {
-            Ok(()) => metrics.increment_reissued_status_writes(),
+            Ok(()) => {
+                metrics.increment_reissued_status_writes();
+                // stop tracking — but only if it's still our Terminal, not a re-claimed Pending.
+                task_map.remove_if(&proof_id, |_, v| matches!(v, TaskState::Terminal(_)));
+            }
             Err(e) => {
                 tracing::warn!(
                     "re-issue of lost status write for {} failed: {}",
@@ -99,10 +104,15 @@ pub fn spawn_proof_status_task<P: AssignmentPolicy>(
                 extra_data,
                 ..Default::default()
             };
+            // Record the write before attempting it; the claimer re-issues it if it's lost.
             task_map.insert(id.clone(), TaskState::Terminal(update.clone()));
-
-            if let Err(e) = api_client.update_proof_request(update).await {
-                tracing::error!("Failed to update proof status: {}", e);
+            match api_client.update_proof_request(update).await {
+                Ok(()) => {
+                    // confirmed (or moot) → stop tracking; conditional so a re-claim isn't dropped.
+                    task_map.remove_if(&id, |_, v| matches!(v, TaskState::Terminal(_)));
+                }
+                // transient failure → keep the Terminal entry so the claimer re-issues it
+                Err(e) => tracing::error!("Failed to update proof status: {}", e),
             }
         }
     })
@@ -139,17 +149,8 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                         let mut seen_set = HashSet::new();
                         for proof in response.into_iter().rev() {
                             seen_set.insert(proof.id.clone());
-                            if let Some(state) = task_map.get(&proof.id) {
-                                // Tracked, but still PENDING in the DB. If we hold its terminal
-                                // write, it was lost — re-issue it. (Pending = still proving → skip.)
-                                if let TaskState::Terminal(update) = state.value() {
-                                    reissue_lost_status_write(
-                                        &api_client,
-                                        &metrics,
-                                        &reissue_inflight,
-                                        update.clone(),
-                                    );
-                                }
+                            if task_map.contains_key(&proof.id) {
+                                // Already tracking it (proving, or a lost write the sweep handles).
                                 continue;
                             }
                             let Some(options_artifact_id) = proof.options_artifact_id else {
@@ -219,18 +220,19 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                                 }
                             }
                         }
-                        // Remove proofs from task_map that are no longer Claimed.
+                        // Fail a Pending proof that vanished from the DB list. Keep every Terminal
+                        // entry (it may just be on a later page) — removed only when its write lands.
                         let mut proofs_to_fail = vec![];
-                        task_map.retain(|id, state| {
-                            let was_seen = seen_set.contains(id);
-                            if !was_seen && matches!(state, TaskState::Pending) {
+                        task_map.retain(|id, state| match state {
+                            TaskState::Pending if !seen_set.contains(id) => {
                                 tracing::warn!(
                                     "Running proof {} is no longer in cluster DB list",
                                     id
                                 );
                                 proofs_to_fail.push(id.clone());
+                                false
                             }
-                            was_seen
+                            _ => true,
                         });
                         for id in proofs_to_fail {
                             if let Err(e) =
@@ -238,6 +240,25 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                             {
                                 tracing::error!("Failed to fail expired proof: {:?}", e);
                             }
+                        }
+
+                        // Sweep all unconfirmed terminal writes (not just this page), so a lost write
+                        // beyond the 1000-row page still recovers.
+                        let unconfirmed: Vec<ProofRequestUpdateRequest> = task_map
+                            .iter()
+                            .filter_map(|e| match e.value() {
+                                TaskState::Terminal(update) => Some(update.clone()),
+                                TaskState::Pending => None,
+                            })
+                            .collect();
+                        for update in unconfirmed {
+                            reissue_lost_status_write(
+                                &api_client,
+                                &metrics,
+                                &reissue_inflight,
+                                &task_map,
+                                update,
+                            );
                         }
                     }
                     Err(e) => {

--- a/bin/coordinator/src/cluster.rs
+++ b/bin/coordinator/src/cluster.rs
@@ -13,44 +13,34 @@ use sp1_cluster_common::{
 use sp1_prover::worker::ControllerInputMetadata;
 use tokio::{sync::mpsc, task::JoinHandle};
 
-/// For a row the DB still reports PENDING: if we already hold a *terminal* status (Completed/Failed)
-/// in memory, the original completion write was lost (e.g. a cluster-DB outage) — return it to
-/// re-write. Otherwise (still proving) `None`.
-fn lost_status_write(in_memory: ProofRequestStatus) -> Option<ProofRequestStatus> {
-    match in_memory {
-        ProofRequestStatus::Completed | ProofRequestStatus::Failed => Some(in_memory),
-        _ => None,
-    }
+/// What the coordinator knows about a proof it owns.
+#[derive(Clone)]
+pub enum TaskState {
+    /// Claimed and still proving.
+    Pending,
+    /// Finished — the exact completion write, kept so a lost one can be re-issued verbatim.
+    Terminal(ProofRequestUpdateRequest),
 }
 
-/// Re-write a proof's lost terminal status to the cluster API. Spawned fire-and-forget so a slow
-/// write never stalls the claimer loop, and deduped via `inflight` so a still-PENDING row on the
-/// next poll doesn't start a second write while the first runs.
+/// Re-write a proof's lost terminal write to the cluster API, preserving its full payload (status +
+/// metadata + `extra_data`). Spawned fire-and-forget so a slow write never stalls the claimer loop,
+/// and deduped via `inflight` so a still-PENDING row on the next poll doesn't start a second write.
 fn reissue_lost_status_write(
     api_client: &Arc<ClusterServiceClient>,
     metrics: &Arc<CoordinatorMetrics>,
     inflight: &Arc<DashSet<String>>,
-    proof_id: String,
-    status: ProofRequestStatus,
+    update: ProofRequestUpdateRequest,
 ) {
+    let proof_id = update.proof_id.clone();
     if !inflight.insert(proof_id.clone()) {
         return; // a re-issue for this proof is already running
     }
-    tracing::warn!(
-        "re-issuing lost {:?} status write for proof {}",
-        status,
-        proof_id
-    );
+    tracing::warn!("re-issuing lost status write for proof {}", proof_id);
 
     let api_client = api_client.clone();
     let metrics = metrics.clone();
     let inflight = inflight.clone();
     tokio::task::spawn(async move {
-        let update = ProofRequestUpdateRequest {
-            proof_id: proof_id.clone(),
-            proof_status: Some(status.into()),
-            ..Default::default()
-        };
         match api_client.update_proof_request(update).await {
             Ok(()) => metrics.increment_reissued_status_writes(),
             Err(e) => {
@@ -68,7 +58,7 @@ fn reissue_lost_status_write(
 /// Spawn a task to update proof statuses with the cluster API given a channel of proof completions.
 pub fn spawn_proof_status_task<P: AssignmentPolicy>(
     api_client: Arc<ClusterServiceClient>,
-    task_map: Arc<DashMap<String, ProofRequestStatus>>,
+    task_map: Arc<DashMap<String, TaskState>>,
     mut completed_rx: mpsc::UnboundedReceiver<ProofResult<P>>,
 ) -> JoinHandle<()> {
     tokio::task::spawn(async move {
@@ -79,36 +69,39 @@ pub fn spawn_proof_status_task<P: AssignmentPolicy>(
             extra_data,
         }) = completed_rx.recv().await
         {
-            let Some(mut status) = task_map.get_mut(&id) else {
-                tracing::error!("proof {} not found", id);
-                continue;
-            };
-            if *status != ProofRequestStatus::Pending {
-                tracing::error!("proof {} is in unexpected state {:?}", id, status);
+            match task_map.get(&id).map(|s| matches!(*s, TaskState::Pending)) {
+                None => {
+                    tracing::error!("proof {} not found", id);
+                    continue;
+                }
+                Some(false) => {
+                    tracing::error!(
+                        "proof {} completed from an unexpected (non-Pending) state",
+                        id
+                    );
+                }
+                Some(true) => {}
             }
-            *status = if success {
+            let status = if success {
                 ProofRequestStatus::Completed
             } else {
                 ProofRequestStatus::Failed
             };
-            tracing::info!("Setting proof status to {:?} for {}", *status, id);
-            let status_copy = *status;
+            tracing::info!("Setting proof status to {:?} for {}", status, id);
             let metadata_string = serde_json::to_string(&metadata).unwrap_or_else(|e| {
                 tracing::error!("Failed to serialize metadata: {}", e);
                 "null".to_string()
             });
-            drop(status);
+            let update = ProofRequestUpdateRequest {
+                proof_id: id.clone(),
+                proof_status: Some(status.into()),
+                metadata: Some(metadata_string),
+                extra_data,
+                ..Default::default()
+            };
+            task_map.insert(id.clone(), TaskState::Terminal(update.clone()));
 
-            if let Err(e) = api_client
-                .update_proof_request(ProofRequestUpdateRequest {
-                    proof_id: id.clone(),
-                    proof_status: Some(status_copy.into()),
-                    metadata: Some(metadata_string),
-                    extra_data,
-                    ..Default::default()
-                })
-                .await
-            {
+            if let Err(e) = api_client.update_proof_request(update).await {
                 tracing::error!("Failed to update proof status: {}", e);
             }
         }
@@ -119,7 +112,7 @@ pub fn spawn_proof_status_task<P: AssignmentPolicy>(
 pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
     api_client: Arc<ClusterServiceClient>,
     coordinator: Arc<Coordinator<P>>,
-    task_map: Arc<DashMap<String, ProofRequestStatus>>,
+    task_map: Arc<DashMap<String, TaskState>>,
     metrics: Arc<CoordinatorMetrics>,
 ) -> JoinHandle<()> {
     tokio::task::spawn({
@@ -146,16 +139,15 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                         let mut seen_set = HashSet::new();
                         for proof in response.into_iter().rev() {
                             seen_set.insert(proof.id.clone());
-                            if let Some(in_memory) = task_map.get(&proof.id).map(|s| *s) {
-                                // Tracked already. Terminal in memory but still PENDING here → its
-                                // completion write was lost; re-issue it.
-                                if let Some(status) = lost_status_write(in_memory) {
+                            if let Some(state) = task_map.get(&proof.id) {
+                                // Tracked, but still PENDING in the DB. If we hold its terminal
+                                // write, it was lost — re-issue it. (Pending = still proving → skip.)
+                                if let TaskState::Terminal(update) = state.value() {
                                     reissue_lost_status_write(
                                         &api_client,
                                         &metrics,
                                         &reissue_inflight,
-                                        proof.id.clone(),
-                                        status,
+                                        update.clone(),
                                     );
                                 }
                                 continue;
@@ -220,7 +212,7 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                                         proof.id,
                                         task_id
                                     );
-                                    task_map.insert(proof.id, ProofRequestStatus::Pending);
+                                    task_map.insert(proof.id, TaskState::Pending);
                                 }
                                 Err(e) => {
                                     tracing::error!("Failed to create proof: {}", e);
@@ -229,9 +221,9 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                         }
                         // Remove proofs from task_map that are no longer Claimed.
                         let mut proofs_to_fail = vec![];
-                        task_map.retain(|id, status| {
+                        task_map.retain(|id, state| {
                             let was_seen = seen_set.contains(id);
-                            if !was_seen && *status == ProofRequestStatus::Pending {
+                            if !was_seen && matches!(state, TaskState::Pending) {
                                 tracing::warn!(
                                     "Running proof {} is no longer in cluster DB list",
                                     id

--- a/bin/coordinator/src/metrics.rs
+++ b/bin/coordinator/src/metrics.rs
@@ -105,6 +105,16 @@ impl CoordinatorMetrics {
         );
         counter!("coordinator_dead_worker_missing_task_total").increment(1);
     }
+
+    /// Claimer re-issued a terminal status write that an earlier completion lost. A nonzero rate
+    /// means completion writes are being dropped (e.g. a cluster-DB blip). Observability-only.
+    pub fn increment_reissued_status_writes(&self) {
+        describe_counter!(
+            "coordinator_reissued_status_writes_total",
+            "Terminal proof-status writes re-issued by the claimer after an earlier write was lost.",
+        );
+        counter!("coordinator_reissued_status_writes_total").increment(1);
+    }
 }
 
 pub async fn initialize_metrics() -> Result<(

--- a/bin/coordinator/src/server.rs
+++ b/bin/coordinator/src/server.rs
@@ -576,6 +576,7 @@ pub async fn start_coordinator_server<P: AssignmentPolicy + Default + Send + Syn
         api_client.clone(),
         service.coordinator.clone(),
         task_map.clone(),
+        metrics.clone(),
     );
 
     spawn_heartbeat_task(service.coordinator.clone());

--- a/bin/coordinator/src/server.rs
+++ b/bin/coordinator/src/server.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::cluster::{spawn_proof_claimer_task, spawn_proof_status_task};
+use crate::cluster::{spawn_proof_claimer_task, spawn_proof_status_task, TaskState};
 use crate::config::Settings;
 use crate::latency::print_latency;
 use crate::metrics::initialize_metrics;
@@ -10,8 +10,7 @@ use mti::prelude::{MagicTypeIdExt, V7};
 use sp1_cluster_common::client::ClusterServiceClient;
 use sp1_cluster_common::logger;
 use sp1_cluster_common::proto::{
-    self, server_sub_message, CreateTaskResponse, GetStatsResponse, ProofRequestStatus,
-    ServerMessage, ServerSubMessage,
+    self, server_sub_message, CreateTaskResponse, GetStatsResponse, ServerMessage, ServerSubMessage,
 };
 use std::future::Future;
 use std::marker::PhantomData;
@@ -552,7 +551,7 @@ pub async fn start_coordinator_server<P: AssignmentPolicy + Default + Send + Syn
         .set_metrics(metrics.clone());
 
     let (completed_tx, completed_rx) = mpsc::unbounded_channel::<ProofResult<P>>();
-    let task_map = Arc::new(DashMap::<String, ProofRequestStatus>::new());
+    let task_map = Arc::new(DashMap::<String, TaskState>::new());
     let api_rpc =
         std::env::var("COORDINATOR_CLUSTER_RPC").unwrap_or("http://127.0.0.1:50051".to_string());
     let api_client = Arc::new(ClusterServiceClient::new(api_rpc).await?);

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -26,6 +26,7 @@ rustls = { workspace = true, features = ["ring"] }
 serde.workspace = true
 serde_json.workspace = true
 sp1-prover-types = { workspace = true }
+tokio.workspace = true
 tokio-blocked = { workspace = true, optional = true }
 tonic.workspace = true
 tracing.workspace = true

--- a/crates/common/src/client.rs
+++ b/crates/common/src/client.rs
@@ -8,8 +8,27 @@ use crate::{
 };
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use eyre::Result;
+use std::future::Future;
 use std::time::Duration;
 use tonic::transport::{Channel, Endpoint};
+use tonic::{Response, Status};
+
+/// Per-attempt cap. `backoff_retry` only counts time *between* attempts, so a hung call (e.g. a DB
+/// connection killed mid-restart) never retries — it blocks until the 60s channel timeout. Capping
+/// each attempt turns the hang into a fast, retryable failure. 5s sits above a normal call (~ms) and
+/// under the 10s backoff budget, so it fires only on a real stall yet still leaves room to retry.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One gRPC attempt under [`ATTEMPT_TIMEOUT`], body unwrapped. A timeout becomes a transient
+/// `DeadlineExceeded` so `backoff_retry` re-issues it.
+async fn with_timeout<T>(
+    fut: impl Future<Output = Result<Response<T>, Status>>,
+) -> Result<T, Status> {
+    match tokio::time::timeout(ATTEMPT_TIMEOUT, fut).await {
+        Ok(resp) => resp.map(|r| r.into_inner()),
+        Err(_) => Err(Status::deadline_exceeded("cluster API attempt timed out")),
+    }
+}
 
 pub async fn reconnect_with_backoff(addr: &str) -> Result<Channel> {
     let backoff = ExponentialBackoffBuilder::new()
@@ -69,19 +88,30 @@ impl ClusterServiceClient {
         Ok(Self { rpc, backoff })
     }
 
+    /// Shared call policy: retry transient failures within the backoff budget, each attempt bounded
+    /// by [`ATTEMPT_TIMEOUT`]. `make_call` builds one fresh attempt per try (cloning client/request).
+    async fn retry_call<T, Fut>(&self, make_call: impl Fn() -> Fut) -> Result<T>
+    where
+        Fut: Future<Output = Result<Response<T>, Status>>,
+    {
+        Ok(backoff_retry(self.backoff.clone(), || with_timeout(make_call())).await?)
+    }
+
     pub async fn create_proof_request(&self, request: ProofRequestCreateRequest) -> Result<()> {
-        backoff_retry(self.backoff.clone(), || async {
-            let response = self.rpc.clone().proof_request_create(request.clone()).await;
-            response.map(|response| response.into_inner())
+        self.retry_call(|| {
+            let mut client = self.rpc.clone();
+            let request = request.clone();
+            async move { client.proof_request_create(request).await }
         })
         .await?;
         Ok(())
     }
 
     pub async fn cancel_proof_request(&self, request: ProofRequestCancelRequest) -> Result<()> {
-        backoff_retry(self.backoff.clone(), || async {
-            let response = self.rpc.clone().proof_request_cancel(request.clone()).await;
-            response.map(|response| response.into_inner())
+        self.retry_call(|| {
+            let mut client = self.rpc.clone();
+            let request = request.clone();
+            async move { client.proof_request_cancel(request).await }
         })
         .await?;
         Ok(())
@@ -91,18 +121,21 @@ impl ClusterServiceClient {
         &self,
         request: ProofRequestListRequest,
     ) -> Result<Vec<proto::ProofRequest>> {
-        let result = backoff_retry(self.backoff.clone(), || async {
-            let response = self.rpc.clone().proof_request_list(request.clone()).await;
-            response.map(|response| response.into_inner().proof_requests)
-        })
-        .await?;
-        Ok(result)
+        let result = self
+            .retry_call(|| {
+                let mut client = self.rpc.clone();
+                let request = request.clone();
+                async move { client.proof_request_list(request).await }
+            })
+            .await?;
+        Ok(result.proof_requests)
     }
 
     pub async fn update_proof_request(&self, request: ProofRequestUpdateRequest) -> Result<()> {
-        backoff_retry(self.backoff.clone(), || async {
-            let response = self.rpc.clone().proof_request_update(request.clone()).await;
-            response.map(|response| response.into_inner())
+        self.retry_call(|| {
+            let mut client = self.rpc.clone();
+            let request = request.clone();
+            async move { client.proof_request_update(request).await }
         })
         .await?;
         Ok(())
@@ -112,11 +145,13 @@ impl ClusterServiceClient {
         &self,
         request: ProofRequestGetRequest,
     ) -> Result<Option<proto::ProofRequest>> {
-        let result = backoff_retry(self.backoff.clone(), || async {
-            let response = self.rpc.clone().proof_request_get(request.clone()).await;
-            response.map(|response| response.into_inner().proof_request)
-        })
-        .await?;
-        Ok(result)
+        let result = self
+            .retry_call(|| {
+                let mut client = self.rpc.clone();
+                let request = request.clone();
+                async move { client.proof_request_get(request).await }
+            })
+            .await?;
+        Ok(result.proof_request)
     }
 }


### PR DESCRIPTION
## Why

A fully-proved request can be stranded forever. When the coordinator's completion write (proof_status → Completed) is lost during a cluster-DB outage, the row stays PENDING, the fulfiller (which only acts on COMPLETED rows) never delivers it, and a valid proof in S3 expires UNFULFILLABLE.

## Root cause

A ~40s cluster-DB write outage (single-AZ engine minor-version upgrade):

```
  13:01:33  pre-check for DB engine version upgrade
  13:01:57  downtime started
  13:01:59.688  DB instance shutdown        ← matches our "terminating connection" at 13:01:59.471
  13:02:23  engine version upgrade started
  13:02:32.586  DB instance restarted       ← matches our first successful write at 13:02:32.815
  13:03:08  upgrade complete: 16.8.R2 → 16.13.R1
```

The completion write was issued the instant the DB went away and hung ~30s, which defeated the existing retry.

1) ~40s with zero successful writes (any writer):

```
13:01:52.678  Successfully updated proof request: fba569b7   ← last success before
13:01:59.471  ping on idle connection returned error: terminating connection due to administrator command
     ── ~40s gap, no successful cluster-DB write ──
13:02:32.815  Successfully updated proof request: 35bebaa5   ← DB recovered
```

2) the lost write hung 30s, then quit without retry ([e43c1526…](https://explorer.succinct.xyz/request/0xe43c1526d5399e39c337bff1f65b63d1d451b9bcf56fc824e5798dc04b95544f)):

```
13:02:01.586  Updating proof request with ID: e43c1526…     ← issued at outage onset, then HANGS
     ── 30s, nothing ──
13:02:31.587  (returns FAILED ~30s later)    ← backoff: 30s > 10s budget → gives up, no retry
```

3) proof of why it hung — its neighbour finished slightly later, failed fast, and the same retry path saved it:

```
13:02:31.588  Updating proof request: 35bebaa5  → fail → retry → retry → retry (5×)
13:02:32.815  Successfully updated proof request: 35bebaa5   ✅
```

So two latent gaps turned a transient outage into a permanent loss:
- A single hung attempt defeats the retry budget. Each gRPC call can hang up to the 60s channel timeout, but backoff's budget is 10s and it only checks elapsed time between attempts — one 30s hang blows the budget in a single un-retried shot.
- Head-of-line blocking. The completion write runs on a single-consumer loop, so the 30s hang stalled all other completions (35bebaa5 finished proving at 13:02:13 but couldn't write until 13:02:31).
- No reconciliation once the write was finally lost.

## Fix

1. Per-attempt timeout: Bound each gRPC attempt (reads/writes to 5s) so a hang fails fast → backoff actually retries, and the completion loop unblocks in 3s not 30s. Fixes short blips and the head-of-line stall.

2. Reconciliation backstop: The claimer already polls PENDING rows every 500ms; it now re-issues the write when a row is PENDING in the DB but terminal in memory. Covers outages longer than the retry budget (the 40s case). DB is the source of truth, so it's restart-safe and can't resurrect a status that moved on.

Why both: you can't just enlarge the retry budget — a 40s budget means a 40s pipeline stall. Short waits stay in-line (backoff); long waits go out-of-band (reconciliation).


