### PR TITLE
fix(fulfiller): stop re-failing already-terminal requests in the cancel sweep

### DIFF
--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -334,6 +334,10 @@ impl NetworkRequest for NetworkProofRequest {
         hex::encode(&self.0.request_id)
     }
 
+    fn is_unfulfillable(&self) -> bool {
+        self.0.fulfillment_status == spn_network_types::FulfillmentStatus::Unfulfillable as i32
+    }
+
     fn program_uri(&self) -> &str {
         &self.0.program_uri
     }

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -380,7 +380,18 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             let self_clone = self.clone();
             tokio::spawn(async move {
                 let request_id = request.request_id();
-                match self_clone.cancel_request(&request_id).await {
+                let result = async {
+                    // Only fail on the network while it still expects one. A request the network
+                    // has already finalized treats the fail as a no-op, so re-sending it each
+                    // sweep until the deadline would only spend the signer's nonce. The cluster
+                    // unclaim runs either way.
+                    if !request.is_unfulfillable() {
+                        self_clone.cancel_on_network(&request_id).await?;
+                    }
+                    self_clone.cancel_on_cluster(&request_id).await
+                }
+                .await;
+                match result {
                     Ok(_) => {
                         info!("cancelled request 0x{}", request_id);
                         self_clone.metrics.requests_cancelled.increment(1);
@@ -399,23 +410,24 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         Ok(())
     }
 
-    /// Cancels a request by failing fulfillment on the network and unclaming it on the cluster.
-    async fn cancel_request(&self, request_id: &str) -> Result<()> {
-        // Send the failed fulfillment to the network.
+    /// Releases the request on the network by failing its fulfillment.
+    async fn cancel_on_network(&self, request_id: &str) -> Result<()> {
         if !self.disable_fulfillment {
             self.network
                 .cancel_request(request_id, &self.signer)
                 .await?;
         }
+        Ok(())
+    }
 
-        // Update the status to cancelled on the cluster.
+    /// Marks the request cancelled on the cluster so workers stop proving it.
+    async fn cancel_on_cluster(&self, request_id: &str) -> Result<()> {
         self.cluster
             .cancel_proof_request(ProofRequestCancelRequest {
                 proof_id: request_id.to_string(),
             })
             .map_err(|e| anyhow!("failed to update proof request status: {}", e))
             .await?;
-
         Ok(())
     }
 

--- a/crates/fulfillment/src/network.rs
+++ b/crates/fulfillment/src/network.rs
@@ -7,6 +7,9 @@ use sp1_sdk::network::signer::NetworkSigner;
 pub trait NetworkRequest: Send + Sync + 'static {
     fn request_id(&self) -> String;
 
+    /// Whether the network already marked this request `Unfulfillable` (a terminal state).
+    fn is_unfulfillable(&self) -> bool;
+
     fn program_uri(&self) -> &str;
 
     fn stdin_uri(&self) -> &str;


### PR DESCRIPTION
## What

The cancel sweep re-sent `fail_fulfillment` to already-`Unfulfillable` requests every pass until their deadline. The network no-ops the call, but each one spends a signer nonce and races concurrent sends. Like one request got hit 2,240× over 2.5h on an external prover.

## Why

Regression from #109, which added an Unfulfillable query to drive the cluster unclaim. Those requests stay terminal and keep matching the query, so the sweep also kept re-sending the now-pointless network fail.

## Fix

```
  if !request.is_unfulfillable() {
      self.cancel_on_network(&request_id).await?;   // only while the network expects it
  }
  self.cancel_on_cluster(&request_id).await         // always — #109's purpose
```

Gate the network call on a new `is_unfulfillable()` predicate; keep the cluster unclaim unconditional.