### PR TITLE
feat(worker,node): add experimental feature flag

### DIFF
--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = ["native-gnark"]
 native-gnark = ["sp1-sdk/native-gnark"]
 gpu = ["dep:sp1-gpu-prover", "dep:sp1-gpu-cudart", "sp1-cluster-worker/gpu"]
+experimental = ["sp1-cluster-worker/experimental"]
 
 [dependencies]
 sp1-gpu-cudart = { workspace = true, optional = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -10,6 +10,7 @@ categories.workspace = true
 default = ["native-gnark"]
 native-gnark = ["sp1-sdk/native-gnark"]
 gpu = ["dep:sp1-gpu-prover", "dep:sp1-gpu-cudart"]
+experimental = ["sp1-prover/experimental", "sp1-gpu-prover?/experimental"]
 
 [dependencies]
 sp1-cluster-artifact = { workspace = true }


### PR DESCRIPTION
Adds an `experimental` feature so the GPU node can be built with the prover's
experimental code paths enabled.

- `sp1-cluster-worker`: `experimental = ["sp1-prover/experimental", "sp1-gpu-prover?/experimental"]`
  (the `sp1-gpu-prover` forward is weak, so it only activates when the `gpu`
  feature pulls that optional dependency in).
- `sp1-cluster-node`: `experimental = ["sp1-cluster-worker/experimental"]`.

This lets the CUDA worker builder honor `WITHOUT_VK_VERIFICATION`, which is
gated behind `#[cfg(feature = "experimental")]` in `sp1-gpu-prover`.

Build with `--features gpu,experimental`. Feature resolution verified with
`cargo tree` (enables `sp1-prover`/`sp1-gpu-prover` `experimental` on `6.2.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)