### PR TITLE
feat(fulfiller): emit structured error traces on failed fulfillments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,7 +1853,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1873,7 +1873,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4291,7 +4291,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6287,8 +6287,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6334,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -9541,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
+source = "git+https://github.com/succinctlabs/network?branch=main#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
+source = "git+https://github.com/succinctlabs/network?branch=main#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9574,7 +9574,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
+source = "git+https://github.com/succinctlabs/network?branch=main#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
+source = "git+https://github.com/succinctlabs/network?branch=main#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#560c3bec4324088c1680a51cf0aa5cf2f599b84f"
+source = "git+https://github.com/succinctlabs/network?branch=main#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -11,6 +11,7 @@ use sp1_cluster_fulfillment::{
 };
 use sp1_sdk::network::signer::NetworkSigner;
 use spn_artifacts::Artifact;
+use spn_network_types::error_trace::ErrorTrace;
 
 /// SPN (SP1 Prover Network) implementation of FulfillmentNetwork.
 #[derive(Clone)]
@@ -92,12 +93,21 @@ impl FulfillmentNetwork for MainnetFulfiller {
         signer: &NetworkSigner,
     ) -> Result<()> {
         let error = request_error_from_extra_data(request.extra_data.as_deref());
-        self.fail_request_with_error(&request.id, error, &[], signer)
+        // Build a bounded, sanitized structured trace from the cluster's failure
+        // `extra_data` so the network records *why* proving failed instead of only
+        // the coarse `ProofRequestError` enum. Useless/empty extra_data yields
+        // `None` (the network stores NULL rather than a junk trace).
+        let error_trace = ErrorTrace::from_cluster_extra_data(request.extra_data.as_deref())
+            .map(|t| t.with_request_id(request.id.clone()))
+            .and_then(|t| t.finalize())
+            .and_then(|t| t.to_wire_bytes());
+        self.fail_request_with_error(&request.id, error, error_trace, &[], signer)
             .await
     }
 
     async fn cancel_request(&self, request_id: &str, signer: &NetworkSigner) -> Result<()> {
-        self.fail_request_with_error(request_id, None, &[], signer)
+        // A cancellation carries no failure detail; send no trace.
+        self.fail_request_with_error(request_id, None, None, &[], signer)
             .await
     }
 
@@ -105,6 +115,7 @@ impl FulfillmentNetwork for MainnetFulfiller {
         &self,
         request_id: &str,
         error: Option<i32>,
+        error_trace: Option<Vec<u8>>,
         _domain: &[u8],
         signer: &NetworkSigner,
     ) -> Result<()> {
@@ -125,6 +136,7 @@ impl FulfillmentNetwork for MainnetFulfiller {
             nonce,
             request_id: request_id_bytes,
             error,
+            error_trace,
         };
 
         let fail_request = spn_network_types::FailFulfillmentRequest {

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -200,6 +200,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                                 .fail_request_with_error(
                                     &request_id,
                                     Some(VK_MISMATCH_ERROR),
+                                    // VK mismatch carries no cluster extra_data trace.
+                                    None,
                                     self_clone.domain.as_slice(),
                                     &self_clone.signer,
                                 )

--- a/crates/fulfillment/src/network.rs
+++ b/crates/fulfillment/src/network.rs
@@ -59,10 +59,15 @@ pub trait FulfillmentNetwork: Send + Sync + 'static {
     ) -> Result<()>;
 
     /// Fail a fulfillment request with a specific error code (e.g., VK mismatch).
+    ///
+    /// `error_trace` is an optional bounded, sanitized JSON trace (see
+    /// `spn_network_types::error_trace`) describing why the request failed. Pass
+    /// `None` when no structured detail is available (e.g. cancellations).
     async fn fail_request_with_error(
         &self,
         request_id: &str,
         error: Option<i32>,
+        error_trace: Option<Vec<u8>>,
         domain: &[u8],
         signer: &NetworkSigner,
     ) -> Result<()>;


### PR DESCRIPTION
## Summary

Wires the open-source fulfiller to include a structured `error_trace` when reporting failed fulfillments to SPN.

This is the producer-side follow-up to:
- succinctlabs/network#231
- succinctlabs/network-services#1191

When a cluster worker records useful failure detail in `proof_requests.extra_data`, the fulfiller now converts that detail into bounded, sanitized trace bytes and sends it on `FailFulfillmentRequestBody.error_trace`.

## Why

External prover operators run the open-source `sp1-cluster` fulfiller. Before this change, the fulfiller read `extra_data` only to derive a coarse `ProofRequestError` enum, then discarded the detailed failure context. That could leave SPN requests with opaque errors like `Unknown Error`.

With this change, the existing enum behavior is preserved, and useful structured context is sent alongside it.

## What Changed

- Pins `spn-network-types` to the `network` rev from succinctlabs/network#231 (`ebe4de1e9e865d657b20279715ac30576a8a6262`).
- Builds `error_trace` from `request.extra_data` in the mainnet fulfiller failure path.
- Sends the trace on `FailFulfillmentRequestBody.error_trace`.
- Leaves cancel and no-detail paths unset (`None`).
- Keeps existing `ProofRequestError` mapping unchanged.

## E2E Flow

```text
cluster worker failure
  -> proof_requests.extra_data
  -> open-source fulfiller reads extra_data
  -> ErrorTrace::from_cluster_extra_data(...).finalize().to_wire_bytes()
  -> FailFulfillmentRequestBody.error_trace
  -> network-services RPC receive/sanitize/store
  -> requests.error_trace JSONB
```

## Scope

This PR wires **only the open-source `sp1-cluster` fulfiller** (`MainnetFulfiller`), which external prover operators run against mainnet/sepolia.

It does **not** cover **private V6 production clusters**, which run `sp1-cluster-private` `/prod-fulfiller` (`ProdFulfiller`) and report failures via network-services `dev` — those clusters will still fail fulfillment without `error_trace` until the follow-up lands. This is a valid scope boundary, not a regression: the two fulfillers deploy from independent per-cluster image tags (no lockstep), and this PR is intentionally scoped to external-prover visibility. Private-path parity is tracked in **succinctlabs/cloud-ops#141** (port #1191 receive/store to `dev` -> wire `ProdFulfiller` -> bump production3 image).

Also out of scope: executor/`fail_execution` paths, SDK/API/explorer read exposure, operator image release/upgrade rollout.

## Validation

- `cargo check --release -p sp1-cluster-fulfillment -p sp1-cluster-fulfiller` → Finished (compiles against network rev `ebe4de1`)
- `cargo fmt --check` → clean
- `git diff --check` → clean

