### PR TITLE
chore: bump version to v2.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-artifact"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-bidder"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy",
  "alloy-signer-local",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-common"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "backoff",
  "chrono",
@@ -8319,7 +8319,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfiller"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8347,7 +8347,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfillment"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-network-gateway"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8443,7 +8443,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-utils"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "eyre",
  "sp1-cluster-artifact",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-worker"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -9464,7 +9464,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-test-cluster"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
     "crates/worker",
 ]
 [workspace.package]
-version = "2.4.2"
+version = "2.4.3"
 edition = "2021"
 repository = "https://github.com/succinctlabs/sp1-cluster"
 keywords = []

--- a/infra/charts/bidder/values.yaml
+++ b/infra/charts/bidder/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/succinctlabs/sp1-cluster
   pullPolicy: IfNotPresent
-  tag: base-v2.4.2
+  tag: base-v2.4.3
 
 extraEnv: {}
 

--- a/infra/charts/fulfiller/values.yaml
+++ b/infra/charts/fulfiller/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/succinctlabs/sp1-cluster
   pullPolicy: IfNotPresent
-  tag: base-v2.4.2
+  tag: base-v2.4.3
 
 extraEnv: {}
 

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -77,7 +77,7 @@ cpu-node:
       cpu: 8
       memory: 96Gi
   image:
-    tag: "base-v2.4.2"
+    tag: "base-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-GPU machine with a powerful CPU.
@@ -110,7 +110,7 @@ gpu-node:
       # cpu: 32.0
       # memory: 24Gi
   image:
-    tag: "node-gpu-v2.4.2"
+    tag: "node-gpu-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
 
@@ -127,7 +127,7 @@ api:
           key: DATABASE_URL
   replicaCount: 1
   image:
-    tag: "base-v2.4.2"
+    tag: "base-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -142,7 +142,7 @@ coordinator:
     COORDINATOR_METRICS_ADDR: 0.0.0.0:9090
     COORDINATOR_ADDR: 0.0.0.0:50051
   image:
-    tag: "base-v2.4.2"
+    tag: "base-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -194,7 +194,7 @@ fulfiller:
           name: cluster-secrets
           key: PRIVATE_KEY
   image:
-    tag: "base-v2.4.2"
+    tag: "base-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -227,7 +227,7 @@ network-gateway:
     # GATEWAY_AUTH_MODE: verify
     # GATEWAY_AUTH_ALLOWLIST: 0xabc...,0xdef...
   image:
-    tag: "base-v2.4.2"
+    tag: "base-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
   # nodeSelector: {}
@@ -252,7 +252,7 @@ bidder:
     BIDDER_MAX_CONCURRENT_PROOFS: 1
     BIDDER_BID_AMOUNT: 1
   image:
-    tag: "base-v2.4.2"
+    tag: "base-v2.4.3"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   # API Service
   api:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     environment:
       - API_GRPC_ADDR=0.0.0.0:50051
       - API_HTTP_ADDR=0.0.0.0:3000
@@ -45,7 +45,7 @@ services:
 
   # Coordinator Service
   coordinator:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     environment:
       - COORDINATOR_CLUSTER_RPC=http://api:50051
       - COORDINATOR_METRICS_ADDR=0.0.0.0:9090
@@ -59,7 +59,7 @@ services:
 
   # CPU Node
   cpu-node:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
       # Concurrency budget: GiB of RAM dedicated to THIS worker, not the host total.
@@ -89,7 +89,7 @@ services:
 
   # CPU Node
   mixed:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
       # See cpu-node: GiB dedicated to this worker, at most the 96G limit below.
@@ -115,7 +115,7 @@ services:
 
   # GPU Node
   gpu0:
-    image: ghcr.io/succinctlabs/sp1-cluster:node-gpu-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:node-gpu-v2.4.3
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
       # Must be <= container memory in GiB (see deploy.resources.limits.memory below).
@@ -183,7 +183,7 @@ services:
   # Fulfiller Service
   # DOMAIN: set to SPN_MAINNET_V1_DOMAIN for mainnet, defaults to SPN_SEPOLIA_V1_DOMAIN
   fulfiller:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     environment:
       - FULFILLER_CLUSTER_RPC=http://api:50051
       - FULFILLER_LOG_FORMAT=Pretty
@@ -205,7 +205,7 @@ services:
   # why the default points at 127.0.0.1:8081 (same host as compose). For
   # remote SDK callers, override it to your public hostname.
   network-gateway:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     profiles: ["gateway"]
     environment:
       - GATEWAY_GRPC_ADDR=0.0.0.0:50061
@@ -226,7 +226,7 @@ services:
 
   # Bidder Service
   bidder:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.2
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.4.3
     environment:
       - BIDDER_LOG_FORMAT=Pretty
       - BIDDER_VERSION=sp1-v6.1.0


### PR DESCRIPTION
## Summary

Bumps the workspace version `2.4.2` → `2.4.3` to cut the official **v2.4.3** release. This is the first release that includes the `error_trace` producer wiring (sp1-cluster#141, `79a41d1`) — the open-source fulfiller now sends `FailFulfillmentRequestBody.error_trace`.

Follows the existing release convention (cf. #137 "bump version to v2.4.1"): bumps `Cargo.toml` + `Cargo.lock` and the image-tag references in `infra/charts/*` and `infra/docker-compose.yml` to `v2.4.3`.

## Why

The network-services receiver is already live on mainnet (`succinct-network:43460eb`, network-services#1191) with the `requests.error_trace` migration verified. We want the **official semver image** `sp1-cluster:base-v2.4.3` (not the SHA tag) for the infra producer bump.

## After merge (maintainer)

Tagging is a GPG-signed maintainer step (v2.4.1/v2.4.2 are signed annotated tags). Once this merges to `main`:

```
git checkout main && git pull
git tag -s v2.4.3 -m "v2.4.3"
git push origin v2.4.3
```

The tag push triggers `.github/workflows/docker.yml`, which builds & pushes `base-v2.4.3` and `node-gpu-v2.4.3` to ECR + GHCR.

No infra changes here; the infra `fulfiller_full_image_tag` bump is a separate follow-up after `base-v2.4.3` is published.
