### PR TITLE
feat(worker): enrich execute-only failure extra_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=0b1eeab#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
+source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9559,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=0b1eeab#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
+source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=0b1eeab#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
+source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=0b1eeab#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
+source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9617,7 +9617,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=0b1eeab#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
+source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9628,7 +9628,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=0b1eeab#0b1eeabc51546ece1dc6d5d9e8143f252bbfd22e"
+source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "0b1eeab" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "0b1eeab" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "0b1eeab", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "0b1eeab" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "0b1eeab" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "8e58693", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
+spn-utils = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
 
 # SP1
 sp1-core-executor = "=6.3.0"

--- a/crates/worker/src/tasks/execute_only.rs
+++ b/crates/worker/src/tasks/execute_only.rs
@@ -68,23 +68,41 @@ impl<W: WorkerClient, A: ArtifactClient, C: SP1ProverComponents> SP1ClusterWorke
                 .unwrap_or_else(|e| ExecutionError::Other(e.to_string()))
         });
 
-        let result_obj = match execution_result {
-            Ok((pv, _, execution_report)) if execution_report.exit_code == 0 => ExecutionResult {
-                status: ExecutionStatus::Executed as i32,
-                failure_cause: ExecutionFailureCause::Unspecified as i32,
-                cycles: execution_report.total_instruction_count(),
-                gas: execution_report.gas().unwrap_or(0),
-                public_values_hash: pv.hash(),
-            },
-            Ok((_, _, execution_report)) => {
-                // Non-zero exit code means the guest program panicked.
+        // `failure_message` (a bounded `Err(ExecutionError)` detail) and `exit_code`
+        // (non-zero halt) are additive enrichment serialized alongside the
+        // `ExecutionResult` into `extra_data`; consumers that don't know them
+        // ignore them. The actual guest panic payload/location is NOT captured
+        // here (that needs a separate SP1 executor stderr-capture change).
+        let (result_obj, failure_message, exit_code): (
+            ExecutionResult,
+            Option<String>,
+            Option<u64>,
+        ) = match execution_result {
+            Ok((pv, _, execution_report)) if execution_report.exit_code == 0 => (
                 ExecutionResult {
-                    status: ExecutionStatus::Failed as i32,
-                    failure_cause: ExecuteFailureCause::HaltWithNonZeroExitCode as i32,
+                    status: ExecutionStatus::Executed as i32,
+                    failure_cause: ExecutionFailureCause::Unspecified as i32,
                     cycles: execution_report.total_instruction_count(),
                     gas: execution_report.gas().unwrap_or(0),
-                    public_values_hash: vec![],
-                }
+                    public_values_hash: pv.hash(),
+                },
+                None,
+                None,
+            ),
+            Ok((_, _, execution_report)) => {
+                // Non-zero exit code means the guest program panicked.
+                let exit_code = execution_report.exit_code;
+                (
+                    ExecutionResult {
+                        status: ExecutionStatus::Failed as i32,
+                        failure_cause: ExecuteFailureCause::HaltWithNonZeroExitCode as i32,
+                        cycles: execution_report.total_instruction_count(),
+                        gas: execution_report.gas().unwrap_or(0),
+                        public_values_hash: vec![],
+                    },
+                    None,
+                    Some(exit_code),
+                )
             }
             Err(err) => {
                 // Determine the cause of failure.
@@ -121,13 +139,17 @@ impl<W: WorkerClient, A: ArtifactClient, C: SP1ProverComponents> SP1ClusterWorke
                     err
                 );
 
-                ExecutionResult {
-                    status: ExecutionStatus::Failed as i32,
-                    failure_cause: execution_fail_cause as i32,
-                    cycles: 0,
-                    gas: 0,
-                    public_values_hash: vec![],
-                }
+                (
+                    ExecutionResult {
+                        status: ExecutionStatus::Failed as i32,
+                        failure_cause: execution_fail_cause as i32,
+                        cycles: 0,
+                        gas: 0,
+                        public_values_hash: vec![],
+                    },
+                    Some(bound_failure_message(&err.to_string())),
+                    None,
+                )
             }
         };
 
@@ -145,17 +167,140 @@ impl<W: WorkerClient, A: ArtifactClient, C: SP1ProverComponents> SP1ClusterWorke
             ProofRequestStatus::Failed
         };
 
+        let extra_data =
+            build_execute_extra_data(&result_obj, failure_message.as_deref(), exit_code)
+                .map_err(|e| TaskError::Fatal(anyhow::anyhow!(e)))?;
+
         self.worker
             .worker_client()
             .complete_proof(
                 ProofId::new(proof_id),
                 Some(TaskId::new(task.task_id.clone())),
                 proof_status,
-                serde_json::to_string(&result_obj)
-                    .map_err(|e| TaskError::Fatal(anyhow::anyhow!(e)))?,
+                extra_data,
             )
             .await?;
 
         Ok(Default::default())
+    }
+}
+
+/// Producer-side cap for the enrichment message written into `extra_data`. The
+/// network re-bounds and redacts on ingest, but we keep the cluster DB write
+/// conservative and free of unbounded logs.
+const FAILURE_MESSAGE_MAX: usize = 2048;
+
+/// Bound an `Err(ExecutionError)` display string to [`FAILURE_MESSAGE_MAX`] bytes
+/// on a UTF-8 char boundary. Not a substitute for receiver-side sanitization.
+fn bound_failure_message(message: &str) -> String {
+    if message.len() <= FAILURE_MESSAGE_MAX {
+        return message.to_string();
+    }
+    let mut cut = FAILURE_MESSAGE_MAX;
+    while cut > 0 && !message.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    message[..cut].to_string()
+}
+
+/// Serialize the `ExecutionResult` plus optional execute-only enrichment
+/// (`failure_message`, `exit_code`) as additive JSON keys. Older consumers that
+/// deserialize only `ExecutionResult` ignore the extra keys; the network's
+/// `ErrorTrace::from_cluster_extra_data` reads them when present.
+fn build_execute_extra_data(
+    result: &ExecutionResult,
+    failure_message: Option<&str>,
+    exit_code: Option<u64>,
+) -> serde_json::Result<String> {
+    // Fast path: no enrichment (e.g. successful execution) serializes exactly as
+    // before, keeping the common-case `extra_data` byte-identical.
+    if failure_message.is_none() && exit_code.is_none() {
+        return serde_json::to_string(result);
+    }
+    let mut value = serde_json::to_value(result)?;
+    if let serde_json::Value::Object(map) = &mut value {
+        if let Some(message) = failure_message {
+            map.insert(
+                "failure_message".to_string(),
+                serde_json::Value::String(message.to_string()),
+            );
+        }
+        if let Some(code) = exit_code {
+            map.insert(
+                "exit_code".to_string(),
+                serde_json::Value::Number(code.into()),
+            );
+        }
+    }
+    serde_json::to_string(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn failed_result(failure_cause: i32) -> ExecutionResult {
+        ExecutionResult {
+            status: ExecutionStatus::Failed as i32,
+            failure_cause,
+            cycles: 0,
+            gas: 0,
+            public_values_hash: vec![],
+        }
+    }
+
+    #[test]
+    fn err_execution_error_serializes_bounded_failure_message() {
+        let msg = bound_failure_message("exceeded cycle limit of 1000000");
+        let extra = build_execute_extra_data(
+            &failed_result(ExecuteFailureCause::ExceededCycleLimit as i32),
+            Some(&msg),
+            None,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&extra).unwrap();
+        assert_eq!(v["failure_message"], "exceeded cycle limit of 1000000");
+        assert!(v.get("exit_code").is_none());
+        // Still a valid ExecutionResult shape for legacy consumers.
+        assert_eq!(
+            v["failure_cause"],
+            ExecuteFailureCause::ExceededCycleLimit as i32
+        );
+    }
+
+    #[test]
+    fn failure_message_is_bounded() {
+        let huge = "x".repeat(FAILURE_MESSAGE_MAX * 4);
+        let bounded = bound_failure_message(&huge);
+        assert!(bounded.len() <= FAILURE_MESSAGE_MAX);
+    }
+
+    #[test]
+    fn non_zero_exit_serializes_exit_code() {
+        let extra = build_execute_extra_data(
+            &failed_result(ExecuteFailureCause::HaltWithNonZeroExitCode as i32),
+            None,
+            Some(101),
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&extra).unwrap();
+        assert_eq!(v["exit_code"], 101);
+        assert!(v.get("failure_message").is_none());
+    }
+
+    #[test]
+    fn success_has_no_enrichment_keys() {
+        let result = ExecutionResult {
+            status: ExecutionStatus::Executed as i32,
+            failure_cause: ExecutionFailureCause::Unspecified as i32,
+            cycles: 10,
+            gas: 20,
+            public_values_hash: vec![1, 2, 3],
+        };
+        let extra = build_execute_extra_data(&result, None, None).unwrap();
+        let v: Value = serde_json::from_str(&extra).unwrap();
+        assert!(v.get("failure_message").is_none());
+        assert!(v.get("exit_code").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Adds bounded execute-only failure metadata to the cluster `extra_data` JSON.

For execute-only failures:
- `Err(ExecutionError)` now adds a bounded `failure_message`.
- Non-zero halt failures now add `exit_code`.

These are additive JSON keys alongside the existing `ExecutionResult` shape, so existing
consumers that only deserialize `ExecutionResult` continue to work. The success/no-enrichment
path is serialized exactly as before.

## Scope

This enriches the producer-side `extra_data` shape only.

It does not capture guest panic message/location. For `HaltWithNonZeroExitCode`, this only
adds `exit_code`; actual panic payload/location requires a separate SP1 executor
stderr-capture change.

The network-services executor path still builds traces from the typed `execute_fail_cause`
enum. Reading this enriched `extra_data` there requires a separate ClusterService
contract/wiring change.

## Dependency

The consumer of this enriched `extra_data` is the parser in `spn-network-types`
(`ErrorTrace::from_cluster_extra_data`), added in succinctlabs/network#233 (**merged**).
`Cargo.toml` keeps `spn-network-types = { git = ".../network", branch = "main" }` (no change,
no `[patch]`); `Cargo.lock` is refreshed so the network git source resolves to the merged
commit `8e58693`. The five crates sharing that git source (`spn-network-types`,
`spn-artifacts`, `spn-artifact-types`, `spn-metrics`, `spn-utils`) move together as one
source; there is no other dependency churn.

## Validation

- `cargo test -p sp1-cluster-worker execute_only --lib`
- `cargo check --release -p sp1-cluster-fulfillment -p sp1-cluster-fulfiller`
- `cargo fmt --check`, `git diff --check`
