### PR TITLE
feat: report prover component build identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ WORKER_METRICS_ADDR=127.0.0.1:9091
 # Fulfiller
 FULFILLER_RPC_GRPC_ADDR=https://rpc.mainnet.succinct.xyz
 FULFILLER_CLUSTER_RPC=http://127.0.0.1:50051
+# Optional: coordinator WorkerService endpoint (same as NODE_COORDINATOR_RPC), so
+# the fulfiller forwards the coordinator + worker build identities to the SPN
+# (cluster-wide reporting). Unset => the fulfiller reports only its own component.
+FULFILLER_COORDINATOR_RPC=http://127.0.0.1:50055
 FULFILLER_CLUSTER_ARTIFACT_STORE=
 FULFILLER_CLUSTER_S3_BUCKET=
 FULFILLER_CLUSTER_S3_REGION=

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,6 +101,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}:base-{1}', env.ECR_REPOSITORY, needs.setup.outputs.TAG_NAME) || '' }}
           build-args: |
             VERGEN_GIT_SHA=${{ needs.setup.outputs.SHORT_SHA }}
+            IMAGE_TAG=base-${{ needs.setup.outputs.SHORT_SHA }}
           secrets: |
             private_pull_token=${{ secrets.PRIVATE_PULL_TOKEN }}
           cache-from: type=gha,scope=base
@@ -125,6 +126,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}:base-{1}', env.GHCR_REPOSITORY, needs.setup.outputs.TAG_NAME) || '' }}
           build-args: |
             VERGEN_GIT_SHA=${{ needs.setup.outputs.SHORT_SHA }}
+            IMAGE_TAG=base-${{ needs.setup.outputs.SHORT_SHA }}
           secrets: |
             private_pull_token=${{ secrets.PRIVATE_PULL_TOKEN }}
           cache-from: type=gha,scope=base
@@ -218,6 +220,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}:node-gpu-{1}', env.ECR_REPOSITORY, needs.setup.outputs.TAG_NAME) || '' }}
           build-args: |
             VERGEN_GIT_SHA=${{ needs.setup.outputs.SHORT_SHA }}
+            IMAGE_TAG=node-gpu-${{ needs.setup.outputs.SHORT_SHA }}
           secrets: |
             private_pull_token=${{ secrets.PRIVATE_PULL_TOKEN }}
           cache-from: type=gha,scope=node-gpu
@@ -242,6 +245,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/tags/') && format('{0}:node-gpu-{1}', env.GHCR_REPOSITORY, needs.setup.outputs.TAG_NAME) || '' }}
           build-args: |
             VERGEN_GIT_SHA=${{ needs.setup.outputs.SHORT_SHA }}
+            IMAGE_TAG=node-gpu-${{ needs.setup.outputs.SHORT_SHA }}
           secrets: |
             private_pull_token=${{ secrets.PRIVATE_PULL_TOKEN }}
           cache-from: type=gha,scope=node-gpu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -662,7 +662,7 @@ checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest",
  "serde_json",
  "tower 0.5.3",
@@ -1853,7 +1853,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1873,7 +1873,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3111,7 +3111,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3378,7 +3378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5106,7 +5106,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6288,7 +6288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6321,7 +6321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6334,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6473,7 +6473,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7081,7 +7081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7676,8 +7676,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f0fad1b9f51cb6beb3aa84be925da5879d381a5c64aac7b50b6734d966439"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-air",
 ]
@@ -7685,8 +7684,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8372b2ed54e584140c8ffe9b11e101fcb27717d71ba9dca9de7f4a02e12cd5"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7696,8 +7694,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6e2a132f01b59001316abcc48696e983f8ae25b9f131c65ae895d28c4f0903"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7707,8 +7704,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e20c8d55cda40285fe8e32d2f5fdae950e5d884a867e51cd6a4d36fe9fb8965"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7722,8 +7718,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f7aef8fe8b67e2523c5b3298766c409b4c5192bbda9a79057ef7c2044944b"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7745,8 +7740,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bc7ea00417968bad0a0b2498d89405a94735a5105dad945b4c109ce9dd50bd"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7772,8 +7766,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e221a87b966e845fc20dde7cf2ae5402abb9f18ada41bbfb1585b84608e37a03"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7787,8 +7780,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1896ae945a0288cbd53027c6aa94e239ca958f46c6f3740c35259620b9174900"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7800,8 +7792,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95de8c30f4af3373cae325895dbe346d40543f2c68cb4fde2b7ca2640a14a36d"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7811,8 +7802,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb47374580d144962efa45651d9b11cd6994219194a9af3499e7d3636b66e09b"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7825,8 +7815,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a2120404ebef7025707178ba8714d103f489880c4e45aa4d1779920eecb05c"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-fri",
 ]
@@ -7834,8 +7823,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be6ce4a857ba32b9ebff00e8c7da7ce4b821021c94ab7841df0fbf3b335de6e"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7849,8 +7837,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358cb67fce3ee8d0eb0aca0f79125b8ba17905fa496d785c68c20303d5033067"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "futures",
@@ -7883,8 +7870,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c390b1ca38b462d897c3d45550150b0681759ac729800fbb509e5c693b07cf5"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7892,8 +7878,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6bdca3d0f1d43db8c6385cd7e711737b4ea3061692c91ae3f1c00e6cee1354"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7907,8 +7892,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73bbd4fa3950410f9cd606cd5aa394c63c143f1ec67a2549247f439e7f60857"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-matrix",
 ]
@@ -7916,8 +7900,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b14472c013bc6af12fa4dbce4914310ed828a8891368ce729c32681fc2e52b"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7925,8 +7908,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd51c818076fad68d93d5de84a0150c95296bbffedf8410ec37768b02c5c9e7"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7951,8 +7933,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec4cc9826228ed4f4e81baa3c8a16f3b3be535ae673009daebfeb06a57aab6d"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "futures",
@@ -7972,8 +7953,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e885d53e76d1909e3e81f445c5dad58f1edb2516a5eecc5fa046bcecc0f79a4d"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7981,8 +7961,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790bdabbedf054cc63898653db2091778350d6cbe92cc4849b720197bf490b3f"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "slop-algebra",
 ]
@@ -7990,8 +7969,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c105fd09e4511635da451a3a5ea67930de8bc2580e38f4e17fee7bfa863679a6"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "futures",
@@ -8013,8 +7991,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21872dbcf1d74412a8694c1c7d591327f9fb135190b532b2bd142d8e6fcb149d"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8031,8 +8008,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60d8d1c8326e64946ad31ff87ea46ed33352c0cd83335616b807cdd7caf54df"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8040,8 +8016,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8808c750ebf2fed123966b1ae2b2cdb68816b1c3720f34940f7d4bd0e642487"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8060,8 +8035,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fed277cde22eb01bee30960fa083d2a675e9753a941c83298cea5f4da90c63"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8069,8 +8043,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae90758e6620773f2add87a35f1f383d5962c1bfb928ce341e6adf89e65e0bbc"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8080,8 +8053,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a84e9e64017411723f6805bc56c56de41f16f3b47c6e0361608e3e24c4181a"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "derive-where",
  "futures",
@@ -8149,8 +8121,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c013676daf7ad3f1b1cfab1655a2e68f7607a6e460a5d51ed94c1b116b1b981"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8183,7 +8154,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-artifact"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8211,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-bidder"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "alloy",
  "alloy-signer-local",
@@ -8259,7 +8230,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-common"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "backoff",
  "chrono",
@@ -8321,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfiller"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8349,7 +8320,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfillment"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8372,11 +8343,12 @@ dependencies = [
  "tokio",
  "tonic 0.12.3",
  "tracing",
+ "vergen-git2",
 ]
 
 [[package]]
 name = "sp1-cluster-network-gateway"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8445,7 +8417,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-utils"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "eyre",
  "sp1-cluster-artifact",
@@ -8458,7 +8430,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-worker"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8504,8 +8476,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d42cb5ff5e1614cab6a504ba35ba2220b1b75ec707ff36290a98a87541dee2"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8545,8 +8516,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c6458a70a3ee7270edc07b088a27a6d976f3806a5176f862a44b459ea038b2"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8567,8 +8537,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8e364bba7ffa8f0920a01380aa49339b402ec0fcda85e8f44f4ecf9fdb9d13"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8582,8 +8551,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f83a1a9147f47904ef93100a4a3628e8cf764845f59fa63ca4d823127a8118a"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8631,8 +8599,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a5b10d6fe1e0f893b1ae45301e6d61a0e89cf6b689659bf1f0151143a3c287"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8653,8 +8620,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d019111b7cffb75a8ac223b917fa6b52ce86d54badff67080cc144b646876489"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8664,8 +8630,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5290d64e8fb3f82c0942c6c8108bddc0d4a51bd8889c23d36c1563ce26d78e3"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8680,8 +8645,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2fc664e2c6278865dc0ba94bab0e94dafe7ddf83160385fa36ea0098197e8"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8714,8 +8678,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f1f20972195d1e08a5f5f8782c2543f162351d8f6f6043a45d73f61c4898fd"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8730,8 +8693,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afc1df42393511ebb7134e9ba9b89d54d344346f4c608ad5f34b5be89a6104e"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8759,8 +8721,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3bf6c94c4c0430742bf8578ca630b95952059da314c2b2801b4aa7e073020"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8789,8 +8750,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49713cce36769cecb006beeb338741bd5fbcbbd318c0c1e4621534ed79f9f014"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8816,8 +8776,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b182efb0c2aba0eaaadb748dbd2ffd0e8dfdd82b00a639172f51b0a63ad13c"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8839,8 +8798,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479da17092bada9012e32a55ad402a7f103747676cec86c78ca7405fddd5ca61"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8868,8 +8826,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6736577421b669049dd1689b041fc29a46a0edccab65f0d3f1a7b922e5ac504"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8905,8 +8862,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b76cab9aa7366cc2c95a6aeb2d4153f05059f8780cbcaced6576fc4459401"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8931,8 +8887,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98b169dd094c1c44c52b422f6d6044bd675d417597fe1413ec2087b2755f5c1"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "clap",
  "serde",
@@ -8967,8 +8922,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884b65d047b459ebe69a981434d13cc0bb300ce17318910fd4a77ed836cee3b1"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -9004,8 +8958,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f6750064bf846b11a777eaf8d1e63ebb8eb3730b8a13d9b6caeb50960debdb"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -9021,8 +8974,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6692af0cfe7a0e0528cf1cee2a2811cacdfe55dd4ad81e9191ff91bfc08cdc9c"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "futures",
  "rayon",
@@ -9047,8 +8999,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf9e7da096bf5eac76c9689af6ee4d51856521bc4d7bcf580cf6341493b6f72"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9058,8 +9009,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542f7bacd943def63ae66e26d137297e53589dd093bf98adf1f792c713ec2bf5"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9072,8 +9022,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1a495e3ca1f9e6faff147da21fda700ce8ca8558c2d9fdff2057ee22bc1a9e"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9104,8 +9053,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9797979904dd620bc4ede3cb5428c80b40a1208aa3af4bfa5c8168765b3005"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9153,8 +9101,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8066e644f241c00b2410ebad85127d6b0f3ca81fcde2c064b0238a1564607f0"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9170,8 +9117,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e37509eacbf8c2d0fe4af1b7faf7452158e6dae9f2d761667a8a5c59b5a863"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "bincode",
  "blake3",
@@ -9194,8 +9140,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1898cf0ab8955a3926942a63e76ae880a90a97e6fec140bb22e4848c0f61fc"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9258,8 +9203,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca81e307651221f0710fb41b64a9db5acedc7911fc71ef73e38e84abf61fbf"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9282,8 +9226,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7476ca64175b28557bb07eb2f51b255b593efa57368d95ab9c54727ce8507b0e"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9322,8 +9265,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b44a83bf53f32effcd9d2ae3fe8d4bb77923166ba228a00dd14ee02d58a6b5"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9343,8 +9285,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b09f1efb9fb06ea8d0527fc83ae1a7d9ed32a1bcd085dc76719dbfbf2d80f37"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9367,8 +9308,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342e1ba459f495fa2301e6af33bb4f314bdb4ab19a2d30c7ce7d8c05e8709d0"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9392,8 +9332,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823880d30e7d9c0c10db6f5c8537c1b4bfadac90e8f44dc8e7da459e3f061f6c"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9414,8 +9353,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431178dd864d35527a643d03193c36f7f52cccd6b7d3e631849ca71d370dcad5"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9465,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-test-cluster"
-version = "2.5.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9491,8 +9429,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a4fb8e2642046acb9ac642137c97fb466c17017579cece9040778306e54dc4"
+source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
 dependencies = [
  "bincode",
  "blake3",
@@ -9547,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
+source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9559,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
+source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9580,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
+source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9599,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
+source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9617,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
+source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9628,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=8e58693#8e586939f21c05dbb67c512ec0306280379bd0c5"
+source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -10161,7 +10098,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-air",
 ]
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7780,7 +7780,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-fri",
 ]
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "futures",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-matrix",
 ]
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "futures",
@@ -7953,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "slop-algebra",
 ]
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "futures",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8008,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8016,7 +8016,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "derive-where",
  "futures",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8537,7 +8537,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8551,7 +8551,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8599,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8645,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8678,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8693,7 +8693,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "clap",
  "serde",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8958,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "futures",
  "rayon",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9009,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9101,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "bincode",
  "blake3",
@@ -9140,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9285,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
+source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
 dependencies = [
  "bincode",
  "blake3",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
+source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
+source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
+source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
+source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
+source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
+source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-air",
 ]
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7780,7 +7780,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-fri",
 ]
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "futures",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-matrix",
 ]
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "futures",
@@ -7953,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "slop-algebra",
 ]
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "futures",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8008,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8016,7 +8016,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "derive-where",
  "futures",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8537,7 +8537,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8551,7 +8551,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8599,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8645,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8678,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8693,7 +8693,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "clap",
  "serde",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8958,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "futures",
  "rayon",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9009,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9101,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "bincode",
  "blake3",
@@ -9140,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9285,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=9069dd6#9069dd60f5fdcaca70be0f9bd9b0351581f1a64d"
+source = "git+https://github.com/succinctlabs/sp1?rev=97e9ecc#97e9ecc195f4e5cd923a828e4ba994f873dad8e9"
 dependencies = [
  "bincode",
  "blake3",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
+source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
+source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
+source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
+source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
+source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
+source = "git+https://github.com/succinctlabs/network?rev=742578c#742578c3aa0f57d76749a5503b93607bd58572ac"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
+source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
+source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
+source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
+source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
+source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=d276723#d276723e147c09622ff2b8030d8ea6cedc4d2fd7"
+source = "git+https://github.com/succinctlabs/network?rev=77e100b#77e100b8c3416de8b631d5bfe67d73d54703c532"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -662,7 +662,7 @@ checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest",
  "serde_json",
  "tower 0.5.3",
@@ -3111,7 +3111,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3378,7 +3378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4291,7 +4291,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5106,7 +5106,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6287,8 +6287,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6321,7 +6321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6334,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6473,7 +6473,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7081,7 +7081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7675,16 +7675,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447a04cb85d3dabad2bb07034e9393419566a5f0bf9c34f746a04469782be963"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c112cafd4c5c374d267a48c8976d12fca3b0f2cc2e44e6fb1343808310b4fc6"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7693,8 +7695,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaa537343a6b95b7c0d4e1f5355a4da7428ae5e2f65b62167295226a9a6f7a5"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7703,8 +7706,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129dff87e6accaf7238f605c536d76049c2bff1f6fa6d032ac56985c27c646be"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7717,8 +7721,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee7b22007e82917494db0e87fbb277d6c1796106572333ed53019be629ad5cd3"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7739,8 +7744,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5bb7b2f76cd38f1ecc42caeaee66841a9cb7cf802df1b5257874b5e773a3ec"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7765,8 +7771,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea991a652ea2e55f0523649f5c9efbfb32cf9fdcc2bf3b3580b4343a94379503"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7779,8 +7786,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b33f1eaadcd4159157758b0edcf1c14f470915f85c648e660e4740ff83e921"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7791,8 +7799,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076e7f6d03a74a62024342eb5ef13719eae1adcfebb5232cfe8858ebc67f4d33"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7801,8 +7810,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c742ca70828453dd3c154ad63816a987d27a7c454c19e9428b03fbdf4f118c"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7814,16 +7824,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274f15a2a2508af5e1071ac890b672ad5b7727efba4bc1b33b33efd06045c02c"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04717ab01c1202613436caf70948f3e7157bb4c35084817879787c98d62c87e9"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7836,8 +7848,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaf578d92dc05de1cd4fa7dc9ffeca918df20cda868326528ec0e81d9c153b1"
 dependencies = [
  "derive-where",
  "futures",
@@ -7869,16 +7882,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d2c1565483d5363ffa431b510778c5bef7c423ed21cee95440721de0372213"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8795ee9a92ecf0a604c0e3ed20e80bbc38772310c0622f94a2e1b66ca2455cb8"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7891,24 +7906,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50770150d6d5efc2ac3d20def5a6db2ca9d021defc74a414613174cfe40d96e1"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dc27cfc5036caca9642a71827c6b99b917fcd195285788d04f9b25f5df590e"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb16c7104504683851c4aea91b9b4d28ac8fc643ecd21d798da894889c261df"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7932,8 +7950,9 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a58b8c6c7ab9fbb7dc55c68269b1d1d722beb23af8d6a1091c15877328145"
 dependencies = [
  "derive-where",
  "futures",
@@ -7952,24 +7971,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25561d9ecf4bcf1aa2e800560ac557bff6dad943b9dc5cd0e8427fceca1e8c65"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b24ad70b49f40d6acfe7b1ccf042db25820abe305a4c2232f15204f63f0227"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7197d135a012724c2988e2c3a643a54eddbdaa0570b2540b55f39337b437cf"
 dependencies = [
  "derive-where",
  "futures",
@@ -7990,8 +8012,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcf5bf842f895678f170cc36ac7c4bc6521e7c119d24b2c0793f4bbcbe0d3d4"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8007,16 +8030,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e580d03bb5383aca1c12579a8a24b838afb12eb356439e740cba34904b6864"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4288b17090a89f1669437b7d4435b48da0e4a904669205c9b5d85afbf47176"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8034,16 +8059,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632cac9d74df33a49efd2ba559ab51171020d9a27c375abb29846f078fa50ad6"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c772904088f4b52275b7faedfa70fdb14dba514c3c4165b8ddb6bbad3b0eb67b"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8052,8 +8079,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5c2e680078bfcfa0b782ce3512c06b8fcf8e3bc373c6c291e32395580e780"
 dependencies = [
  "derive-where",
  "futures",
@@ -8120,8 +8148,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86f0b3b6f39976825b472e2967e212b4e36f6dc395c74076b25b2ed52c605dd"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8154,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-artifact"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8182,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-bidder"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "alloy",
  "alloy-signer-local",
@@ -8230,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-common"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "backoff",
  "chrono",
@@ -8292,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfiller"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8320,7 +8349,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfillment"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8348,7 +8377,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-network-gateway"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8417,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-utils"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "eyre",
  "sp1-cluster-artifact",
@@ -8430,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-worker"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8475,8 +8504,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4dcb59c94af4b470b005468d7c089208bc2ac834363193a8cdc2418e60a211a"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8515,8 +8545,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170ac89e5233e23cff58ad32f7cbbeced26c3ce190207d6b1c7c1f699525b655"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8536,8 +8567,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704fef851e9f123f669ef04045fcff122453b0ca6942cd00b61d27c291c71a87"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8550,8 +8582,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20eaef541ed947056b37a7c16a149090a8c2a3e0d1e5f31fd1b0d688f1e9d96e"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8598,8 +8631,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c3a16e1af983f60fb99176d340a401581677e63b7b1439ca034e83ca29476d"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8619,8 +8653,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a34fe6b15dd14b498a3a4491c86ec2415bb70bac23571b18df1d15ac63c7bf8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8629,8 +8664,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-air"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8429f1466a53010a7fa5c1eb45498d283fcb8025169b9c562c02be51b869cb16"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8644,8 +8680,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-basefold"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f0a92f9f65730e6eef1b06873be767a8dbc578bcece60d92d3cc36d2002c20"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8677,8 +8714,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-challenger"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5f419ddbb69515e40c77f5dc4f4ab169665d6acdf62d622c5e8104179af064"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8692,8 +8730,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-commit"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f95ac15e891411dee43884f1b00847f30980f4d652727097698dfa8370b583"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8720,8 +8759,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-cudart"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f663de114438a24bb510d61a7fe690e6b551f4188f1c92a8e196f47f49b71c5"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8749,8 +8789,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-assist"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3affb2bb17fc3bbbfc8d5539d7254da9b9646d8cf8b46d1fc2ad3cb15dcec81f"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8775,8 +8816,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00813f71e4f25ebf0d6beb28b8416d075d9573609b1a49162d974faf274b32f5"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8797,8 +8839,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1522368a4a3804d13e1b523cd380b44bc81f7460a12138092794d05e02a8d543"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8825,8 +8868,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-logup-gkr"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d08d22b163cecd7c4e3dbae651689560008ed59b93b03b1e4161633d8faf6d"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8861,8 +8905,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-merkle-tree"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409b87e2cb8f97849abed333658f482f0f051adcf6369d804cef6c5da1ef50cb"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8886,8 +8931,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-prover"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e61c716900e133ac58b96baa9fb325a1a4cb02cefeb42f5be677606118f7da"
 dependencies = [
  "clap",
  "serde",
@@ -8921,8 +8967,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-shard-prover"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02b90a7278d41211bc0c21cbaf9b15ecc05202bb0007003877f5f58009f4a2b"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8957,8 +9004,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-sys"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd63f00c80a8c8db061e686e361e0df2a1a209039da7bc0453f5dd28d853c8a7"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8973,8 +9021,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracegen"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1255c56660177888d0404831d307839c11dd0dbe4a37919adfc8aa22bb75050"
 dependencies = [
  "futures",
  "rayon",
@@ -8998,8 +9047,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracing"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cc34f8d409c61a0d98f5cd7861b2d8018e0a8a14087e8741dc4e4c310ad98c"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9008,8 +9058,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-utils"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be33bf22461ade1ea575389441048030afefdca0f98282b5a5fecbc66b95acfe"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9021,8 +9072,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-zerocheck"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4629e0c454bb8effb8f20341cc3adc0ec99fcfd5959dbe96f1320b089d71309c"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9052,8 +9104,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a088f69335f9a594783d9ad3453be5f6f3abcc90b2387be57fb819acc3da203"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9100,8 +9153,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65367f7b364358c1d7514a063177fa8131219a5cf24beb1be5547b0a043ff5ba"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9116,8 +9170,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421b4590a89bf7c263f8a64844a4034ee8cb73c351498911ce0acd18da6b5ed2"
 dependencies = [
  "bincode",
  "blake3",
@@ -9139,8 +9194,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3b14f599150ddbd3d3829ec4080dc9e10d6dac66e9741260d5a5a116fbcb02"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9202,8 +9258,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f0f1c83a25f309c404c61eaca7a0ccb62557042263c8b268f0df1c13d1fd94"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9225,8 +9282,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10edc1eeca25c63957a49516b4daccfe05e7564f75111a7a2d6642367c7bb5c6"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9264,8 +9322,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e968795d47837d58dfec2d650ae72b128722a37096faadff6ac20f5cc716c5"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9284,8 +9343,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28918f6630db8b7dfca815ac97fb0e4442319e52aa5edb813e6e368059e28e93"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9307,8 +9367,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a020c7309bb3c62c34a1c9183106a7923e480b05b66c8a1d3419dc9b78d485"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9331,8 +9392,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1abf661a1ee1f0abb3737c14086a9e2127cbd88392c290ac1622455bd757d1f"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9352,8 +9414,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac474619d83bd48d3bec8ffea7e620c6f490223a399f3ff8ad4826c146c25bef"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9403,7 +9466,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-test-cluster"
-version = "2.5.0"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9428,8 +9491,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.3.0"
-source = "git+https://github.com/succinctlabs/sp1?rev=f41291c#f41291c4577271055a25332cb0b48e3dd0606f16"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dbb411abb1ea167f9b0b082c95f62ede26ab7ba72349770292a60dc0e9a673"
 dependencies = [
  "bincode",
  "blake3",
@@ -9484,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
+source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9496,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
+source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9517,7 +9581,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
+source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9536,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
+source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9554,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
+source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9565,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=e07e786#e07e78653193f2fd8a19c429168f7314ae8cf3e1"
+source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -10098,7 +10162,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ p3-matrix = "=0.3.3-succinct"
 # SPN
 # Bumped to d276723 to pick up network#232 (ReportProverInfo wire contract).
 # d276723 is exactly one commit ahead of the prior 0b1eeab and that commit IS #232.
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "77e100b", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "742578c", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
+spn-utils = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
 
 # SP1
 #
@@ -59,20 +59,20 @@ spn-utils = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
 # the crate boundary (verified: 36 errors in sp1-cluster-worker). So the whole
 # sp1 family is pinned to the SAME git rev 9069dd6 — the minimal set that
 # compiles. Code-wise 9069dd6 == v6.3.0 for every crate except prover-types.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6", features = ["network"] }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ p3-matrix = "=0.3.3-succinct"
 # SPN
 # Bumped to d276723 to pick up network#232 (ReportProverInfo wire contract).
 # d276723 is exactly one commit ahead of the prior 0b1eeab and that commit IS #232.
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "742578c", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "e07e786", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
+spn-utils = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
 
 # SP1
 #
@@ -59,20 +59,20 @@ spn-utils = { git = "https://github.com/succinctlabs/network", rev = "742578c" }
 # the crate boundary (verified: 36 errors in sp1-cluster-worker). So the whole
 # sp1 family is pinned to the SAME git rev 9069dd6 — the minimal set that
 # compiles. Code-wise 9069dd6 == v6.3.0 for every crate except prover-types.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc", features = ["network"] }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "97e9ecc" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,40 +39,30 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-# Bumped to d276723 to pick up network#232 (ReportProverInfo wire contract).
-# d276723 is exactly one commit ahead of the prior 0b1eeab and that commit IS #232.
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "e07e786", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "e07e786" }
+# Pinned to network main f652c93 = the merge commit of network#234, which removes
+# ComponentInfo.instance_id and renumbers the ReportProverInfo build fields. Network
+# crates aren't published to crates.io, so these stay git deps.
+spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "f652c93", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
+spn-utils = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
 
 # SP1
-#
-# Pinned to sp1 git rev 9069dd6 = v6.3.0 + sp1#2850 (one additive proto commit:
-# GetClusterComponentInfo / ClusterComponentInfo + OpenRequest build fields).
-# crates.io v6.3.0 predates #2850, so the new proto types aren't in the published
-# crate. `sp1-prover-types` is what we actually need from #2850, but it shares a
-# type graph (Artifact, ProofRequest, etc.) with sp1-prover / sp1-sdk / the gpu
-# crates. Pinning ONLY sp1-prover-types to git leaves those still on crates.io,
-# which yields TWO `sp1-prover-types` packages and E0308 type mismatches across
-# the crate boundary (verified: 36 errors in sp1-cluster-worker). So the whole
-# sp1 family is pinned to the SAME git rev 9069dd6 — the minimal set that
-# compiles. Code-wise 9069dd6 == v6.3.0 for every crate except prover-types.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c", features = ["network"] }
+sp1-core-executor = "=6.3.1"
+sp1-core-machine = { version = "=6.3.1", features = ["bigint-rug"] }
+sp1-hypercube = "=6.3.1"
+sp1-primitives = "=6.3.1"
+sp1-prover = "=6.3.1"
+sp1-prover-types = "=6.3.1"
+sp1-recursion-circuit = "=6.3.1"
+sp1-recursion-compiler = "=6.3.1"
+sp1-recursion-executor = "=6.3.1"
+sp1-sdk = { version = "=6.3.1", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "f41291c" }
+sp1-gpu-cudart = "=6.3.1"
+sp1-gpu-prover = "=6.3.1"
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ p3-matrix = "=0.3.3-succinct"
 # SPN
 # Bumped to d276723 to pick up network#232 (ReportProverInfo wire contract).
 # d276723 is exactly one commit ahead of the prior 0b1eeab and that commit IS #232.
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "d276723", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "77e100b", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
+spn-utils = { git = "https://github.com/succinctlabs/network", rev = "77e100b" }
 
 # SP1
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,27 +39,40 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "8e58693", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "8e58693" }
+# Bumped to d276723 to pick up network#232 (ReportProverInfo wire contract).
+# d276723 is exactly one commit ahead of the prior 0b1eeab and that commit IS #232.
+spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "d276723", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
+spn-utils = { git = "https://github.com/succinctlabs/network", rev = "d276723" }
 
 # SP1
-sp1-core-executor = "=6.3.0"
-sp1-core-machine = { version = "=6.3.0", features = ["bigint-rug"] }
-sp1-hypercube = "=6.3.0"
-sp1-primitives = "=6.3.0"
-sp1-prover = "=6.3.0"
-sp1-prover-types = "=6.3.0"
-sp1-recursion-circuit = "=6.3.0"
-sp1-recursion-compiler = "=6.3.0"
-sp1-recursion-executor = "=6.3.0"
-sp1-sdk = { version = "=6.3.0", features = ["network"] }
+#
+# Pinned to sp1 git rev 9069dd6 = v6.3.0 + sp1#2850 (one additive proto commit:
+# GetClusterComponentInfo / ClusterComponentInfo + OpenRequest build fields).
+# crates.io v6.3.0 predates #2850, so the new proto types aren't in the published
+# crate. `sp1-prover-types` is what we actually need from #2850, but it shares a
+# type graph (Artifact, ProofRequest, etc.) with sp1-prover / sp1-sdk / the gpu
+# crates. Pinning ONLY sp1-prover-types to git leaves those still on crates.io,
+# which yields TWO `sp1-prover-types` packages and E0308 type mismatches across
+# the crate boundary (verified: 36 errors in sp1-cluster-worker). So the whole
+# sp1 family is pinned to the SAME git rev 9069dd6 — the minimal set that
+# compiles. Code-wise 9069dd6 == v6.3.0 for every crate except prover-types.
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = "=6.3.0"
-sp1-gpu-prover = "=6.3.0"
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "9069dd6" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/bin/coordinator/build.rs
+++ b/bin/coordinator/build.rs
@@ -3,12 +3,19 @@ use std::env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-env-changed=BUILD_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_SHA");
 
-    let git_sha = match env::var("BUILD_GIT_SHA") {
-        Ok(git_sha) => git_sha,
-        Err(_) => "unknown".to_string(),
-    };
+    // The base infra/Dockerfile sets VERGEN_GIT_SHA (not BUILD_GIT_SHA) in the
+    // build stage, so prefer it. Fall back to BUILD_GIT_SHA for any caller that
+    // still sets the old name, then "unknown" for plain local builds.
+    let git_sha = env::var("VERGEN_GIT_SHA")
+        .or_else(|_| env::var("BUILD_GIT_SHA"))
+        .unwrap_or_else(|_| "unknown".to_string());
 
+    // Clean git sha for build-identity reporting (GetClusterComponentInfo).
+    println!("cargo:rustc-env=BUILD_GIT_SHA={git_sha}");
+
+    // Existing human-readable version string (metrics / GetStats); unchanged shape.
     let pretty_time = Utc::now().format("%Y-%m-%dT%H:%M:%S");
     let version_string = format!("{git_sha} {pretty_time}");
     println!("cargo:rustc-env=BUILD_VERSION={version_string}");

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -1706,18 +1706,18 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             .instrument(tracing::debug_span!("acquire"))
             .await;
 
-        // Coordinator's own build identity first. instance_id is "" (singleton).
+        // Coordinator's own build identity first.
         let mut components = vec![proto::ClusterComponentInfo {
             component: COORDINATOR_COMPONENT.to_string(),
-            instance_id: String::new(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             git_sha: BUILD_GIT_SHA.to_string(),
             image_tag: std::env::var("IMAGE_TAG").unwrap_or_default(),
         }];
 
-        // One entry per connected worker, keyed by worker id as instance_id.
+        // One entry per connected worker (keyed by build identity, not instance).
         // Workers with a non-reportable worker_type (Unspecified/None) are skipped
-        // with a warning rather than reported under a false component name.
+        // with a warning rather than reported under a false component name. Same-build
+        // workers produce identical entries; the fulfiller dedupes them downstream.
         components.extend(state.workers.values().filter_map(|w| {
             let Some(component) = worker_component_name(w.worker_type) else {
                 tracing::warn!(
@@ -1729,7 +1729,6 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             };
             Some(proto::ClusterComponentInfo {
                 component: component.to_string(),
-                instance_id: w.id.clone(),
                 version: w.version.clone(),
                 git_sha: w.git_sha.clone(),
                 image_tag: w.image_tag.clone(),
@@ -2819,28 +2818,22 @@ mod tests {
             .iter()
             .find(|ci| ci.component == "coordinator")
             .expect("coordinator entry present");
-        assert_eq!(
-            coord.instance_id, "",
-            "coordinator is a singleton: empty instance_id"
-        );
         assert_eq!(coord.version, env!("CARGO_PKG_VERSION"));
 
         let gpu = resp
             .components
             .iter()
-            .find(|ci| ci.instance_id == "gpu1")
+            .find(|ci| ci.git_sha == "gpusha")
             .expect("gpu worker entry present");
         assert_eq!(gpu.component, "gpu-node", "Gpu maps to gpu-node");
-        assert_eq!(gpu.git_sha, "gpusha");
         assert_eq!(gpu.image_tag, "node-gpu-gpusha");
 
         let cpu = resp
             .components
             .iter()
-            .find(|ci| ci.instance_id == "cpu1")
+            .find(|ci| ci.git_sha == "cpusha")
             .expect("cpu worker entry present");
         assert_eq!(cpu.component, "cpu-node", "Cpu maps to cpu-node");
-        assert_eq!(cpu.git_sha, "cpusha");
     }
 
     #[tokio::test]
@@ -2865,11 +2858,10 @@ mod tests {
         let all = resp
             .components
             .iter()
-            .find(|ci| ci.instance_id == "all1")
+            .find(|ci| ci.git_sha == "allsha")
             .expect("All worker entry present");
         // Lossy compatibility mapping: All is GPU-capable -> gpu-node.
         assert_eq!(all.component, "gpu-node", "All maps to gpu-node");
-        assert_eq!(all.git_sha, "allsha");
     }
 
     #[tokio::test]
@@ -2907,11 +2899,11 @@ mod tests {
         // Non-reportable worker_types are skipped (never reported as a false
         // cpu-node); only the coordinator's own entry remains.
         assert!(
-            resp.components.iter().all(|ci| ci.instance_id != "u1"),
+            resp.components.iter().all(|ci| ci.git_sha != "usha"),
             "Unspecified worker must be skipped"
         );
         assert!(
-            resp.components.iter().all(|ci| ci.instance_id != "n1"),
+            resp.components.iter().all(|ci| ci.git_sha != "nsha"),
             "None worker must be skipped"
         );
         assert_eq!(

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -290,7 +290,7 @@ pub struct Worker<P: AssignmentPolicy> {
     /// Whether the worker is closed and should not be sent any more tasks.
     pub closed: bool,
 
-    /// Self-reported crate version of the worker (from OpenRequest, sp1#2850).
+    /// Self-reported crate version of the worker (from OpenRequest).
     pub version: String,
 
     /// Self-reported git commit the worker was built from (from OpenRequest).
@@ -870,7 +870,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
     /// Add a worker to the Coordinator. Returns true if worker already existed.
     ///
     /// `version` / `git_sha` / `image_tag` are the worker's self-reported build
-    /// identity (OpenRequest, sp1#2850), surfaced via GetClusterComponentInfo.
+    /// identity (OpenRequest), surfaced via GetClusterComponentInfo.
     #[allow(clippy::too_many_arguments)]
     pub async fn add_worker(
         self: &Arc<Self>,

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -30,8 +30,41 @@ use tracing::{instrument, Instrument};
 
 pub const BUILD_VERSION: &str = env!("BUILD_VERSION");
 
+/// The git commit this coordinator was built from. Supplied by the base
+/// `infra/Dockerfile`'s `VERGEN_GIT_SHA` build ARG/ENV (see build.rs, which maps
+/// it to `BUILD_GIT_SHA`); `"unknown"` for plain local builds. Used for the
+/// coordinator's own entry in `GetClusterComponentInfo`.
+pub const BUILD_GIT_SHA: &str = env!("BUILD_GIT_SHA");
+
+/// The component name the coordinator reports itself as in
+/// `GetClusterComponentInfo`. Must be in the network's component allowlist.
+pub const COORDINATOR_COMPONENT: &str = "coordinator";
+
 /// The interval in seconds at which the coordinator periodic task should run.
 pub const COORDINATOR_PERIODIC_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Map a worker type to its network component name for build-identity reporting.
+///
+/// The receiver contract's component allowlist only has `cpu-node` / `gpu-node`,
+/// so:
+/// - `Cpu` -> `cpu-node`
+/// - `Gpu` -> `gpu-node`
+/// - `All` -> `gpu-node`. Lossy compatibility mapping: an `All` worker is
+///   GPU-capable and the contract has no dedicated label for it, so it is
+///   reported as a gpu-node rather than dropped.
+///
+/// Returns `None` for `UnspecifiedWorkerType` / `None`, which are not real
+/// build-reportable node roles. The caller skips and warns rather than
+/// reporting them as a (false) cpu-node. Matched exhaustively (no wildcard) so a
+/// new `WorkerType` variant forces a deliberate mapping decision here.
+pub fn worker_component_name(worker_type: WorkerType) -> Option<&'static str> {
+    match worker_type {
+        WorkerType::Cpu => Some("cpu-node"),
+        WorkerType::Gpu => Some("gpu-node"),
+        WorkerType::All => Some("gpu-node"),
+        WorkerType::UnspecifiedWorkerType | WorkerType::None => None,
+    }
+}
 
 /// Estimate the duration of a task based on its type. Used as a heuristic when assigning tasks to
 /// workers.
@@ -257,16 +290,29 @@ pub struct Worker<P: AssignmentPolicy> {
     /// Whether the worker is closed and should not be sent any more tasks.
     pub closed: bool,
 
+    /// Self-reported crate version of the worker (from OpenRequest, sp1#2850).
+    pub version: String,
+
+    /// Self-reported git commit the worker was built from (from OpenRequest).
+    pub git_sha: String,
+
+    /// Self-reported container image tag the worker is running (from OpenRequest).
+    pub image_tag: String,
+
     /// Any extra state tracked by the assignment policy.
     pub extra: P::WorkerState,
 }
 
 impl<P: AssignmentPolicy> Worker<P> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         worker_type: WorkerType,
         max_weight: u32,
         channel: mpsc::UnboundedSender<Result<ServerMessage, Status>>,
+        version: String,
+        git_sha: String,
+        image_tag: String,
     ) -> Self {
         Self {
             id,
@@ -281,6 +327,9 @@ impl<P: AssignmentPolicy> Worker<P> {
                 .as_secs(),
             channel,
             closed: false,
+            version,
+            git_sha,
+            image_tag,
             extra: P::WorkerState::default(),
         }
     }
@@ -819,12 +868,19 @@ impl<P: AssignmentPolicy> Coordinator<P> {
     }
 
     /// Add a worker to the Coordinator. Returns true if worker already existed.
+    ///
+    /// `version` / `git_sha` / `image_tag` are the worker's self-reported build
+    /// identity (OpenRequest, sp1#2850), surfaced via GetClusterComponentInfo.
+    #[allow(clippy::too_many_arguments)]
     pub async fn add_worker(
         self: &Arc<Self>,
         worker_id: String,
         worker_type: WorkerType,
         max_weight: u32,
         channel: mpsc::UnboundedSender<Result<ServerMessage, Status>>,
+        version: String,
+        git_sha: String,
+        image_tag: String,
     ) -> Result<bool> {
         let mut state = self
             .state
@@ -838,12 +894,26 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             if let Some(worker) = state.workers.get_mut(&worker_id) {
                 tracing::info!("Worker already exists");
                 worker.channel = channel;
+                // Refresh build identity: a worker reconnecting after an upgrade
+                // re-sends OpenRequest with new build fields. Without this the
+                // coordinator would report the worker's pre-upgrade identity.
+                worker.version = version;
+                worker.git_sha = git_sha;
+                worker.image_tag = image_tag;
                 return Ok(true);
             }
 
             state.workers.insert(
                 worker_id.clone(),
-                Worker::new(worker_id, worker_type, max_weight, channel),
+                Worker::new(
+                    worker_id,
+                    worker_type,
+                    max_weight,
+                    channel,
+                    version,
+                    git_sha,
+                    image_tag,
+                ),
             );
             // Assign tasks now that a worker is available.
             self.assign_tasks(state).await?;
@@ -1622,6 +1692,53 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         }
     }
 
+    /// Build the cluster component manifest: the coordinator's own build identity
+    /// followed by one entry per connected worker, from the in-memory registry.
+    ///
+    /// The fulfiller calls this (via the WorkerService RPC) and forwards the
+    /// entries to the SPN `ReportProverInfo` RPC. Component names use the
+    /// network's allowlist: "coordinator", "gpu-node", "cpu-node".
+    pub async fn get_cluster_component_info(&self) -> proto::GetClusterComponentInfoResponse {
+        // Acquire the same state lock used elsewhere; keep the registry in-memory.
+        let state = self
+            .state
+            .read()
+            .instrument(tracing::debug_span!("acquire"))
+            .await;
+
+        // Coordinator's own build identity first. instance_id is "" (singleton).
+        let mut components = vec![proto::ClusterComponentInfo {
+            component: COORDINATOR_COMPONENT.to_string(),
+            instance_id: String::new(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            git_sha: BUILD_GIT_SHA.to_string(),
+            image_tag: std::env::var("IMAGE_TAG").unwrap_or_default(),
+        }];
+
+        // One entry per connected worker, keyed by worker id as instance_id.
+        // Workers with a non-reportable worker_type (Unspecified/None) are skipped
+        // with a warning rather than reported under a false component name.
+        components.extend(state.workers.values().filter_map(|w| {
+            let Some(component) = worker_component_name(w.worker_type) else {
+                tracing::warn!(
+                    worker_id = %w.id,
+                    worker_type = ?w.worker_type,
+                    "skipping worker with non-reportable worker_type in cluster component manifest",
+                );
+                return None;
+            };
+            Some(proto::ClusterComponentInfo {
+                component: component.to_string(),
+                instance_id: w.id.clone(),
+                version: w.version.clone(),
+                git_sha: w.git_sha.clone(),
+                image_tag: w.image_tag.clone(),
+            })
+        }));
+
+        proto::GetClusterComponentInfoResponse { components }
+    }
+
     /// Print coordinator info.
     pub async fn print_info(&self) {
         let info = self.get_info().await;
@@ -2154,7 +2271,15 @@ mod tests {
         active_tasks: &[(&str, &str)],
     ) -> mpsc::UnboundedReceiver<Result<ServerMessage, Status>> {
         let (tx, rx) = mpsc::unbounded_channel();
-        let mut worker = Worker::new(worker_id.into(), worker_type, 24, tx);
+        let mut worker = Worker::new(
+            worker_id.into(),
+            worker_type,
+            24,
+            tx,
+            String::new(),
+            String::new(),
+            String::new(),
+        );
         // Force the heartbeat into the distant past so cleanup_dead_workers picks it up.
         worker.last_heartbeat = 0;
         for (proof_id, task_id) in active_tasks {
@@ -2174,7 +2299,15 @@ mod tests {
             let mut state = c.state.write().await;
             state.workers.insert(
                 "w1".into(),
-                Worker::new("w1".into(), WorkerType::Gpu, 24, tx),
+                Worker::new(
+                    "w1".into(),
+                    WorkerType::Gpu,
+                    24,
+                    tx,
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ),
             );
         }
 
@@ -2380,7 +2513,15 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         state.workers.insert(
             worker_id.into(),
-            Worker::new(worker_id.into(), worker_type, 24, tx),
+            Worker::new(
+                worker_id.into(),
+                worker_type,
+                24,
+                tx,
+                String::new(),
+                String::new(),
+                String::new(),
+            ),
         );
     }
 
@@ -2559,5 +2700,224 @@ mod tests {
                 panic!("ghost complete must not deliver a second subscriber message, got: {msg:?}")
             }
         }
+    }
+
+    // --- build-identity reporting (add_worker registry + manifest) ---
+
+    /// Reads the stored build fields for a worker out of the in-memory registry.
+    async fn worker_build(
+        c: &Arc<Coordinator<DefaultPolicy>>,
+        worker_id: &str,
+    ) -> (String, String, String) {
+        let state = c.state.read().await;
+        let w = state.workers.get(worker_id).expect("worker registered");
+        (w.version.clone(), w.git_sha.clone(), w.image_tag.clone())
+    }
+
+    #[tokio::test]
+    async fn add_worker_stores_build_identity() {
+        let c = Arc::new(coordinator());
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let existed = c
+            .add_worker(
+                "w1".into(),
+                WorkerType::Gpu,
+                24,
+                tx,
+                "2.5.0".into(),
+                "abc1234".into(),
+                "node-gpu-abc1234".into(),
+            )
+            .await
+            .unwrap();
+        assert!(!existed, "first add_worker must report the worker as new");
+
+        let (version, git_sha, image_tag) = worker_build(&c, "w1").await;
+        assert_eq!(version, "2.5.0");
+        assert_eq!(git_sha, "abc1234");
+        assert_eq!(image_tag, "node-gpu-abc1234");
+    }
+
+    #[tokio::test]
+    async fn add_worker_reconnect_refreshes_build_identity() {
+        let c = Arc::new(coordinator());
+
+        let (tx1, _rx1) = mpsc::unbounded_channel();
+        c.add_worker(
+            "w1".into(),
+            WorkerType::Gpu,
+            24,
+            tx1,
+            "2.5.0".into(),
+            "oldsha".into(),
+            "node-gpu-oldsha".into(),
+        )
+        .await
+        .unwrap();
+
+        // Same worker_id reconnects after an upgrade with a new build.
+        let (tx2, _rx2) = mpsc::unbounded_channel();
+        let existed = c
+            .add_worker(
+                "w1".into(),
+                WorkerType::Gpu,
+                24,
+                tx2,
+                "2.6.0".into(),
+                "newsha".into(),
+                "node-gpu-newsha".into(),
+            )
+            .await
+            .unwrap();
+        assert!(existed, "reconnect with same worker_id must report existed");
+
+        // Build identity must reflect the NEW build, not the stale one.
+        let (version, git_sha, image_tag) = worker_build(&c, "w1").await;
+        assert_eq!(version, "2.6.0", "version must refresh on reconnect");
+        assert_eq!(git_sha, "newsha", "git_sha must refresh on reconnect");
+        assert_eq!(image_tag, "node-gpu-newsha", "image_tag must refresh");
+    }
+
+    #[tokio::test]
+    async fn get_cluster_component_info_includes_coordinator_and_workers() {
+        let c = Arc::new(coordinator());
+
+        let (tx_gpu, _rx_gpu) = mpsc::unbounded_channel();
+        c.add_worker(
+            "gpu1".into(),
+            WorkerType::Gpu,
+            24,
+            tx_gpu,
+            "2.5.0".into(),
+            "gpusha".into(),
+            "node-gpu-gpusha".into(),
+        )
+        .await
+        .unwrap();
+
+        let (tx_cpu, _rx_cpu) = mpsc::unbounded_channel();
+        c.add_worker(
+            "cpu1".into(),
+            WorkerType::Cpu,
+            24,
+            tx_cpu,
+            "2.5.0".into(),
+            "cpusha".into(),
+            "base-cpusha".into(),
+        )
+        .await
+        .unwrap();
+
+        let resp = c.get_cluster_component_info().await;
+
+        // Exactly one coordinator entry + one per worker.
+        assert_eq!(resp.components.len(), 3, "coordinator + 2 workers");
+
+        let coord = resp
+            .components
+            .iter()
+            .find(|ci| ci.component == "coordinator")
+            .expect("coordinator entry present");
+        assert_eq!(
+            coord.instance_id, "",
+            "coordinator is a singleton: empty instance_id"
+        );
+        assert_eq!(coord.version, env!("CARGO_PKG_VERSION"));
+
+        let gpu = resp
+            .components
+            .iter()
+            .find(|ci| ci.instance_id == "gpu1")
+            .expect("gpu worker entry present");
+        assert_eq!(gpu.component, "gpu-node", "Gpu maps to gpu-node");
+        assert_eq!(gpu.git_sha, "gpusha");
+        assert_eq!(gpu.image_tag, "node-gpu-gpusha");
+
+        let cpu = resp
+            .components
+            .iter()
+            .find(|ci| ci.instance_id == "cpu1")
+            .expect("cpu worker entry present");
+        assert_eq!(cpu.component, "cpu-node", "Cpu maps to cpu-node");
+        assert_eq!(cpu.git_sha, "cpusha");
+    }
+
+    #[tokio::test]
+    async fn get_cluster_component_info_maps_all_to_gpu_node() {
+        let c = Arc::new(coordinator());
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        c.add_worker(
+            "all1".into(),
+            WorkerType::All,
+            24,
+            tx,
+            "2.5.0".into(),
+            "allsha".into(),
+            "node-gpu-allsha".into(),
+        )
+        .await
+        .unwrap();
+
+        let resp = c.get_cluster_component_info().await;
+
+        let all = resp
+            .components
+            .iter()
+            .find(|ci| ci.instance_id == "all1")
+            .expect("All worker entry present");
+        // Lossy compatibility mapping: All is GPU-capable -> gpu-node.
+        assert_eq!(all.component, "gpu-node", "All maps to gpu-node");
+        assert_eq!(all.git_sha, "allsha");
+    }
+
+    #[tokio::test]
+    async fn get_cluster_component_info_skips_unspecified_and_none_workers() {
+        let c = Arc::new(coordinator());
+
+        let (tx_u, _rx_u) = mpsc::unbounded_channel();
+        c.add_worker(
+            "u1".into(),
+            WorkerType::UnspecifiedWorkerType,
+            24,
+            tx_u,
+            "2.5.0".into(),
+            "usha".into(),
+            "base-usha".into(),
+        )
+        .await
+        .unwrap();
+
+        let (tx_n, _rx_n) = mpsc::unbounded_channel();
+        c.add_worker(
+            "n1".into(),
+            WorkerType::None,
+            24,
+            tx_n,
+            "2.5.0".into(),
+            "nsha".into(),
+            "base-nsha".into(),
+        )
+        .await
+        .unwrap();
+
+        let resp = c.get_cluster_component_info().await;
+
+        // Non-reportable worker_types are skipped (never reported as a false
+        // cpu-node); only the coordinator's own entry remains.
+        assert!(
+            resp.components.iter().all(|ci| ci.instance_id != "u1"),
+            "Unspecified worker must be skipped"
+        );
+        assert!(
+            resp.components.iter().all(|ci| ci.instance_id != "n1"),
+            "None worker must be skipped"
+        );
+        assert_eq!(
+            resp.components.len(),
+            1,
+            "only the coordinator entry remains"
+        );
     }
 }

--- a/bin/coordinator/src/server.rs
+++ b/bin/coordinator/src/server.rs
@@ -67,7 +67,15 @@ impl<P: AssignmentPolicy + Send + Sync + 'static>
                 tracing::info!("Worker registered: {}", hb.worker_id);
 
                 if let Err(e) = coordinator
-                    .add_worker(hb.worker_id.clone(), hb.worker_type(), hb.max_weight, tx)
+                    .add_worker(
+                        hb.worker_id.clone(),
+                        hb.worker_type(),
+                        hb.max_weight,
+                        tx,
+                        hb.version.clone(),
+                        hb.git_sha.clone(),
+                        hb.image_tag.clone(),
+                    )
                     .await
                 {
                     tracing::error!("Failed to add worker: {:?}", e);
@@ -415,6 +423,14 @@ impl<P: AssignmentPolicy + Send + Sync + 'static>
 
     async fn get_stats(&self, _: Request<()>) -> Result<Response<GetStatsResponse>, Status> {
         let response = self.coordinator.get_info().await;
+        Ok(Response::new(response))
+    }
+
+    async fn get_cluster_component_info(
+        &self,
+        _: Request<proto::GetClusterComponentInfoRequest>,
+    ) -> Result<Response<proto::GetClusterComponentInfoResponse>, Status> {
+        let response = self.coordinator.get_cluster_component_info().await;
         Ok(Response::new(response))
     }
 

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -7,6 +7,7 @@ use sp1_cluster_artifact::ArtifactType;
 use sp1_cluster_common::proto::ProofRequest;
 use sp1_cluster_fulfillment::{
     network::{FulfillmentNetwork, NetworkRequest},
+    prover_info::build_report_prover_info_body,
     request_error_from_extra_data,
 };
 use sp1_sdk::network::signer::NetworkSigner;
@@ -45,6 +46,29 @@ impl FulfillmentNetwork for MainnetFulfiller {
             .into_inner()
             .owner;
         Ok(Address::from_slice(&prover_bytes))
+    }
+
+    async fn report_prover_info(
+        &self,
+        domain: &[u8],
+        prover: Address,
+        components: Vec<spn_network_types::ComponentInfo>,
+        signer: &NetworkSigner,
+    ) -> Result<()> {
+        // ReportProverInfo (network#232) carries no nonce and writes no ledger
+        // tx — it is signed, non-ledger telemetry: the body is signed and the
+        // receiver verifies the signer, binding the report to the signer-resolved
+        // prover. Build + sign the body exactly like fulfill_proof, minus GetNonce.
+        let body = build_report_prover_info_body(domain, prover.as_slice(), components);
+
+        let request = spn_network_types::ReportProverInfoRequest {
+            format: spn_network_types::MessageFormat::Binary.into(),
+            signature: signer.sign_message(&body.encode_to_vec()).await?.into(),
+            body: Some(body),
+        };
+
+        self.network.clone().report_prover_info(request).await?;
+        Ok(())
     }
 
     async fn submit_request(

--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -55,7 +55,7 @@ impl FulfillmentNetwork for MainnetFulfiller {
         components: Vec<spn_network_types::ComponentInfo>,
         signer: &NetworkSigner,
     ) -> Result<()> {
-        // ReportProverInfo (network#232) carries no nonce and writes no ledger
+        // ReportProverInfo carries no nonce and writes no ledger
         // tx — it is signed, non-ledger telemetry: the body is signed and the
         // receiver verifies the signer, binding the report to the signer-resolved
         // prover. Build + sign the body exactly like fulfill_proof, minus GetNonce.

--- a/crates/fulfillment/Cargo.toml
+++ b/crates/fulfillment/Cargo.toml
@@ -31,3 +31,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+
+[build-dependencies]
+vergen-git2 = { workspace = true }

--- a/crates/fulfillment/build.rs
+++ b/crates/fulfillment/build.rs
@@ -1,0 +1,15 @@
+use vergen_git2::{Emitter, Git2Builder};
+
+/// Emit `VERGEN_GIT_SHA` so the fulfiller can self-report the git commit it was
+/// built from via the network `ReportProverInfo` RPC. Mirrors the worker crate's
+/// build.rs but keeps to git info only (the only build constant the fulfiller
+/// needs), to avoid pulling in heavier vergen instruction sets.
+///
+/// In Docker builds the value is supplied by the `VERGEN_GIT_SHA` build ARG/ENV
+/// (see `infra/Dockerfile`); vergen honours that env override. Local builds read
+/// it from the `.git` directory.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let git2 = Git2Builder::all_git()?;
+    Emitter::default().add_instructions(&git2)?.emit()?;
+    Ok(())
+}

--- a/crates/fulfillment/src/config.rs
+++ b/crates/fulfillment/src/config.rs
@@ -10,6 +10,12 @@ pub struct FulfillerSettings {
     pub sp1_private_key: String,
     pub use_aws_kms: bool,
     pub cluster_rpc: String,
+    /// Optional gRPC address of the coordinator's WorkerService, used to collect
+    /// the cluster component manifest (coordinator + workers) for cluster-wide
+    /// build-identity reporting. Set via `FULFILLER_COORDINATOR_RPC`. When unset,
+    /// the fulfiller reports only its own component (fulfiller-only).
+    #[serde(default)]
+    pub coordinator_rpc: Option<String>,
     pub version: String,
     pub log_format: LogFormat,
     #[serde(deserialize_with = "deserialize_domain")]

--- a/crates/fulfillment/src/coordinator_client.rs
+++ b/crates/fulfillment/src/coordinator_client.rs
@@ -2,11 +2,13 @@
 //! component manifest (coordinator + workers) via the `GetClusterComponentInfo`
 //! RPC (sp1#2850), for forwarding to the SPN `ReportProverInfo` RPC.
 //!
-//! Strictly best-effort: every failure mode — unset config, unreachable
-//! coordinator, an old coordinator that returns `Unimplemented`, or a slow/
-//! hanging coordinator — degrades the fulfiller to reporting only its own
-//! component. Both connect and fetch are bounded by short explicit timeouts so
-//! telemetry can never stall fulfillment.
+//! Two outcomes are distinct because the receiver treats each report as a full
+//! snapshot: an *unset* coordinator means "fulfiller-only is the whole manifest"
+//! (valid), whereas a *configured* coordinator that is unreachable / `Unimplemented`
+//! / slow is a *failure* (we must not send a fulfiller-only snapshot that would
+//! prune the coordinator/worker rows — the caller skips and retries). Both connect
+//! and fetch are bounded by short explicit timeouts so telemetry can never stall
+//! fulfillment.
 
 use std::time::Duration;
 
@@ -21,8 +23,8 @@ use tracing::warn;
 /// Bounded timeout for the optional coordinator connect attempt made lazily
 /// during telemetry collection. The shared `reconnect_with_backoff` helper
 /// retries indefinitely; this cap turns each (re)connect into a one-shot bounded
-/// attempt so a missing/unreachable coordinator degrades to fulfiller-only
-/// reporting instead of stalling the report path.
+/// attempt so an unreachable coordinator fails promptly (caller skips + retries)
+/// instead of stalling the report path.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Bounded timeout for a single `GetClusterComponentInfo` fetch, so a slow or
@@ -39,8 +41,8 @@ pub struct CoordinatorComponentClient {
 
 impl CoordinatorComponentClient {
     /// Connect to the coordinator's WorkerService at `addr`, bounded by
-    /// [`CONNECT_TIMEOUT`]. A timeout or connection failure here is non-fatal to
-    /// the fulfiller; the caller logs and falls back to self-only reporting.
+    /// [`CONNECT_TIMEOUT`]. A timeout or connection failure is returned as `Err`;
+    /// because the coordinator is configured, the caller skips the report and retries.
     pub async fn connect(addr: &str) -> anyhow::Result<Self> {
         let channel = tokio::time::timeout(
             CONNECT_TIMEOUT,
@@ -62,8 +64,8 @@ impl CoordinatorComponentClient {
     /// `ComponentInfo` type.
     ///
     /// Returns `Err` on any failure — timeout, transport error, or `Unimplemented`
-    /// from a coordinator built before sp1#2850 — which the caller treats as "no
-    /// manifest available" and reports self only.
+    /// from a coordinator built before sp1#2850 — which the caller propagates as a
+    /// report failure (skip + retry), not as a fulfiller-only snapshot.
     pub async fn get_cluster_component_info(&self) -> anyhow::Result<Vec<ClusterComponentInfo>> {
         let resp = tokio::time::timeout(
             FETCH_TIMEOUT,
@@ -83,26 +85,26 @@ impl CoordinatorComponentClient {
 /// Collect the coordinator's cluster component manifest for one report tick,
 /// managing the lazily-(re)connected client `cache`.
 ///
-/// Availability is decided per tick, not once at startup, so a coordinator that
-/// is down when the fulfiller boots is still picked up on a later tick:
-/// - `coordinator_rpc` is `None` (unset): no coordinator configured -> return
-///   empty (fulfiller-only); the cache is left untouched.
-/// - a cached client exists: try a bounded fetch; on success return it; on
-///   failure invalidate the cache (mark stale) and fall through to reconnect.
-/// - no client cached (first tick, or just invalidated): bounded reconnect +
-///   bounded fetch; on success cache the client and return the manifest.
-/// - any reconnect/fetch failure or timeout: return empty (fulfiller-only).
+/// Returns:
+/// - `Ok(None)` when `coordinator_rpc` is unset: no coordinator is configured, so a
+///   fulfiller-only report is the correct full snapshot; the cache is left untouched.
+/// - `Ok(Some(manifest))` when a configured coordinator is reached and the fetch
+///   succeeds (the client is cached for later ticks).
+/// - `Err(_)` when a configured coordinator's connect/fetch fails or times out. This
+///   is NOT a fulfiller-only snapshot: the caller must skip the report and retry,
+///   otherwise the receiver would prune the coordinator/worker rows from current.
 ///
-/// Bounded end-to-end (each connect/fetch is timeout-capped) and intended to be
-/// called from the fulfiller's detached background report task — never from the
-/// main fulfillment loop.
+/// Availability is decided per tick, not once at startup, so a coordinator that is
+/// down when the fulfiller boots is still picked up on a later tick. Bounded
+/// end-to-end (each connect/fetch is timeout-capped); intended to be called from the
+/// fulfiller's detached background report task, never from the main fulfillment loop.
 pub async fn collect_cluster_components(
     coordinator_rpc: &Option<String>,
     cache: &Mutex<Option<CoordinatorComponentClient>>,
-) -> Vec<ClusterComponentInfo> {
+) -> anyhow::Result<Option<Vec<ClusterComponentInfo>>> {
     let Some(addr) = coordinator_rpc.as_deref() else {
         // No coordinator configured -> fulfiller-only. Leave the cache untouched.
-        return Vec::new();
+        return Ok(None);
     };
 
     let mut guard = cache.lock().await;
@@ -110,7 +112,7 @@ pub async fn collect_cluster_components(
     // Fast path: reuse the cached client if one is connected.
     if let Some(client) = guard.as_ref() {
         match client.get_cluster_component_info().await {
-            Ok(components) => return components,
+            Ok(components) => return Ok(Some(components)),
             Err(e) => {
                 warn!("coordinator component fetch failed on cached client; reconnecting: {e:?}");
                 // Invalidate so the next step (and future ticks) reconnect.
@@ -120,23 +122,11 @@ pub async fn collect_cluster_components(
     }
 
     // No (valid) client: bounded reconnect, then bounded fetch.
-    match CoordinatorComponentClient::connect(addr).await {
-        Ok(client) => match client.get_cluster_component_info().await {
-            Ok(components) => {
-                // Cache the freshly connected client for subsequent ticks.
-                *guard = Some(client);
-                components
-            }
-            Err(e) => {
-                warn!("coordinator component fetch failed after reconnect (reporting fulfiller only): {e:?}");
-                Vec::new()
-            }
-        },
-        Err(e) => {
-            warn!("coordinator reconnect failed (reporting fulfiller only): {e:?}");
-            Vec::new()
-        }
-    }
+    let client = CoordinatorComponentClient::connect(addr).await?;
+    let components = client.get_cluster_component_info().await?;
+    // Cache the freshly connected client for subsequent ticks.
+    *guard = Some(client);
+    Ok(Some(components))
 }
 
 #[cfg(test)]
@@ -144,13 +134,11 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn unset_coordinator_reports_fulfiller_only_without_touching_cache() {
+    async fn unset_coordinator_returns_none_without_touching_cache() {
         let cache = Mutex::new(None);
-        let components = collect_cluster_components(&None, &cache).await;
-        assert!(
-            components.is_empty(),
-            "unset coordinator => no cluster components (fulfiller-only)"
-        );
+        let result = collect_cluster_components(&None, &cache).await;
+        // Unset coordinator => Ok(None): fulfiller-only is the valid full snapshot.
+        assert!(matches!(result, Ok(None)), "unset coordinator => Ok(None)");
         assert!(
             cache.lock().await.is_none(),
             "cache must be left untouched when no coordinator is configured"
@@ -158,21 +146,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unreachable_coordinator_degrades_and_stays_recoverable() {
+    async fn unreachable_configured_coordinator_errors_and_stays_recoverable() {
         // Closed port: connect fails (bounded by CONNECT_TIMEOUT), never hangs.
         let addr = Some("http://127.0.0.1:1".to_string());
         let cache = Mutex::new(None);
 
         let started = std::time::Instant::now();
-        let components = collect_cluster_components(&addr, &cache).await;
+        let result = collect_cluster_components(&addr, &cache).await;
 
-        // Degrades to fulfiller-only rather than blocking or erroring.
+        // A configured-but-unreachable coordinator is a failure, NOT a fulfiller-only
+        // snapshot: the caller must skip the report and retry.
         assert!(
-            components.is_empty(),
-            "unreachable coordinator => fulfiller-only"
+            result.is_err(),
+            "configured + unreachable coordinator => Err"
         );
-        // No client cached on failure => the NEXT tick reconnects from the
-        // retained address. There is no permanent-disable state.
+        // No client cached on failure => the NEXT tick reconnects from the retained
+        // address. There is no permanent-disable state.
         assert!(
             cache.lock().await.is_none(),
             "failed connect must leave the cache empty so later ticks retry"

--- a/crates/fulfillment/src/coordinator_client.rs
+++ b/crates/fulfillment/src/coordinator_client.rs
@@ -1,0 +1,186 @@
+//! Optional client the fulfiller uses to collect the coordinator's cluster
+//! component manifest (coordinator + workers) via the `GetClusterComponentInfo`
+//! RPC (sp1#2850), for forwarding to the SPN `ReportProverInfo` RPC.
+//!
+//! Strictly best-effort: every failure mode — unset config, unreachable
+//! coordinator, an old coordinator that returns `Unimplemented`, or a slow/
+//! hanging coordinator — degrades the fulfiller to reporting only its own
+//! component. Both connect and fetch are bounded by short explicit timeouts so
+//! telemetry can never stall fulfillment.
+
+use std::time::Duration;
+
+use sp1_cluster_common::proto::{
+    worker_service_client::WorkerServiceClient, ClusterComponentInfo,
+    GetClusterComponentInfoRequest,
+};
+use tokio::sync::Mutex;
+use tonic::transport::Channel;
+use tracing::warn;
+
+/// Bounded timeout for the optional coordinator connect attempt made lazily
+/// during telemetry collection. The shared `reconnect_with_backoff` helper
+/// retries indefinitely; this cap turns each (re)connect into a one-shot bounded
+/// attempt so a missing/unreachable coordinator degrades to fulfiller-only
+/// reporting instead of stalling the report path.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bounded timeout for a single `GetClusterComponentInfo` fetch, so a slow or
+/// hanging coordinator can never stall the fulfiller's report path.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Wraps a coordinator `WorkerServiceClient` for the single RPC the fulfiller
+/// needs. Held as `Option` by the fulfiller — `None` means no coordinator was
+/// configured and only the fulfiller's own component is reported.
+#[derive(Clone)]
+pub struct CoordinatorComponentClient {
+    client: WorkerServiceClient<Channel>,
+}
+
+impl CoordinatorComponentClient {
+    /// Connect to the coordinator's WorkerService at `addr`, bounded by
+    /// [`CONNECT_TIMEOUT`]. A timeout or connection failure here is non-fatal to
+    /// the fulfiller; the caller logs and falls back to self-only reporting.
+    pub async fn connect(addr: &str) -> anyhow::Result<Self> {
+        let channel = tokio::time::timeout(
+            CONNECT_TIMEOUT,
+            sp1_cluster_common::client::reconnect_with_backoff(addr),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("connect coordinator WorkerService timed out after {CONNECT_TIMEOUT:?}")
+        })?
+        .map_err(|e| anyhow::anyhow!("connect coordinator WorkerService: {e}"))?;
+        Ok(Self {
+            client: WorkerServiceClient::new(channel),
+        })
+    }
+
+    /// Fetch the coordinator's cluster component manifest (its own entry + one per
+    /// connected worker), bounded by [`FETCH_TIMEOUT`]. Returns the raw
+    /// `ClusterComponentInfo` list; the caller maps it onto the network
+    /// `ComponentInfo` type.
+    ///
+    /// Returns `Err` on any failure — timeout, transport error, or `Unimplemented`
+    /// from a coordinator built before sp1#2850 — which the caller treats as "no
+    /// manifest available" and reports self only.
+    pub async fn get_cluster_component_info(&self) -> anyhow::Result<Vec<ClusterComponentInfo>> {
+        let resp = tokio::time::timeout(
+            FETCH_TIMEOUT,
+            self.client
+                .clone()
+                .get_cluster_component_info(GetClusterComponentInfoRequest {}),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("get_cluster_component_info timed out after {FETCH_TIMEOUT:?}")
+        })??
+        .into_inner();
+        Ok(resp.components)
+    }
+}
+
+/// Collect the coordinator's cluster component manifest for one report tick,
+/// managing the lazily-(re)connected client `cache`.
+///
+/// Availability is decided per tick, not once at startup, so a coordinator that
+/// is down when the fulfiller boots is still picked up on a later tick:
+/// - `coordinator_rpc` is `None` (unset): no coordinator configured -> return
+///   empty (fulfiller-only); the cache is left untouched.
+/// - a cached client exists: try a bounded fetch; on success return it; on
+///   failure invalidate the cache (mark stale) and fall through to reconnect.
+/// - no client cached (first tick, or just invalidated): bounded reconnect +
+///   bounded fetch; on success cache the client and return the manifest.
+/// - any reconnect/fetch failure or timeout: return empty (fulfiller-only).
+///
+/// Bounded end-to-end (each connect/fetch is timeout-capped) and intended to be
+/// called from the fulfiller's detached background report task — never from the
+/// main fulfillment loop.
+pub async fn collect_cluster_components(
+    coordinator_rpc: &Option<String>,
+    cache: &Mutex<Option<CoordinatorComponentClient>>,
+) -> Vec<ClusterComponentInfo> {
+    let Some(addr) = coordinator_rpc.as_deref() else {
+        // No coordinator configured -> fulfiller-only. Leave the cache untouched.
+        return Vec::new();
+    };
+
+    let mut guard = cache.lock().await;
+
+    // Fast path: reuse the cached client if one is connected.
+    if let Some(client) = guard.as_ref() {
+        match client.get_cluster_component_info().await {
+            Ok(components) => return components,
+            Err(e) => {
+                warn!("coordinator component fetch failed on cached client; reconnecting: {e:?}");
+                // Invalidate so the next step (and future ticks) reconnect.
+                *guard = None;
+            }
+        }
+    }
+
+    // No (valid) client: bounded reconnect, then bounded fetch.
+    match CoordinatorComponentClient::connect(addr).await {
+        Ok(client) => match client.get_cluster_component_info().await {
+            Ok(components) => {
+                // Cache the freshly connected client for subsequent ticks.
+                *guard = Some(client);
+                components
+            }
+            Err(e) => {
+                warn!("coordinator component fetch failed after reconnect (reporting fulfiller only): {e:?}");
+                Vec::new()
+            }
+        },
+        Err(e) => {
+            warn!("coordinator reconnect failed (reporting fulfiller only): {e:?}");
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unset_coordinator_reports_fulfiller_only_without_touching_cache() {
+        let cache = Mutex::new(None);
+        let components = collect_cluster_components(&None, &cache).await;
+        assert!(
+            components.is_empty(),
+            "unset coordinator => no cluster components (fulfiller-only)"
+        );
+        assert!(
+            cache.lock().await.is_none(),
+            "cache must be left untouched when no coordinator is configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn unreachable_coordinator_degrades_and_stays_recoverable() {
+        // Closed port: connect fails (bounded by CONNECT_TIMEOUT), never hangs.
+        let addr = Some("http://127.0.0.1:1".to_string());
+        let cache = Mutex::new(None);
+
+        let started = std::time::Instant::now();
+        let components = collect_cluster_components(&addr, &cache).await;
+
+        // Degrades to fulfiller-only rather than blocking or erroring.
+        assert!(
+            components.is_empty(),
+            "unreachable coordinator => fulfiller-only"
+        );
+        // No client cached on failure => the NEXT tick reconnects from the
+        // retained address. There is no permanent-disable state.
+        assert!(
+            cache.lock().await.is_none(),
+            "failed connect must leave the cache empty so later ticks retry"
+        );
+        // Sanity: stayed within a bounded window (real worst case ~CONNECT_TIMEOUT).
+        assert!(
+            started.elapsed() < Duration::from_secs(20),
+            "telemetry must be bounded, not block"
+        );
+    }
+}

--- a/crates/fulfillment/src/coordinator_client.rs
+++ b/crates/fulfillment/src/coordinator_client.rs
@@ -1,6 +1,6 @@
 //! Optional client the fulfiller uses to collect the coordinator's cluster
 //! component manifest (coordinator + workers) via the `GetClusterComponentInfo`
-//! RPC (sp1#2850), for forwarding to the SPN `ReportProverInfo` RPC.
+//! RPC, for forwarding to the SPN `ReportProverInfo` RPC.
 //!
 //! Two outcomes are distinct because the receiver treats each report as a full
 //! snapshot: an *unset* coordinator means "fulfiller-only is the whole manifest"
@@ -64,7 +64,7 @@ impl CoordinatorComponentClient {
     /// `ComponentInfo` type.
     ///
     /// Returns `Err` on any failure — timeout, transport error, or `Unimplemented`
-    /// from a coordinator built before sp1#2850 — which the caller propagates as a
+    /// from a coordinator built before SP1 v6.3.1 — which the caller propagates as a
     /// report failure (skip + retry), not as a fulfiller-only snapshot.
     pub async fn get_cluster_component_info(&self) -> anyhow::Result<Vec<ClusterComponentInfo>> {
         let resp = tokio::time::timeout(

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -987,12 +987,11 @@ mod tests {
         }
     }
 
-    /// Build a cluster manifest entry. `instance_id` is set but is dropped at the
-    /// public boundary; distinct workers on the same build share a build identity.
-    fn cluster_entry(component: &str, instance_id: &str, git_sha: &str) -> ClusterComponentInfo {
+    /// Build a cluster manifest entry, keyed by build identity (same-build workers
+    /// produce identical entries).
+    fn cluster_entry(component: &str, git_sha: &str) -> ClusterComponentInfo {
         ClusterComponentInfo {
             component: component.to_string(),
-            instance_id: instance_id.to_string(),
             version: "2.5.0".to_string(),
             git_sha: git_sha.to_string(),
             image_tag: format!("{component}-{git_sha}"),
@@ -1012,9 +1011,9 @@ mod tests {
     #[test]
     fn assemble_components_includes_fulfiller_coordinator_and_workers() {
         let cluster = vec![
-            cluster_entry("coordinator", "", "coordsha"),
-            cluster_entry("gpu-node", "gpu1", "gpusha"),
-            cluster_entry("cpu-node", "cpu1", "cpusha"),
+            cluster_entry("coordinator", "coordsha"),
+            cluster_entry("gpu-node", "gpusha"),
+            cluster_entry("cpu-node", "cpusha"),
         ];
 
         let components = assemble_components(&fulfiller_identity(), Some(cluster)).unwrap();
@@ -1041,9 +1040,9 @@ mod tests {
         // Two gpu-node workers on the same build collapse to one public entry;
         // fulfiller + coordinator are still included.
         let cluster = vec![
-            cluster_entry("coordinator", "", "coordsha"),
-            cluster_entry("gpu-node", "gpu1", "samesha"),
-            cluster_entry("gpu-node", "gpu2", "samesha"),
+            cluster_entry("coordinator", "coordsha"),
+            cluster_entry("gpu-node", "samesha"),
+            cluster_entry("gpu-node", "samesha"),
         ];
 
         let components = assemble_components(&fulfiller_identity(), Some(cluster)).unwrap();
@@ -1065,9 +1064,9 @@ mod tests {
     fn assemble_components_keeps_distinct_builds_for_rolling_deploy() {
         // Old + new gpu-node builds during a rolling deploy: both remain.
         let cluster = vec![
-            cluster_entry("coordinator", "", "coordsha"),
-            cluster_entry("gpu-node", "gpu1", "oldsha"),
-            cluster_entry("gpu-node", "gpu2", "newsha"),
+            cluster_entry("coordinator", "coordsha"),
+            cluster_entry("gpu-node", "oldsha"),
+            cluster_entry("gpu-node", "newsha"),
         ];
 
         let components = assemble_components(&fulfiller_identity(), Some(cluster)).unwrap();
@@ -1088,8 +1087,8 @@ mod tests {
     fn assemble_components_rejects_two_coordinator_builds() {
         // Two distinct coordinator builds is malformed (singleton) => Err, not sent.
         let cluster = vec![
-            cluster_entry("coordinator", "", "coordsha-a"),
-            cluster_entry("coordinator", "", "coordsha-b"),
+            cluster_entry("coordinator", "coordsha-a"),
+            cluster_entry("coordinator", "coordsha-b"),
         ];
 
         assert!(
@@ -1102,7 +1101,7 @@ mod tests {
     fn assemble_components_rejects_manifest_without_coordinator() {
         // A reached coordinator must report itself: a Some manifest with no coordinator
         // entry (workers-only, or empty) is malformed and must not be sent.
-        let workers_only = vec![cluster_entry("gpu-node", "gpu1", "gpusha")];
+        let workers_only = vec![cluster_entry("gpu-node", "gpusha")];
         assert!(
             assemble_components(&fulfiller_identity(), Some(workers_only)).is_err(),
             "workers-only manifest (no coordinator) must be rejected"

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -17,12 +17,14 @@ use spn_network_types::ProofRequestError;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::{sync::Mutex, task::JoinSet, time::sleep};
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 pub mod config;
+pub mod coordinator_client;
 pub mod grpc;
 pub mod metrics;
 pub mod network;
+pub mod prover_info;
 pub mod run;
 
 /// The maximum number of requests to handle in a single refresh loop.
@@ -70,6 +72,25 @@ pub fn request_error_from_extra_data(extra_data: Option<&str>) -> Option<i32> {
     ProvingFailure::from_extra_data(s).map(|_| ProofRequestError::ProvingFailure as i32)
 }
 
+/// Assemble the full prover component list for a single `ReportProverInfo`:
+/// the fulfiller's own component first, then the coordinator manifest
+/// (coordinator + workers) mapped from the coordinator's `ClusterComponentInfo`.
+/// `cluster_components` is empty when no coordinator manifest was available, in
+/// which case the result is just the fulfiller's own component (fulfiller-only).
+pub fn assemble_components(
+    identity: &prover_info::BuildIdentity,
+    cluster_components: Vec<sp1_cluster_common::proto::ClusterComponentInfo>,
+) -> Vec<spn_network_types::ComponentInfo> {
+    let mut components = Vec::with_capacity(1 + cluster_components.len());
+    components.push(prover_info::fulfiller_component(identity));
+    components.extend(
+        cluster_components
+            .into_iter()
+            .map(prover_info::component_from_cluster),
+    );
+    components
+}
+
 #[derive(Clone)]
 pub struct Fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> {
     network: N,
@@ -95,6 +116,18 @@ pub struct Fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork
     /// submitting; without serialization, concurrent submissions sign the same nonce and all but
     /// one fail verification. Guards a single process only — replicas sharing a signer still race.
     nonce_lock: Arc<Mutex<()>>,
+    /// Configured coordinator WorkerService address (`FULFILLER_COORDINATOR_RPC`).
+    /// `None` means no coordinator is configured -> the fulfiller reports only its
+    /// own component (fulfiller-only). `Some` means cluster-wide reporting is
+    /// desired; the client below is (re)connected lazily by the report task, so a
+    /// coordinator that is down at fulfiller startup is picked up on a later tick.
+    coordinator_rpc: Option<String>,
+    /// Lazily-(re)connected client for the coordinator's `GetClusterComponentInfo`
+    /// RPC, shared across `Fulfiller` clones. `None` while disconnected/stale; the
+    /// background report task reconnects (bounded) on the next tick. Distinct from
+    /// `coordinator_rpc`: an empty client with a `Some` address means "configured
+    /// but not currently connected", not "unconfigured".
+    coordinator_client: Arc<Mutex<Option<coordinator_client::CoordinatorComponentClient>>>,
 }
 
 impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N> {
@@ -113,6 +146,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         request_probability: f64,
         name: Option<String>,
         refresh_interval_sec: u64,
+        coordinator_rpc: Option<String>,
     ) -> Self {
         Self {
             network,
@@ -129,6 +163,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             name,
             refresh_interval: Duration::from_secs(refresh_interval_sec),
             nonce_lock: Arc::new(Mutex::new(())),
+            coordinator_rpc,
+            coordinator_client: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -144,7 +180,26 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         let prover = self.network.init(&self.signer).await?;
         info!("prover address: {}", prover);
 
+        // Resolve this fulfiller's build identity once and report it to the
+        // network at startup, then on a low-frequency interval inside the main
+        // loop below. Best-effort: a failure here never blocks fulfillment.
+        let build_identity = prover_info::BuildIdentity::resolve();
+        info!(
+            version = %build_identity.version,
+            git_sha = %build_identity.git_sha,
+            image_tag = %build_identity.image_tag,
+            "fulfiller build identity",
+        );
+        self.spawn_report_prover_info(prover, build_identity.clone());
+        let mut last_prover_info_report = std::time::Instant::now();
+        let report_interval = Duration::from_secs(prover_info::REPORT_INTERVAL_SECS);
+
         loop {
+            // Re-report build identity on a low-frequency interval (best-effort).
+            if last_prover_info_report.elapsed() >= report_interval {
+                self.spawn_report_prover_info(prover, build_identity.clone());
+                last_prover_info_report = std::time::Instant::now();
+            }
             // Check for requests to submit.
             if let Err(e) = self.submit_requests().await {
                 error!("submitting requests: {:?}", e);
@@ -167,6 +222,57 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             }
             // Wait for the next interval.
             sleep(self.refresh_interval).await;
+        }
+    }
+
+    /// Spawns [`Self::report_prover_info`] as a detached background task so this
+    /// best-effort telemetry can never block the fulfiller's startup or its
+    /// submit/fail/cancel/schedule loop — even though the report itself uses
+    /// bounded timeouts. Fire-and-forget: failures are logged inside the task.
+    /// Skipped when fulfillment is disabled (dry-run).
+    fn spawn_report_prover_info(
+        self: &Arc<Self>,
+        prover: Address,
+        identity: prover_info::BuildIdentity,
+    ) {
+        if self.disable_fulfillment {
+            return;
+        }
+        let this = self.clone();
+        tokio::spawn(async move {
+            this.report_prover_info(prover, &identity).await;
+        });
+    }
+
+    /// Reports cluster build identity to the network (best-effort).
+    ///
+    /// Assembles the full component list — `[fulfiller self] ++ coordinator
+    /// manifest (coordinator + workers)` — and sends it in ONE `ReportProverInfo`
+    /// request. If no coordinator client is configured, or the coordinator call
+    /// fails (unreachable / `Unimplemented` / timeout / etc.), the fulfiller
+    /// degrades to reporting only its own component.
+    ///
+    /// On error, logs a warning and returns — this telemetry must never fail the
+    /// fulfiller. `ReportProverInfo` carries no nonce, so unlike fulfill/fail it
+    /// needs no `nonce_lock` serialization.
+    async fn report_prover_info(&self, prover: Address, identity: &prover_info::BuildIdentity) {
+        // Best-effort: collect the coordinator manifest, (re)connecting lazily when
+        // a coordinator is configured. Any failure (unset / unreachable /
+        // Unimplemented / timeout) degrades to a fulfiller-only report.
+        let cluster_components = coordinator_client::collect_cluster_components(
+            &self.coordinator_rpc,
+            &self.coordinator_client,
+        )
+        .await;
+
+        let components = assemble_components(identity, cluster_components);
+
+        if let Err(e) = self
+            .network
+            .report_prover_info(self.domain.as_slice(), prover, components, &self.signer)
+            .await
+        {
+            warn!("failed to report prover info (continuing): {:?}", e);
         }
     }
 
@@ -774,7 +880,8 @@ pub fn extract_artifact_name(s3_url: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_cancel, should_cancel_on_network};
+    use super::*;
+    use sp1_cluster_common::proto::ClusterComponentInfo;
 
     /// `should_cancel` skips exactly one case: a fulfilled request that is not
     /// in the cluster's in-flight set (a no-op cancel). All other combinations
@@ -810,5 +917,74 @@ mod tests {
                 !is_unfulfillable
             );
         }
+    }
+
+    fn fulfiller_identity() -> prover_info::BuildIdentity {
+        prover_info::BuildIdentity {
+            version: "2.5.0".to_string(),
+            git_sha: "fulfillersha".to_string(),
+            image_tag: "base-fulfillersha".to_string(),
+        }
+    }
+
+    #[test]
+    fn assemble_components_fulfiller_only_when_no_coordinator() {
+        // Empty cluster manifest => fulfiller-only: just the fulfiller's own component.
+        let components = assemble_components(&fulfiller_identity(), Vec::new());
+
+        assert_eq!(components.len(), 1, "fulfiller-only when no manifest");
+        assert_eq!(components[0].component, "fulfiller");
+        assert_eq!(components[0].instance_id, "");
+        assert_eq!(components[0].git_sha, "fulfillersha");
+    }
+
+    #[test]
+    fn assemble_components_includes_fulfiller_coordinator_and_workers() {
+        // Coordinator manifest: coordinator + one gpu worker + one cpu worker.
+        let cluster = vec![
+            ClusterComponentInfo {
+                component: "coordinator".to_string(),
+                instance_id: "".to_string(),
+                version: "2.5.0".to_string(),
+                git_sha: "coordsha".to_string(),
+                image_tag: "base-coordsha".to_string(),
+            },
+            ClusterComponentInfo {
+                component: "gpu-node".to_string(),
+                instance_id: "gpu1".to_string(),
+                version: "2.5.0".to_string(),
+                git_sha: "gpusha".to_string(),
+                image_tag: "node-gpu-gpusha".to_string(),
+            },
+            ClusterComponentInfo {
+                component: "cpu-node".to_string(),
+                instance_id: "cpu1".to_string(),
+                version: "2.5.0".to_string(),
+                git_sha: "cpusha".to_string(),
+                image_tag: "base-cpusha".to_string(),
+            },
+        ];
+
+        let components = assemble_components(&fulfiller_identity(), cluster);
+
+        // fulfiller + coordinator + 2 workers.
+        assert_eq!(components.len(), 4);
+        // Fulfiller must be first.
+        assert_eq!(components[0].component, "fulfiller");
+        assert_eq!(components[0].git_sha, "fulfillersha");
+        // Coordinator + worker entries forwarded verbatim.
+        assert_eq!(components[1].component, "coordinator");
+        assert_eq!(components[1].git_sha, "coordsha");
+        let gpu = components
+            .iter()
+            .find(|c| c.instance_id == "gpu1")
+            .expect("gpu worker forwarded");
+        assert_eq!(gpu.component, "gpu-node");
+        assert_eq!(gpu.git_sha, "gpusha");
+        let cpu = components
+            .iter()
+            .find(|c| c.instance_id == "cpu1")
+            .expect("cpu worker forwarded");
+        assert_eq!(cpu.component, "cpu-node");
     }
 }

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -81,14 +81,16 @@ pub fn request_error_from_extra_data(extra_data: Option<&str>) -> Option<i32> {
 /// `(component, version, git_sha, image_tag)`, so many workers on the same build
 /// collapse to one entry while distinct builds (a rolling deploy) are kept.
 ///
-/// Returns `Err` if the manifest yields more than one `fulfiller` or `coordinator`
-/// build — those are logical singletons, and the receiver rejects such a report, so
-/// we refuse to send it rather than emit a malformed snapshot.
+/// Returns `Err` for a malformed manifest, so the caller skips the report rather than
+/// emit a bad snapshot: a configured coordinator (`Some`) must yield exactly one
+/// `coordinator` build after dedup (zero — a manifest missing its coordinator — or
+/// many are malformed), and there must never be more than one `fulfiller`.
 pub fn assemble_components(
     identity: &prover_info::BuildIdentity,
     cluster_components: Option<Vec<sp1_cluster_common::proto::ClusterComponentInfo>>,
 ) -> Result<Vec<spn_network_types::ComponentInfo>> {
     let mut components = vec![prover_info::fulfiller_component(identity)];
+    let had_manifest = cluster_components.is_some();
     if let Some(cluster) = cluster_components {
         let mut seen = HashSet::with_capacity(cluster.len());
         for c in cluster {
@@ -105,15 +107,27 @@ pub fn assemble_components(
         }
     }
 
-    // Singletons must appear at most once; distinct builds of one would be malformed.
-    for singleton in ["fulfiller", "coordinator"] {
-        let count = components
+    // The fulfiller is added exactly once; reject a manifest that injected another.
+    let fulfillers = components
+        .iter()
+        .filter(|c| c.component == "fulfiller")
+        .count();
+    if fulfillers > 1 {
+        return Err(anyhow!(
+            "manifest reported {fulfillers} fulfiller builds; refusing to send a malformed report"
+        ));
+    }
+
+    // A reached coordinator must report exactly one coordinator build after dedup;
+    // zero (manifest missing its coordinator) or many are malformed.
+    if had_manifest {
+        let coordinators = components
             .iter()
-            .filter(|c| c.component == singleton)
+            .filter(|c| c.component == "coordinator")
             .count();
-        if count > 1 {
+        if coordinators != 1 {
             return Err(anyhow!(
-                "manifest reported {count} distinct {singleton} builds; refusing to send a malformed singleton report"
+                "coordinator manifest reported {coordinators} coordinator builds (expected exactly 1); refusing to send a malformed report"
             ));
         }
     }
@@ -1024,9 +1038,10 @@ mod tests {
 
     #[test]
     fn assemble_components_collapses_same_build_workers() {
-        // Two gpu-node workers on the same build collapse to one public entry; the
-        // fulfiller is still included.
+        // Two gpu-node workers on the same build collapse to one public entry;
+        // fulfiller + coordinator are still included.
         let cluster = vec![
+            cluster_entry("coordinator", "", "coordsha"),
             cluster_entry("gpu-node", "gpu1", "samesha"),
             cluster_entry("gpu-node", "gpu2", "samesha"),
         ];
@@ -1035,8 +1050,8 @@ mod tests {
 
         assert_eq!(
             components.len(),
-            2,
-            "fulfiller + one collapsed gpu-node build"
+            3,
+            "fulfiller + coordinator + one collapsed gpu-node build"
         );
         assert_eq!(components[0].component, "fulfiller");
         let gpu = components
@@ -1050,6 +1065,7 @@ mod tests {
     fn assemble_components_keeps_distinct_builds_for_rolling_deploy() {
         // Old + new gpu-node builds during a rolling deploy: both remain.
         let cluster = vec![
+            cluster_entry("coordinator", "", "coordsha"),
             cluster_entry("gpu-node", "gpu1", "oldsha"),
             cluster_entry("gpu-node", "gpu2", "newsha"),
         ];
@@ -1079,6 +1095,21 @@ mod tests {
         assert!(
             assemble_components(&fulfiller_identity(), Some(cluster)).is_err(),
             "two distinct coordinator builds must be rejected"
+        );
+    }
+
+    #[test]
+    fn assemble_components_rejects_manifest_without_coordinator() {
+        // A reached coordinator must report itself: a Some manifest with no coordinator
+        // entry (workers-only, or empty) is malformed and must not be sent.
+        let workers_only = vec![cluster_entry("gpu-node", "gpu1", "gpusha")];
+        assert!(
+            assemble_components(&fulfiller_identity(), Some(workers_only)).is_err(),
+            "workers-only manifest (no coordinator) must be rejected"
+        );
+        assert!(
+            assemble_components(&fulfiller_identity(), Some(vec![])).is_err(),
+            "empty manifest (no coordinator) must be rejected"
         );
     }
 }

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -72,23 +72,53 @@ pub fn request_error_from_extra_data(extra_data: Option<&str>) -> Option<i32> {
     ProvingFailure::from_extra_data(s).map(|_| ProofRequestError::ProvingFailure as i32)
 }
 
-/// Assemble the full prover component list for a single `ReportProverInfo`:
-/// the fulfiller's own component first, then the coordinator manifest
-/// (coordinator + workers) mapped from the coordinator's `ClusterComponentInfo`.
-/// `cluster_components` is empty when no coordinator manifest was available, in
-/// which case the result is just the fulfiller's own component (fulfiller-only).
+/// Assemble the public component list for a single `ReportProverInfo`: the
+/// fulfiller's own component first, then the coordinator manifest (coordinator +
+/// workers) mapped onto the public `ComponentInfo` (which has no `instance_id`).
+///
+/// `cluster_components` is `None` when no coordinator is configured, giving a
+/// fulfiller-only report. Manifest entries are deduped by build identity
+/// `(component, version, git_sha, image_tag)`, so many workers on the same build
+/// collapse to one entry while distinct builds (a rolling deploy) are kept.
+///
+/// Returns `Err` if the manifest yields more than one `fulfiller` or `coordinator`
+/// build — those are logical singletons, and the receiver rejects such a report, so
+/// we refuse to send it rather than emit a malformed snapshot.
 pub fn assemble_components(
     identity: &prover_info::BuildIdentity,
-    cluster_components: Vec<sp1_cluster_common::proto::ClusterComponentInfo>,
-) -> Vec<spn_network_types::ComponentInfo> {
-    let mut components = Vec::with_capacity(1 + cluster_components.len());
-    components.push(prover_info::fulfiller_component(identity));
-    components.extend(
-        cluster_components
-            .into_iter()
-            .map(prover_info::component_from_cluster),
-    );
-    components
+    cluster_components: Option<Vec<sp1_cluster_common::proto::ClusterComponentInfo>>,
+) -> Result<Vec<spn_network_types::ComponentInfo>> {
+    let mut components = vec![prover_info::fulfiller_component(identity)];
+    if let Some(cluster) = cluster_components {
+        let mut seen = HashSet::with_capacity(cluster.len());
+        for c in cluster {
+            let mapped = prover_info::component_from_cluster(c);
+            // Dedup by build identity: collapse same-build workers to one entry.
+            if seen.insert((
+                mapped.component.clone(),
+                mapped.version.clone(),
+                mapped.git_sha.clone(),
+                mapped.image_tag.clone(),
+            )) {
+                components.push(mapped);
+            }
+        }
+    }
+
+    // Singletons must appear at most once; distinct builds of one would be malformed.
+    for singleton in ["fulfiller", "coordinator"] {
+        let count = components
+            .iter()
+            .filter(|c| c.component == singleton)
+            .count();
+        if count > 1 {
+            return Err(anyhow!(
+                "manifest reported {count} distinct {singleton} builds; refusing to send a malformed singleton report"
+            ));
+        }
+    }
+
+    Ok(components)
 }
 
 #[derive(Clone)]
@@ -246,26 +276,42 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 
     /// Reports cluster build identity to the network (best-effort).
     ///
-    /// Assembles the full component list — `[fulfiller self] ++ coordinator
-    /// manifest (coordinator + workers)` — and sends it in ONE `ReportProverInfo`
-    /// request. If no coordinator client is configured, or the coordinator call
-    /// fails (unreachable / `Unimplemented` / timeout / etc.), the fulfiller
-    /// degrades to reporting only its own component.
+    /// Sends `[fulfiller self] ++ coordinator manifest (coordinator + workers)` as a
+    /// full snapshot in ONE `ReportProverInfo`. With no coordinator configured this is
+    /// a valid fulfiller-only report. But when a coordinator IS configured and its
+    /// fetch fails (unreachable / `Unimplemented` / timeout), this report is SKIPPED:
+    /// the receiver treats the payload as a full snapshot, so sending fulfiller-only
+    /// would prune the coordinator/worker rows. The next tick retries.
     ///
-    /// On error, logs a warning and returns — this telemetry must never fail the
-    /// fulfiller. `ReportProverInfo` carries no nonce, so unlike fulfill/fail it
-    /// needs no `nonce_lock` serialization.
+    /// On any error, logs a warning and returns — this telemetry never fails the
+    /// fulfiller. `ReportProverInfo` carries no nonce, so unlike fulfill/fail it needs
+    /// no `nonce_lock` serialization.
     async fn report_prover_info(&self, prover: Address, identity: &prover_info::BuildIdentity) {
-        // Best-effort: collect the coordinator manifest, (re)connecting lazily when
-        // a coordinator is configured. Any failure (unset / unreachable /
-        // Unimplemented / timeout) degrades to a fulfiller-only report.
-        let cluster_components = coordinator_client::collect_cluster_components(
+        // Collect the manifest, (re)connecting lazily when a coordinator is configured.
+        // Ok(None) = unset (fulfiller-only is valid); Err = configured fetch failed.
+        let cluster_components = match coordinator_client::collect_cluster_components(
             &self.coordinator_rpc,
             &self.coordinator_client,
         )
-        .await;
+        .await
+        {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                warn!(
+                    "coordinator manifest fetch failed; skipping this report to avoid pruning \
+                     coordinator/worker rows (retrying next tick): {e:?}"
+                );
+                return;
+            }
+        };
 
-        let components = assemble_components(identity, cluster_components);
+        let components = match assemble_components(identity, cluster_components) {
+            Ok(components) => components,
+            Err(e) => {
+                warn!("refusing to send malformed prover-info report (retrying next tick): {e:?}");
+                return;
+            }
+        };
 
         if let Err(e) = self
             .network
@@ -927,64 +973,112 @@ mod tests {
         }
     }
 
+    /// Build a cluster manifest entry. `instance_id` is set but is dropped at the
+    /// public boundary; distinct workers on the same build share a build identity.
+    fn cluster_entry(component: &str, instance_id: &str, git_sha: &str) -> ClusterComponentInfo {
+        ClusterComponentInfo {
+            component: component.to_string(),
+            instance_id: instance_id.to_string(),
+            version: "2.5.0".to_string(),
+            git_sha: git_sha.to_string(),
+            image_tag: format!("{component}-{git_sha}"),
+        }
+    }
+
     #[test]
     fn assemble_components_fulfiller_only_when_no_coordinator() {
-        // Empty cluster manifest => fulfiller-only: just the fulfiller's own component.
-        let components = assemble_components(&fulfiller_identity(), Vec::new());
+        // No coordinator manifest => fulfiller-only.
+        let components = assemble_components(&fulfiller_identity(), None).unwrap();
 
         assert_eq!(components.len(), 1, "fulfiller-only when no manifest");
         assert_eq!(components[0].component, "fulfiller");
-        assert_eq!(components[0].instance_id, "");
         assert_eq!(components[0].git_sha, "fulfillersha");
     }
 
     #[test]
     fn assemble_components_includes_fulfiller_coordinator_and_workers() {
-        // Coordinator manifest: coordinator + one gpu worker + one cpu worker.
         let cluster = vec![
-            ClusterComponentInfo {
-                component: "coordinator".to_string(),
-                instance_id: "".to_string(),
-                version: "2.5.0".to_string(),
-                git_sha: "coordsha".to_string(),
-                image_tag: "base-coordsha".to_string(),
-            },
-            ClusterComponentInfo {
-                component: "gpu-node".to_string(),
-                instance_id: "gpu1".to_string(),
-                version: "2.5.0".to_string(),
-                git_sha: "gpusha".to_string(),
-                image_tag: "node-gpu-gpusha".to_string(),
-            },
-            ClusterComponentInfo {
-                component: "cpu-node".to_string(),
-                instance_id: "cpu1".to_string(),
-                version: "2.5.0".to_string(),
-                git_sha: "cpusha".to_string(),
-                image_tag: "base-cpusha".to_string(),
-            },
+            cluster_entry("coordinator", "", "coordsha"),
+            cluster_entry("gpu-node", "gpu1", "gpusha"),
+            cluster_entry("cpu-node", "cpu1", "cpusha"),
         ];
 
-        let components = assemble_components(&fulfiller_identity(), cluster);
+        let components = assemble_components(&fulfiller_identity(), Some(cluster)).unwrap();
 
         // fulfiller + coordinator + 2 workers.
         assert_eq!(components.len(), 4);
-        // Fulfiller must be first.
-        assert_eq!(components[0].component, "fulfiller");
+        assert_eq!(
+            components[0].component, "fulfiller",
+            "fulfiller must be first"
+        );
         assert_eq!(components[0].git_sha, "fulfillersha");
-        // Coordinator + worker entries forwarded verbatim.
         assert_eq!(components[1].component, "coordinator");
         assert_eq!(components[1].git_sha, "coordsha");
+        assert!(components
+            .iter()
+            .any(|c| c.component == "gpu-node" && c.git_sha == "gpusha"));
+        assert!(components
+            .iter()
+            .any(|c| c.component == "cpu-node" && c.git_sha == "cpusha"));
+    }
+
+    #[test]
+    fn assemble_components_collapses_same_build_workers() {
+        // Two gpu-node workers on the same build collapse to one public entry; the
+        // fulfiller is still included.
+        let cluster = vec![
+            cluster_entry("gpu-node", "gpu1", "samesha"),
+            cluster_entry("gpu-node", "gpu2", "samesha"),
+        ];
+
+        let components = assemble_components(&fulfiller_identity(), Some(cluster)).unwrap();
+
+        assert_eq!(
+            components.len(),
+            2,
+            "fulfiller + one collapsed gpu-node build"
+        );
+        assert_eq!(components[0].component, "fulfiller");
         let gpu = components
             .iter()
-            .find(|c| c.instance_id == "gpu1")
-            .expect("gpu worker forwarded");
-        assert_eq!(gpu.component, "gpu-node");
-        assert_eq!(gpu.git_sha, "gpusha");
-        let cpu = components
+            .filter(|c| c.component == "gpu-node")
+            .count();
+        assert_eq!(gpu, 1, "same-build gpu workers collapse to one entry");
+    }
+
+    #[test]
+    fn assemble_components_keeps_distinct_builds_for_rolling_deploy() {
+        // Old + new gpu-node builds during a rolling deploy: both remain.
+        let cluster = vec![
+            cluster_entry("gpu-node", "gpu1", "oldsha"),
+            cluster_entry("gpu-node", "gpu2", "newsha"),
+        ];
+
+        let components = assemble_components(&fulfiller_identity(), Some(cluster)).unwrap();
+
+        let builds: HashSet<_> = components
             .iter()
-            .find(|c| c.instance_id == "cpu1")
-            .expect("cpu worker forwarded");
-        assert_eq!(cpu.component, "cpu-node");
+            .filter(|c| c.component == "gpu-node")
+            .map(|c| c.git_sha.as_str())
+            .collect();
+        assert_eq!(
+            builds,
+            HashSet::from(["oldsha", "newsha"]),
+            "both builds kept"
+        );
+    }
+
+    #[test]
+    fn assemble_components_rejects_two_coordinator_builds() {
+        // Two distinct coordinator builds is malformed (singleton) => Err, not sent.
+        let cluster = vec![
+            cluster_entry("coordinator", "", "coordsha-a"),
+            cluster_entry("coordinator", "", "coordsha-b"),
+        ];
+
+        assert!(
+            assemble_components(&fulfiller_identity(), Some(cluster)).is_err(),
+            "two distinct coordinator builds must be rejected"
+        );
     }
 }

--- a/crates/fulfillment/src/network.rs
+++ b/crates/fulfillment/src/network.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use sp1_cluster_artifact::ArtifactType;
 use sp1_cluster_common::proto::ProofRequest;
 use sp1_sdk::network::signer::NetworkSigner;
+use spn_network_types::ComponentInfo;
 pub trait NetworkRequest: Send + Sync + 'static {
     fn request_id(&self) -> String;
 
@@ -118,6 +119,23 @@ pub trait FulfillmentNetwork: Send + Sync + 'static {
         request: &Self::NetworkRequest,
         signer: &NetworkSigner,
     ) -> Result<String>;
+
+    /// Report build identity for one or more cluster components to the network
+    /// (network#232 `ReportProverInfo`). The fulfiller passes its own component
+    /// plus any coordinator/worker components it could collect, in ONE request.
+    ///
+    /// Best-effort debugging telemetry: implementations must never block or fail
+    /// fulfillment on this. The default is a no-op for networks that don't
+    /// support the RPC.
+    async fn report_prover_info(
+        &self,
+        _domain: &[u8],
+        _prover: Address,
+        _components: Vec<ComponentInfo>,
+        _signer: &NetworkSigner,
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /// Whether to download proofs for fulfillment when submitting a request.
     ///

--- a/crates/fulfillment/src/network.rs
+++ b/crates/fulfillment/src/network.rs
@@ -120,22 +120,19 @@ pub trait FulfillmentNetwork: Send + Sync + 'static {
         signer: &NetworkSigner,
     ) -> Result<String>;
 
-    /// Report build identity for one or more cluster components to the network
-    /// (network#232 `ReportProverInfo`). The fulfiller passes its own component
-    /// plus any coordinator/worker components it could collect, in ONE request.
+    /// Report build identity for one or more cluster components via the public
+    /// `ReportProverInfo` contract. The fulfiller passes its own component plus
+    /// any coordinator/worker components it could collect, in ONE request.
     ///
     /// Best-effort debugging telemetry: implementations must never block or fail
-    /// fulfillment on this. The default is a no-op for networks that don't
-    /// support the RPC.
+    /// fulfillment on this.
     async fn report_prover_info(
         &self,
-        _domain: &[u8],
-        _prover: Address,
-        _components: Vec<ComponentInfo>,
-        _signer: &NetworkSigner,
-    ) -> Result<()> {
-        Ok(())
-    }
+        domain: &[u8],
+        prover: Address,
+        components: Vec<ComponentInfo>,
+        signer: &NetworkSigner,
+    ) -> Result<()>;
 
     /// Whether to download proofs for fulfillment when submitting a request.
     ///

--- a/crates/fulfillment/src/prover_info.rs
+++ b/crates/fulfillment/src/prover_info.rs
@@ -1,0 +1,156 @@
+//! Self-reported build identity for cluster prover components.
+//!
+//! Prover-component build reporting: the fulfiller reports build identity
+//! (version / git sha / image tag) to the SPN via the `ReportProverInfo` RPC
+//! (network#232). It always reports its own component (fulfiller-only) and,
+//! when a coordinator client is wired (`FULFILLER_COORDINATOR_RPC` is set),
+//! also forwards the coordinator + every connected worker it fronts
+//! (cluster-wide reporting). This is best-effort debugging telemetry — never
+//! block or fail fulfillment on it.
+
+use sp1_cluster_common::proto::ClusterComponentInfo;
+use spn_network_types::{ComponentInfo, ReportProverInfoRequestBody};
+
+/// The git commit this binary was built from. Supplied by the `VERGEN_GIT_SHA`
+/// build ARG in Docker builds; read from `.git` for local builds (see build.rs).
+pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA");
+
+/// The component name the fulfiller reports itself as. Must be in the network's
+/// component allowlist {fulfiller, coordinator, gpu-node, cpu-node}.
+pub const FULFILLER_COMPONENT: &str = "fulfiller";
+
+/// How often the fulfiller re-reports its build identity, in addition to the
+/// one-shot report at startup. Low frequency: this is static-ish telemetry.
+pub const REPORT_INTERVAL_SECS: u64 = 15 * 60;
+
+/// The fulfiller's static build identity, resolved once at startup.
+#[derive(Clone, Debug)]
+pub struct BuildIdentity {
+    /// Crate version (`CARGO_PKG_VERSION`).
+    pub version: String,
+    /// Git commit the binary was built from.
+    pub git_sha: String,
+    /// Container image tag the component is running (from the `IMAGE_TAG` env var).
+    pub image_tag: String,
+}
+
+impl BuildIdentity {
+    /// Resolve the fulfiller's build identity from compile-time and runtime sources.
+    pub fn resolve() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            git_sha: VERGEN_GIT_SHA.to_string(),
+            image_tag: std::env::var("IMAGE_TAG").unwrap_or_default(),
+        }
+    }
+}
+
+/// The fulfiller's own component entry.
+///
+/// The fulfiller is a singleton component, so its `instance_id` is always empty
+/// (the network rejects a non-empty instance_id for singleton components).
+pub fn fulfiller_component(identity: &BuildIdentity) -> ComponentInfo {
+    ComponentInfo {
+        component: FULFILLER_COMPONENT.to_string(),
+        instance_id: String::new(),
+        version: identity.version.clone(),
+        git_sha: identity.git_sha.clone(),
+        image_tag: identity.image_tag.clone(),
+    }
+}
+
+/// Map a coordinator-reported `ClusterComponentInfo` (sp1#2850) onto the network
+/// `ComponentInfo`. The two messages have identical field layout and semantics —
+/// component name, instance id, version, git sha, image tag — so this is a direct
+/// 1:1 forward with no remapping.
+pub fn component_from_cluster(c: ClusterComponentInfo) -> ComponentInfo {
+    ComponentInfo {
+        component: c.component,
+        instance_id: c.instance_id,
+        version: c.version,
+        git_sha: c.git_sha,
+        image_tag: c.image_tag,
+    }
+}
+
+/// Build the `ReportProverInfoRequestBody` carrying the given component list.
+///
+/// The fulfiller assembles `[fulfiller self] ++ (coordinator manifest)` and sends
+/// it in ONE request, so the SPN sees the whole prover cluster's build identity
+/// atomically. `ReportProverInfo` carries no nonce and writes no ledger tx.
+pub fn build_report_prover_info_body(
+    domain: &[u8],
+    prover: &[u8],
+    components: Vec<ComponentInfo>,
+) -> ReportProverInfoRequestBody {
+    ReportProverInfoRequestBody {
+        domain: domain.to_vec(),
+        prover: prover.to_vec(),
+        components,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fulfiller_component_is_empty_instance_singleton() {
+        let identity = BuildIdentity {
+            version: "2.5.0".to_string(),
+            git_sha: "abc1234".to_string(),
+            image_tag: "base-abc1234".to_string(),
+        };
+
+        let c = fulfiller_component(&identity);
+        assert_eq!(c.component, "fulfiller");
+        // Singleton component => instance_id must be empty (network rejects otherwise).
+        assert_eq!(c.instance_id, "");
+        assert_eq!(c.version, "2.5.0");
+        assert_eq!(c.git_sha, "abc1234");
+        assert_eq!(c.image_tag, "base-abc1234");
+    }
+
+    #[test]
+    fn build_body_carries_component_list_verbatim() {
+        let identity = BuildIdentity {
+            version: "2.5.0".to_string(),
+            git_sha: "abc1234".to_string(),
+            image_tag: "base-abc1234".to_string(),
+        };
+        let domain = [0xaau8; 32];
+        let prover = [0x11u8; 20];
+
+        let body =
+            build_report_prover_info_body(&domain, &prover, vec![fulfiller_component(&identity)]);
+
+        assert_eq!(body.domain, domain.to_vec());
+        assert_eq!(body.prover, prover.to_vec());
+        assert_eq!(body.components.len(), 1);
+        assert_eq!(body.components[0].component, "fulfiller");
+        assert_eq!(body.components[0].git_sha, "abc1234");
+    }
+
+    #[test]
+    fn component_from_cluster_is_a_direct_forward() {
+        let cluster = ClusterComponentInfo {
+            component: "gpu-node".to_string(),
+            instance_id: "worker-7".to_string(),
+            version: "2.5.0".to_string(),
+            git_sha: "gpusha".to_string(),
+            image_tag: "node-gpu-gpusha".to_string(),
+        };
+        let c = component_from_cluster(cluster);
+        assert_eq!(c.component, "gpu-node");
+        assert_eq!(c.instance_id, "worker-7");
+        assert_eq!(c.version, "2.5.0");
+        assert_eq!(c.git_sha, "gpusha");
+        assert_eq!(c.image_tag, "node-gpu-gpusha");
+    }
+
+    #[test]
+    fn resolve_uses_cargo_pkg_version() {
+        let identity = BuildIdentity::resolve();
+        assert_eq!(identity.version, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/crates/fulfillment/src/prover_info.rs
+++ b/crates/fulfillment/src/prover_info.rs
@@ -57,9 +57,8 @@ pub fn fulfiller_component(identity: &BuildIdentity) -> ComponentInfo {
 }
 
 /// Map a coordinator-reported `ClusterComponentInfo` (sp1#2850) onto the public
-/// network `ComponentInfo`. The cluster-internal message keeps `instance_id` for the
-/// coordinator's per-worker registry, but the public report is keyed by build
-/// identity (network#234), so `instance_id` is dropped at this boundary.
+/// network `ComponentInfo`. Both are keyed by build identity (component +
+/// version/git_sha/image_tag), so this is a straight field copy.
 pub fn component_from_cluster(c: ClusterComponentInfo) -> ComponentInfo {
     ComponentInfo {
         component: c.component,
@@ -126,12 +125,9 @@ mod tests {
     }
 
     #[test]
-    fn component_from_cluster_drops_instance_id() {
-        // The cluster-internal entry carries an instance_id (worker-7); the public
-        // ComponentInfo has no such field, so it is dropped in the mapping.
+    fn component_from_cluster_copies_build_fields() {
         let cluster = ClusterComponentInfo {
             component: "gpu-node".to_string(),
-            instance_id: "worker-7".to_string(),
             version: "2.5.0".to_string(),
             git_sha: "gpusha".to_string(),
             image_tag: "node-gpu-gpusha".to_string(),

--- a/crates/fulfillment/src/prover_info.rs
+++ b/crates/fulfillment/src/prover_info.rs
@@ -1,8 +1,8 @@
 //! Self-reported build identity for cluster prover components.
 //!
 //! Prover-component build reporting: the fulfiller reports build identity
-//! (version / git sha / image tag) to the SPN via the `ReportProverInfo` RPC
-//! (network#232). It always reports its own component (fulfiller-only) and,
+//! (version / git sha / image tag) to the SPN via the public `ReportProverInfo`
+//! contract. It always reports its own component (fulfiller-only) and,
 //! when a coordinator client is wired (`FULFILLER_COORDINATOR_RPC` is set),
 //! also forwards the coordinator + every connected worker it fronts
 //! (cluster-wide reporting). This is best-effort debugging telemetry — never
@@ -56,7 +56,7 @@ pub fn fulfiller_component(identity: &BuildIdentity) -> ComponentInfo {
     }
 }
 
-/// Map a coordinator-reported `ClusterComponentInfo` (sp1#2850) onto the public
+/// Map a coordinator-reported SP1 v6.3.1 `ClusterComponentInfo` onto the public
 /// network `ComponentInfo`. Both are keyed by build identity (component +
 /// version/git_sha/image_tag), so this is a straight field copy.
 pub fn component_from_cluster(c: ClusterComponentInfo) -> ComponentInfo {
@@ -90,21 +90,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fulfiller_component_has_build_fields() {
-        let identity = BuildIdentity {
-            version: "2.5.0".to_string(),
-            git_sha: "abc1234".to_string(),
-            image_tag: "base-abc1234".to_string(),
-        };
-
-        let c = fulfiller_component(&identity);
-        assert_eq!(c.component, "fulfiller");
-        assert_eq!(c.version, "2.5.0");
-        assert_eq!(c.git_sha, "abc1234");
-        assert_eq!(c.image_tag, "base-abc1234");
-    }
-
-    #[test]
     fn build_body_carries_component_list_verbatim() {
         let identity = BuildIdentity {
             version: "2.5.0".to_string(),
@@ -122,26 +107,5 @@ mod tests {
         assert_eq!(body.components.len(), 1);
         assert_eq!(body.components[0].component, "fulfiller");
         assert_eq!(body.components[0].git_sha, "abc1234");
-    }
-
-    #[test]
-    fn component_from_cluster_copies_build_fields() {
-        let cluster = ClusterComponentInfo {
-            component: "gpu-node".to_string(),
-            version: "2.5.0".to_string(),
-            git_sha: "gpusha".to_string(),
-            image_tag: "node-gpu-gpusha".to_string(),
-        };
-        let c = component_from_cluster(cluster);
-        assert_eq!(c.component, "gpu-node");
-        assert_eq!(c.version, "2.5.0");
-        assert_eq!(c.git_sha, "gpusha");
-        assert_eq!(c.image_tag, "node-gpu-gpusha");
-    }
-
-    #[test]
-    fn resolve_uses_cargo_pkg_version() {
-        let identity = BuildIdentity::resolve();
-        assert_eq!(identity.version, env!("CARGO_PKG_VERSION"));
     }
 }

--- a/crates/fulfillment/src/prover_info.rs
+++ b/crates/fulfillment/src/prover_info.rs
@@ -45,28 +45,24 @@ impl BuildIdentity {
     }
 }
 
-/// The fulfiller's own component entry.
-///
-/// The fulfiller is a singleton component, so its `instance_id` is always empty
-/// (the network rejects a non-empty instance_id for singleton components).
+/// The fulfiller's own component entry. The fulfiller is a logical singleton, so a
+/// report includes exactly one.
 pub fn fulfiller_component(identity: &BuildIdentity) -> ComponentInfo {
     ComponentInfo {
         component: FULFILLER_COMPONENT.to_string(),
-        instance_id: String::new(),
         version: identity.version.clone(),
         git_sha: identity.git_sha.clone(),
         image_tag: identity.image_tag.clone(),
     }
 }
 
-/// Map a coordinator-reported `ClusterComponentInfo` (sp1#2850) onto the network
-/// `ComponentInfo`. The two messages have identical field layout and semantics —
-/// component name, instance id, version, git sha, image tag — so this is a direct
-/// 1:1 forward with no remapping.
+/// Map a coordinator-reported `ClusterComponentInfo` (sp1#2850) onto the public
+/// network `ComponentInfo`. The cluster-internal message keeps `instance_id` for the
+/// coordinator's per-worker registry, but the public report is keyed by build
+/// identity (network#234), so `instance_id` is dropped at this boundary.
 pub fn component_from_cluster(c: ClusterComponentInfo) -> ComponentInfo {
     ComponentInfo {
         component: c.component,
-        instance_id: c.instance_id,
         version: c.version,
         git_sha: c.git_sha,
         image_tag: c.image_tag,
@@ -95,7 +91,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fulfiller_component_is_empty_instance_singleton() {
+    fn fulfiller_component_has_build_fields() {
         let identity = BuildIdentity {
             version: "2.5.0".to_string(),
             git_sha: "abc1234".to_string(),
@@ -104,8 +100,6 @@ mod tests {
 
         let c = fulfiller_component(&identity);
         assert_eq!(c.component, "fulfiller");
-        // Singleton component => instance_id must be empty (network rejects otherwise).
-        assert_eq!(c.instance_id, "");
         assert_eq!(c.version, "2.5.0");
         assert_eq!(c.git_sha, "abc1234");
         assert_eq!(c.image_tag, "base-abc1234");
@@ -132,7 +126,9 @@ mod tests {
     }
 
     #[test]
-    fn component_from_cluster_is_a_direct_forward() {
+    fn component_from_cluster_drops_instance_id() {
+        // The cluster-internal entry carries an instance_id (worker-7); the public
+        // ComponentInfo has no such field, so it is dropped in the mapping.
         let cluster = ClusterComponentInfo {
             component: "gpu-node".to_string(),
             instance_id: "worker-7".to_string(),
@@ -142,7 +138,6 @@ mod tests {
         };
         let c = component_from_cluster(cluster);
         assert_eq!(c.component, "gpu-node");
-        assert_eq!(c.instance_id, "worker-7");
         assert_eq!(c.version, "2.5.0");
         assert_eq!(c.git_sha, "gpusha");
         assert_eq!(c.image_tag, "node-gpu-gpusha");

--- a/crates/fulfillment/src/run.rs
+++ b/crates/fulfillment/src/run.rs
@@ -32,6 +32,19 @@ pub async fn run_fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentN
         .await
         .expect("failed to connect to cluster");
 
+    // Coordinator address for cluster-wide build-identity aggregation. The client
+    // is connected lazily (and bounded) by the background report task, not here:
+    // a coordinator that is down at startup must not permanently disable
+    // cluster-wide reporting, and startup must never block on it. Unset =>
+    // fulfiller-only reporting.
+    match &settings.coordinator_rpc {
+        Some(addr) => info!(
+            "FULFILLER_COORDINATOR_RPC={addr}; cluster-wide component reporting enabled \
+             (coordinator connected lazily by the report task)"
+        ),
+        None => info!("FULFILLER_COORDINATOR_RPC unset; reporting fulfiller component only"),
+    }
+
     // Initialize the metrics server.
     // let version_info = get_version!();
     let version_info = VersionInfo {
@@ -97,6 +110,7 @@ pub async fn run_fulfiller<A: ArtifactClient + CompressedUpload, N: FulfillmentN
         settings.request_probability,
         settings.name.clone(),
         settings.refresh_interval_sec,
+        settings.coordinator_rpc.clone(),
     );
     let fulfiller = Arc::new(fulfiller);
 

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -80,7 +80,7 @@ impl WorkerServiceClient {
             worker_id: self.worker_id.clone(),
             worker_type: self.worker_type as i32,
             max_weight: get_max_weight() as u32,
-            // Self-reported build identity (sp1#2850). The coordinator stores
+            // Self-reported build identity. The coordinator stores
             // these and exposes them via GetClusterComponentInfo so the fulfiller
             // can forward them to the SPN. Re-sent on every Open, so a reconnect
             // after an upgrade refreshes the coordinator's view.

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -80,6 +80,13 @@ impl WorkerServiceClient {
             worker_id: self.worker_id.clone(),
             worker_type: self.worker_type as i32,
             max_weight: get_max_weight() as u32,
+            // Self-reported build identity (sp1#2850). The coordinator stores
+            // these and exposes them via GetClusterComponentInfo so the fulfiller
+            // can forward them to the SPN. Re-sent on every Open, so a reconnect
+            // after an upgrade refreshes the coordinator's view.
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            git_sha: crate::VERGEN_GIT_SHA.to_string(),
+            image_tag: std::env::var("IMAGE_TAG").unwrap_or_default(),
         };
         let response = backoff_retry(retry::infinite(), || {
             let mut client = self.client.clone();

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -113,6 +113,13 @@ RUN apt-get update -y && \
 
 WORKDIR /app
 
+# Immutable image tag (e.g. base-<short_sha>), promoted to a runtime env var so
+# the fulfiller can self-report which container image it is running via the
+# network ReportProverInfo RPC. Runtime stages don't inherit build-stage ENVs,
+# so this ARG/ENV must be declared here.
+ARG IMAGE_TAG=""
+ENV IMAGE_TAG=$IMAGE_TAG
+
 # Create a non-root user and group for better security
 RUN groupadd --gid 1001 appgroup && \
     useradd --uid 1001 --gid appgroup --shell /bin/false --create-home appuser

--- a/infra/Dockerfile.node_gpu
+++ b/infra/Dockerfile.node_gpu
@@ -119,6 +119,14 @@ RUN \
 
 WORKDIR /app
 
+# Immutable image tag (e.g. node-gpu-<short_sha>), promoted to a runtime env var
+# so the GPU worker can self-report which container image it is running via the
+# OpenRequest build fields (forwarded by the coordinator's GetClusterComponentInfo).
+# Runtime stages don't inherit build-stage ENVs, so this ARG/ENV must be declared
+# here. Mirrors the base infra/Dockerfile IMAGE_TAG wiring.
+ARG IMAGE_TAG=""
+ENV IMAGE_TAG=$IMAGE_TAG
+
 # Create a non-root user and group for better security
 RUN groupadd --gid 1001 appgroup && \
   useradd --uid 1001 --gid appgroup --shell /bin/false --create-home appuser

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -177,6 +177,10 @@ fulfiller:
   enabled: false
   extraEnv:
     FULFILLER_CLUSTER_RPC: http://coordinator-grpc:50051
+    # Optional: coordinator WorkerService endpoint, so the fulfiller forwards the
+    # coordinator + worker build identities to the SPN (cluster-wide reporting).
+    # Unset => the fulfiller reports only its own component (fulfiller-only).
+    FULFILLER_COORDINATOR_RPC: http://coordinator-grpc:50051
     FULFILLER_LOG_FORMAT: Pretty
     FULFILLER_CLUSTER_ARTIFACT_STORE: redis
     # Ensure these five env vars are set correctly.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -186,6 +186,10 @@ services:
     image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - FULFILLER_CLUSTER_RPC=http://api:50051
+      # Optional: coordinator WorkerService endpoint, so the fulfiller forwards the
+      # coordinator + worker build identities to the SPN (cluster-wide reporting).
+      # Unset => the fulfiller reports only its own component (fulfiller-only).
+      - FULFILLER_COORDINATOR_RPC=http://coordinator:50051
       - FULFILLER_LOG_FORMAT=Pretty
       - FULFILLER_CLUSTER_ARTIFACT_STORE=redis
       - FULFILLER_VERSION=sp1-v6.1.0


### PR DESCRIPTION
## Summary

Report prover component build identity (version, git sha, image tag) to the network so we can see what each connected prover is running.

## What changed

- Workers send `version`/`git_sha`/`image_tag` on `OpenRequest`.
- Coordinator keeps those in its worker registry (refreshed on reconnect) and serves them — plus its own build — via `GetClusterComponentInfo`.
- Fulfiller fetches that manifest, maps it onto the public `ComponentInfo` (build-keyed, no `instance_id`; succinctlabs/network#234), adds its own component, signs one `ReportProverInfo`, and sends it.
- The public report is a full snapshot deduped by build identity `(component, version, git_sha, image_tag)`: many workers on the same build collapse to one entry, while distinct builds (rolling deploy) are kept. `fulfiller`/`coordinator` are logical singletons.
- `IMAGE_TAG` is promoted to a runtime env in the base/node-gpu images. CI passes the immutable build tag (`base-<sha>` / `node-gpu-<sha>`), which is what gets reported — not necessarily the semver deployment tag.
- `FULFILLER_COORDINATOR_RPC` added to the bundled compose/helm/.env examples.

Behavior notes:
- Best-effort; never blocks fulfillment. Coordinator client is optional and bounded (connect/fetch timeouts), (re)connected lazily so a coordinator down at startup is picked up on a later tick.
- Snapshot safety: with no coordinator configured, a fulfiller-only report is valid. But if a coordinator IS configured and its fetch fails/times out, or the returned manifest is malformed (no/duplicate coordinator build), the report is SKIPPED and retried next tick — the receiver treats the payload as a full snapshot, so sending a partial one would prune coordinator/worker rows.
- `WorkerType::All` → `gpu-node` (lossy: contract only has cpu/gpu node kinds). `Unspecified`/`None` are skipped, not reported as `cpu-node`.

## Scope

In: sp1-cluster producer wiring (worker, coordinator, fulfiller) + the dep pin + bundled deploy examples.
Out: infra rollout / image bump, network-services, SDK/UI/read path. Reports are signed by the prover key, but the component fields are self-reported telemetry, not image attestation.

## Dependency note

All temporary git-rev pins this PR carried are now gone — every dependency points at a merged/released artifact:

- **SP1 family** uses the **released** crates.io `=6.3.1` (sp1#2854; v6.3.1 GitHub release + crates.io publish complete), which includes #2855's `GetClusterComponentInfo` + `OpenRequest` build fields and the `ClusterComponentInfo` removal/renumber (drops `instance_id`, build fields renumbered to 1..4). No git-rev pin.
- **`spn-*`** point at the **merged** succinctlabs/network#234 commit on `main` (`f652c93`) — `ComponentInfo` with `instance_id` removed and build fields renumbered to 1..4. Network crates aren't published to crates.io, so these stay git deps.
- **network-services#1207** (the receiver: `ReportProverInfo` handler + `prover_component_current`/`history` schema) is **merged** and validated live on Sepolia.

- `ClusterComponentInfo` is build-keyed (`component` + `version`/`git_sha`/`image_tag`) with no `instance_id`; the coordinator still tracks workers by `OpenRequest.worker_id` internally.

## Validation — Sepolia shakedown PASSED

Validated end-to-end on Sepolia (running the released sp1 `=6.3.1` crates + merged network#234), then re-hibernated:
- `ReportProverInfo` produced `prover_component_current`/`history` rows for **fulfiller + coordinator + cpu-node + gpu-node**.
- A periodic re-report refreshed `last_reported_at` **without** growing history (first-seen only).
- A coordinator-fetch failure **skipped** the report rather than sending a partial — **no partial-snapshot prune**.
- The network-services#1207 receiver (live on Sepolia) accepted the reports.
- Sepolia was re-hibernated (infra#2047) and verified fully spun down.

**Follow-up (not a blocker for this PR):** incorporate #146 into the `sp1-cluster-private` overlay so the production coordinator/rpc carry it, then roll out via infra with `FULFILLER_COORDINATOR_RPC` set on the hosted fulfiller.

## Backlog

- Bidder build reporting remains backlog until there is a fulfiller↔bidder info path; once it exists, the bidder's build can be added to the report and `bidder` added to the receiver allowlist.

## Checks

- `cargo check --release -p sp1-cluster-fulfillment -p sp1-cluster-fulfiller -p sp1-cluster-coordinator`
- `cargo test --release -p sp1-cluster-fulfillment -p sp1-cluster-coordinator` (coordinator 34 + fulfillment 12 pass)
- `cargo clippy --release -p sp1-cluster-fulfillment -p sp1-cluster-fulfiller -p sp1-cluster-coordinator --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`
- `git diff --check`
