### PR TITLE
chore: bump version to v2.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-artifact"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-bidder"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy",
  "alloy-signer-local",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-common"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "backoff",
  "chrono",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfiller"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8349,7 +8349,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfillment"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8376,7 +8376,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-network-gateway"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8445,7 +8445,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-utils"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "eyre",
  "sp1-cluster-artifact",
@@ -8458,7 +8458,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-worker"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -9465,7 +9465,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-test-cluster"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
     "crates/worker",
 ]
 [workspace.package]
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 repository = "https://github.com/succinctlabs/sp1-cluster"
 keywords = []

--- a/infra/charts/bidder/values.yaml
+++ b/infra/charts/bidder/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/succinctlabs/sp1-cluster
   pullPolicy: IfNotPresent
-  tag: base-v2.5.1
+  tag: base-v2.5.2
 
 extraEnv: {}
 

--- a/infra/charts/fulfiller/values.yaml
+++ b/infra/charts/fulfiller/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/succinctlabs/sp1-cluster
   pullPolicy: IfNotPresent
-  tag: base-v2.5.1
+  tag: base-v2.5.2
 
 extraEnv: {}
 

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -77,7 +77,7 @@ cpu-node:
       cpu: 8
       memory: 96Gi
   image:
-    tag: "base-v2.5.1"
+    tag: "base-v2.5.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-GPU machine with a powerful CPU.
@@ -127,7 +127,7 @@ api:
           key: DATABASE_URL
   replicaCount: 1
   image:
-    tag: "base-v2.5.1"
+    tag: "base-v2.5.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -142,7 +142,7 @@ coordinator:
     COORDINATOR_METRICS_ADDR: 0.0.0.0:9090
     COORDINATOR_ADDR: 0.0.0.0:50051
   image:
-    tag: "base-v2.5.1"
+    tag: "base-v2.5.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -194,7 +194,7 @@ fulfiller:
           name: cluster-secrets
           key: PRIVATE_KEY
   image:
-    tag: "base-v2.5.1"
+    tag: "base-v2.5.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -227,7 +227,7 @@ network-gateway:
     # GATEWAY_AUTH_MODE: verify
     # GATEWAY_AUTH_ALLOWLIST: 0xabc...,0xdef...
   image:
-    tag: "base-v2.5.1"
+    tag: "base-v2.5.2"
   imagePullSecrets:
     - name: ghcr-secret
   # nodeSelector: {}
@@ -252,7 +252,7 @@ bidder:
     BIDDER_MAX_CONCURRENT_PROOFS: 1
     BIDDER_BID_AMOUNT: 1
   image:
-    tag: "base-v2.5.1"
+    tag: "base-v2.5.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   # API Service
   api:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - API_GRPC_ADDR=0.0.0.0:50051
       - API_HTTP_ADDR=0.0.0.0:3000
@@ -45,7 +45,7 @@ services:
 
   # Coordinator Service
   coordinator:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - COORDINATOR_CLUSTER_RPC=http://api:50051
       - COORDINATOR_METRICS_ADDR=0.0.0.0:9090
@@ -59,7 +59,7 @@ services:
 
   # CPU Node
   cpu-node:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
       # Concurrency budget: GiB of RAM dedicated to THIS worker, not the host total.
@@ -89,7 +89,7 @@ services:
 
   # CPU Node
   mixed:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
       # See cpu-node: GiB dedicated to this worker, at most the 96G limit below.
@@ -183,7 +183,7 @@ services:
   # Fulfiller Service
   # DOMAIN: set to SPN_MAINNET_V1_DOMAIN for mainnet, defaults to SPN_SEPOLIA_V1_DOMAIN
   fulfiller:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - FULFILLER_CLUSTER_RPC=http://api:50051
       - FULFILLER_LOG_FORMAT=Pretty
@@ -205,7 +205,7 @@ services:
   # why the default points at 127.0.0.1:8081 (same host as compose). For
   # remote SDK callers, override it to your public hostname.
   network-gateway:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     profiles: ["gateway"]
     environment:
       - GATEWAY_GRPC_ADDR=0.0.0.0:50061
@@ -226,7 +226,7 @@ services:
 
   # Bidder Service
   bidder:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.5.2
     environment:
       - BIDDER_LOG_FORMAT=Pretty
       - BIDDER_VERSION=sp1-v6.1.0


### PR DESCRIPTION
Cut v2.5.2 so succinctlabs/sp1-cluster-private#129 can depend on a tag that includes #140 (`abort cluster proof for already-fulfilled requests`, merged at a65f372).

Mirrors the v2.5.1 bump (89aa2b4): workspace version 2.5.1→2.5.2, Cargo.lock workspace-member versions, and `base-v2.5.1`→`base-v2.5.2` image tags in infra charts/compose. No code changes.

**After merge:** tag the merged commit `v2.5.2`, then sp1-cluster-private#129 bumps its sp1-cluster deps v2.4.1→v2.5.2.