### PR TITLE
refactor(fulfillment): route cancels via CancelableKind enum

### DIFF
--- a/bin/fulfiller/src/mainnet.rs
+++ b/bin/fulfiller/src/mainnet.rs
@@ -6,7 +6,7 @@ use prost::Message;
 use sp1_cluster_artifact::ArtifactType;
 use sp1_cluster_common::proto::ProofRequest;
 use sp1_cluster_fulfillment::{
-    network::{FulfillmentNetwork, NetworkRequest},
+    network::{CancelableKind, FulfillmentNetwork, NetworkRequest},
     prover_info::build_report_prover_info_body,
     request_error_from_extra_data,
 };
@@ -237,12 +237,14 @@ impl FulfillmentNetwork for MainnetFulfiller {
         fulfiller_addresses: Vec<Vec<u8>>,
         minimum_deadline: u64,
         limit: u32,
-    ) -> Result<Vec<Self::NetworkRequest>> {
+    ) -> Result<Vec<(Self::NetworkRequest, CancelableKind)>> {
         // Two terminal shapes the network writes for an assigned request:
         //   1. `Assigned + Unexecutable`     — oracle reported an exec failure; the
         //                                      cluster still owes a `fail_fulfillment`.
         //   2. `Unfulfillable` (any exec)    — network already flipped it terminal
         //                                      (e.g. gas-limit, validation failure).
+        // Mainnet never produces `CancelableKind::Fulfilled` candidates: fulfillers
+        // are paid per fulfillment, so a fulfilled request is never ours to abort.
         let queries: Vec<_> = fulfiller_addresses
             .into_iter()
             .flat_map(|address| {
@@ -265,13 +267,21 @@ impl FulfillmentNetwork for MainnetFulfiller {
                     limit: Some(limit),
                     ..Default::default()
                 };
-                [assigned, unfulfillable]
+                [
+                    (assigned, CancelableKind::Unexecutable),
+                    (unfulfillable, CancelableKind::Unfulfillable),
+                ]
             })
             .collect();
 
-        let responses = join_all(queries.into_iter().map(|request| {
+        let responses = join_all(queries.into_iter().map(|(request, kind)| {
             let mut network = self.network.clone();
-            async move { network.get_filtered_proof_requests(request).await }
+            async move {
+                network
+                    .get_filtered_proof_requests(request)
+                    .await
+                    .map(|response| (response, kind))
+            }
         }))
         .await;
 
@@ -279,15 +289,15 @@ impl FulfillmentNetwork for MainnetFulfiller {
         let mut seen = std::collections::HashSet::new();
         let mut requests = Vec::new();
         for response in responses {
-            let response = response?;
+            let (response, kind) = response?;
             for request in response.into_inner().requests {
                 if seen.insert(request.request_id.clone()) {
-                    requests.push(request);
+                    requests.push((NetworkProofRequest(request), kind));
                 }
             }
         }
 
-        Ok(requests.into_iter().map(NetworkProofRequest).collect())
+        Ok(requests)
     }
 
     async fn download_artifact(
@@ -368,14 +378,6 @@ pub struct NetworkProofRequest(pub spn_network_types::ProofRequest);
 impl NetworkRequest for NetworkProofRequest {
     fn request_id(&self) -> String {
         hex::encode(&self.0.request_id)
-    }
-
-    fn is_unfulfillable(&self) -> bool {
-        self.0.fulfillment_status == spn_network_types::FulfillmentStatus::Unfulfillable as i32
-    }
-
-    fn is_fulfilled(&self) -> bool {
-        self.0.fulfillment_status == spn_network_types::FulfillmentStatus::Fulfilled as i32
     }
 
     fn program_uri(&self) -> &str {

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -36,28 +36,6 @@ const VK_MISMATCH_STRINGS: &[&str] = &[
     "vk hash from syscall does not match vkey from input",
 ];
 
-/// Whether a cancelable candidate should be cancelled at all.
-///
-/// A `Fulfilled` candidate that is NOT in the cluster's in-flight set is a no-op:
-/// the network already succeeded and our cluster isn't wasting work on it, so
-/// cancelling it would only pollute `requests_cancelled`. Every other candidate
-/// (unexecutable, unfulfillable, or fulfilled-while-still-in-flight) is cancelable.
-fn should_cancel(is_fulfilled: bool, in_flight: bool) -> bool {
-    !is_fulfilled || in_flight
-}
-
-/// Whether the network still expects an answer for this request, i.e. whether we
-/// should call `fail_fulfillment` (`cancel_on_network`).
-///
-/// We only release it on the network when it is neither already `Unfulfillable`
-/// nor `Fulfilled`. A `Fulfilled` request succeeded, so failing it would be wrong;
-/// an `Unfulfillable` one is already terminal, so failing it is a wasteful no-op.
-/// For non-fulfilled requests this is identical to the existing `!is_unfulfillable`
-/// gate.
-fn should_cancel_on_network(is_unfulfillable: bool, is_fulfilled: bool) -> bool {
-    !is_unfulfillable && !is_fulfilled
-}
-
 /// Derive the network's `ProofRequestError` from the worker's `extra_data`.
 /// An `ExecutionResult` with non-zero `failure_cause` means execute_only itself
 /// faulted -> `EXECUTION_FAILURE`. A `ProvingFailure` payload means a
@@ -575,36 +553,33 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         info!("found {} cancelable requests", requests.len());
 
         // Fetch the cluster's in-flight (Pending) request IDs so we can tell whether a
-        // `Fulfilled` candidate still has wasted cluster work to abort. Mirrors the
-        // listing in `schedule_requests`. Only `Fulfilled` candidates consult this set, so
-        // skip the extra cluster RPC entirely when none are present (e.g. mainnet, which
-        // never produces a `Fulfilled` cancelable).
-        let in_flight: HashSet<String> = if requests.iter().any(|r| r.is_fulfilled()) {
-            self.cluster
-                .get_proof_requests(ProofRequestListRequest {
-                    limit: Some(REQUEST_LIMIT),
-                    minimum_deadline: Some(time_now()),
-                    ..Default::default()
-                })
-                .map_err(|e| anyhow!("failed to get requests: {}", e))
-                .await?
-                .into_iter()
-                .filter(|r| r.proof_status == ProofRequestStatus::Pending as i32)
-                .map(|r| r.id)
-                .collect()
-        } else {
-            HashSet::new()
-        };
-        let in_flight = Arc::new(in_flight);
+        // `Fulfilled` candidate still has wasted cluster work to abort. Only `Fulfilled`
+        // candidates consult this set, so skip the extra cluster RPC entirely when none
+        // are present (e.g. mainnet, which never produces a `Fulfilled` cancelable).
+        let in_flight: HashSet<String> =
+            if requests.iter().any(|(_, kind)| kind.requires_in_flight()) {
+                self.cluster
+                    .get_proof_requests(ProofRequestListRequest {
+                        proof_status: vec![ProofRequestStatus::Pending.into()],
+                        limit: Some(REQUEST_LIMIT),
+                        minimum_deadline: Some(time_now()),
+                        ..Default::default()
+                    })
+                    .map_err(|e| anyhow!("failed to get requests: {}", e))
+                    .await?
+                    .into_iter()
+                    .map(|r| r.id)
+                    .collect()
+            } else {
+                HashSet::new()
+            };
 
-        let failure_tasks = requests.into_iter().filter_map(|request| {
+        let failure_tasks = requests.into_iter().filter_map(|(request, kind)| {
             let request_id = request.request_id();
-            let is_fulfilled = request.is_fulfilled();
-            let in_flight = in_flight.contains(&request_id);
 
             // Skip no-op cancels: a request the network already fulfilled that our cluster
             // is not proving has nothing to abort and no fulfillment to release.
-            if !should_cancel(is_fulfilled, in_flight) {
+            if kind.requires_in_flight() && !in_flight.contains(&request_id) {
                 debug!(
                     "skipping fulfilled request 0x{} not in cluster in-flight set",
                     request_id
@@ -615,11 +590,11 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
             let self_clone = self.clone();
             Some(tokio::spawn(async move {
                 let result = async {
-                    // Only fail on the network while it still expects one. A request the network
-                    // has already finalized (unfulfillable) treats the fail as a no-op, and a
-                    // fulfilled request succeeded — failing either would be wrong or wasteful.
-                    // The cluster unclaim runs either way.
-                    if should_cancel_on_network(request.is_unfulfillable(), is_fulfilled) {
+                    // Only fail on the network while it still expects an answer. A request
+                    // the network has already finalized (unfulfillable) treats the fail as
+                    // a no-op, and a fulfilled request succeeded — failing either would be
+                    // wrong or wasteful. The cluster unclaim runs either way.
+                    if kind.should_fail_fulfillment() {
                         self_clone.cancel_on_network(&request_id).await?;
                     }
                     self_clone.cancel_on_cluster(&request_id).await
@@ -943,39 +918,20 @@ mod tests {
     use super::*;
     use sp1_cluster_common::proto::ClusterComponentInfo;
 
-    /// `should_cancel` skips exactly one case: a fulfilled request that is not
-    /// in the cluster's in-flight set (a no-op cancel). All other combinations
-    /// are cancelable.
+    /// The full routing matrix: only `Unexecutable` owes the network a
+    /// `fail_fulfillment`, and only `Fulfilled` gates the cluster abort on the
+    /// request still being in-flight.
     #[test]
-    fn should_cancel_all_combos() {
-        // (is_fulfilled, in_flight) -> expected
-        assert!(should_cancel(false, false)); // unexecutable/unfulfillable, not in-flight
-        assert!(should_cancel(false, true)); // unexecutable/unfulfillable, in-flight
-        assert!(should_cancel(true, true)); // fulfilled while still proving -> abort
-        assert!(!should_cancel(true, false)); // fulfilled, nothing to abort -> skip
-    }
-
-    /// `should_cancel_on_network` only releases the request on the network when it
-    /// is neither already unfulfillable nor fulfilled. This generalizes the old
-    /// `!is_unfulfillable` gate: for non-fulfilled requests the result is identical.
-    #[test]
-    fn should_cancel_on_network_all_combos() {
-        // (is_unfulfillable, is_fulfilled) -> expected
-        assert!(should_cancel_on_network(false, false)); // network still expects an answer
-        assert!(!should_cancel_on_network(true, false)); // already terminal (unfulfillable)
-        assert!(!should_cancel_on_network(false, true)); // succeeded -> must not fail it
-        assert!(!should_cancel_on_network(true, true)); // both terminal -> no-op
-    }
-
-    /// For non-fulfilled requests, `should_cancel_on_network` must match the old
-    /// `!is_unfulfillable` behavior exactly.
-    #[test]
-    fn should_cancel_on_network_preserves_legacy_gate() {
-        for is_unfulfillable in [false, true] {
-            assert_eq!(
-                should_cancel_on_network(is_unfulfillable, false),
-                !is_unfulfillable
-            );
+    fn cancelable_kind_routing_matrix() {
+        use crate::network::CancelableKind::*;
+        // (kind, should_fail_fulfillment, requires_in_flight)
+        for (kind, fail, gate) in [
+            (Unexecutable, true, false),
+            (Unfulfillable, false, false),
+            (Fulfilled, false, true),
+        ] {
+            assert_eq!(kind.should_fail_fulfillment(), fail, "{kind:?}");
+            assert_eq!(kind.requires_in_flight(), gate, "{kind:?}");
         }
     }
 

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -557,7 +557,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         // candidates consult this set, so skip the extra cluster RPC entirely when none
         // are present (e.g. mainnet, which never produces a `Fulfilled` cancelable).
         let in_flight: HashSet<String> =
-            if requests.iter().any(|(_, kind)| kind.requires_in_flight()) {
+            if requests.iter().any(|(_, kind)| kind.gated_on_in_flight()) {
                 self.cluster
                     .get_proof_requests(ProofRequestListRequest {
                         proof_status: vec![ProofRequestStatus::Pending.into()],
@@ -579,7 +579,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 
             // Skip no-op cancels: a request the network already fulfilled that our cluster
             // is not proving has nothing to abort and no fulfillment to release.
-            if kind.requires_in_flight() && !in_flight.contains(&request_id) {
+            if kind.gated_on_in_flight() && !in_flight.contains(&request_id) {
                 debug!(
                     "skipping fulfilled request 0x{} not in cluster in-flight set",
                     request_id
@@ -924,14 +924,14 @@ mod tests {
     #[test]
     fn cancelable_kind_routing_matrix() {
         use crate::network::CancelableKind::*;
-        // (kind, should_fail_fulfillment, requires_in_flight)
+        // (kind, should_fail_fulfillment, gated_on_in_flight)
         for (kind, fail, gate) in [
             (Unexecutable, true, false),
             (Unfulfillable, false, false),
             (Fulfilled, false, true),
         ] {
             assert_eq!(kind.should_fail_fulfillment(), fail, "{kind:?}");
-            assert_eq!(kind.requires_in_flight(), gate, "{kind:?}");
+            assert_eq!(kind.gated_on_in_flight(), gate, "{kind:?}");
         }
     }
 

--- a/crates/fulfillment/src/network.rs
+++ b/crates/fulfillment/src/network.rs
@@ -32,7 +32,7 @@ impl CancelableKind {
 
     /// Whether cancelling is conditional on the request still being in the
     /// cluster's in-flight (Pending) set.
-    pub fn requires_in_flight(self) -> bool {
+    pub fn gated_on_in_flight(self) -> bool {
         matches!(self, Self::Fulfilled)
     }
 }

--- a/crates/fulfillment/src/network.rs
+++ b/crates/fulfillment/src/network.rs
@@ -5,18 +5,40 @@ use sp1_cluster_artifact::ArtifactType;
 use sp1_cluster_common::proto::ProofRequest;
 use sp1_sdk::network::signer::NetworkSigner;
 use spn_network_types::ComponentInfo;
+/// Why a request is cancelable. The kind is assigned by the network producer
+/// (which knows which query surfaced the request) and decides the routing in
+/// `cancel_requests`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancelableKind {
+    /// `Assigned + Unexecutable`: the network still expects an answer, so the
+    /// cluster owes a `fail_fulfillment` before aborting the proof.
+    Unexecutable,
+    /// The network already flipped the request terminal (`Unfulfillable`);
+    /// failing it again is a wasteful no-op. Cluster abort only.
+    Unfulfillable,
+    /// The network already marked the request `Fulfilled` — another path (e.g.
+    /// the SPN proxy delivering a mainnet proof) succeeded while our cluster
+    /// was still proving. Never fail a succeeded request; abort the cluster
+    /// proof only if it is still in-flight, otherwise there is nothing to do.
+    Fulfilled,
+}
+
+impl CancelableKind {
+    /// Whether the network still expects an answer, i.e. `fail_fulfillment`
+    /// must run before the cluster abort.
+    pub fn should_fail_fulfillment(self) -> bool {
+        matches!(self, Self::Unexecutable)
+    }
+
+    /// Whether cancelling is conditional on the request still being in the
+    /// cluster's in-flight (Pending) set.
+    pub fn requires_in_flight(self) -> bool {
+        matches!(self, Self::Fulfilled)
+    }
+}
+
 pub trait NetworkRequest: Send + Sync + 'static {
     fn request_id(&self) -> String;
-
-    /// Whether the network already marked this request `Unfulfillable` (a terminal state).
-    fn is_unfulfillable(&self) -> bool;
-
-    /// Whether the network already marked this request `Fulfilled` (a terminal success).
-    ///
-    /// This happens when another path (e.g. the SPN proxy delivering a mainnet proof)
-    /// satisfied the request while our cluster was still proving it. The request
-    /// succeeded, so we must abort the wasted cluster work without failing fulfillment.
-    fn is_fulfilled(&self) -> bool;
 
     fn program_uri(&self) -> &str;
 
@@ -92,14 +114,14 @@ pub trait FulfillmentNetwork: Send + Sync + 'static {
         limit: u32,
     ) -> Result<Vec<Self::NetworkRequest>>;
 
-    /// Get cancelable requests (unexecutable assigned requests).
+    /// Get cancelable requests, each tagged with why it is cancelable.
     async fn get_cancelable_requests(
         &self,
         version: &str,
         fulfiller_addresses: Vec<Vec<u8>>,
         minimum_deadline: u64,
         limit: u32,
-    ) -> Result<Vec<Self::NetworkRequest>>;
+    ) -> Result<Vec<(Self::NetworkRequest, CancelableKind)>>;
 
     /// Download an artifact from the network.
     async fn download_artifact(


### PR DESCRIPTION
## Why
Follow-up to #140 (Farhad's non-blocking review note): fold the bool-based cancel routing (`is_unfulfillable()`/`is_fulfilled()` + `should_cancel`/`should_cancel_on_network`) into a single `CancelableKind` enum, so the producer that knows *why* a request is cancelable tags it explicitly instead of the loop re-deriving it from two bools.

## What
- `CancelableKind { Unexecutable, Unfulfillable, Fulfilled }` in `crates/fulfillment/src/network.rs`, with the two routing decisions on the enum: `should_fail_fulfillment()` (only `Unexecutable`) and `requires_in_flight()` (only `Fulfilled`).
- `get_cancelable_requests` now returns `Vec<(Self::NetworkRequest, CancelableKind)>`.
- `cancel_requests` reads as the routing table: fetch tagged candidates → fetch Pending cluster IDs only if some candidate `requires_in_flight()` → skip `Fulfilled` not in Pending → `cancel_on_network` only when `should_fail_fulfillment()` → `cancel_on_cluster` for everything kept.
- Deleted: `should_cancel`, `should_cancel_on_network`, `NetworkRequest::is_unfulfillable`, `NetworkRequest::is_fulfilled` (all now unused).
- In-flight fetch filters `proof_status = Pending` **server-side** (`ProofRequestListRequest.proof_status` — same pattern as the Completed/Failed queries in this file; `bin/api` has always honored it) instead of listing everything and filtering client-side. Dropped the needless `Arc<HashSet>` (the set is only read before spawning).
- Mainnet producer tags its two queries: `Assigned+Unexecutable` → `Unexecutable`, `Unfulfillable` → `Unfulfillable`. Mainnet still never emits `Fulfilled` candidates (fulfillers are paid per fulfillment) — now stated in a comment.

## Behavior preserved
The enum reproduces the old bool routing exactly:
| kind | fail network | cluster cancel |
|---|---|---|
| Unexecutable | yes | yes |
| Unfulfillable | no | yes |
| Fulfilled | no | only if still Pending in cluster |

Net **−20 lines**.

## Tests / checks
- Replaced the 3 bool-helper tests with one `cancelable_kind_routing_matrix` test (full matrix).
- `cargo test --release -p sp1-cluster-fulfillment` → 10/10.
- `cargo check --release --workspace`, `cargo clippy --release -p sp1-cluster-fulfillment -p sp1-cluster-fulfiller --all-targets -- -D warnings`, `cargo fmt --check` all clean.

## Private follow-up (required on next version bump)
`sp1-cluster-private` implements this trait; when it bumps past this change it must (compile-enforced): tag its producers (`unexecutable_cancelable_query` → `Unexecutable`, `fulfilled_cancelable_query` → `Fulfilled`) and drop its `is_unfulfillable`/`is_fulfilled` impls. Same behavior, no query changes.