### PR TITLE
feat(bidder): clamp deadlines to performance requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
+source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
+source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
+source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
+source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
+source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?rev=f652c93#f652c9326f1635db8bc699c9bb31612ef31a8ad0"
+source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,14 +39,11 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-# Pinned to network main f652c93 = the merge commit of network#234, which removes
-# ComponentInfo.instance_id and renumbers the ReportProverInfo build fields. Network
-# crates aren't published to crates.io, so these stay git deps.
-spn-artifacts = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", rev = "f652c93", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
-spn-utils = { git = "https://github.com/succinctlabs/network", rev = "f652c93" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "main", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 
 # SP1
 #

--- a/bin/bidder/Cargo.toml
+++ b/bin/bidder/Cargo.toml
@@ -21,7 +21,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 serde = { workspace = true }
-time = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/bin/bidder/src/lib.rs
+++ b/bin/bidder/src/lib.rs
@@ -5,7 +5,7 @@ use alloy::primitives::{Address, U256};
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
 use futures::future::join_all;
-use time::OffsetDateTime;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::{
     sync::RwLock,
     time::{interval, sleep, MissedTickBehavior},
@@ -317,10 +317,14 @@ impl Bidder {
             .set(if is_suspended { 1.0 } else { 0.0 });
 
         if is_suspended && suspended_until != previous {
+            let ends_at = OffsetDateTime::from_unix_timestamp(suspended_until as i64)
+                .ok()
+                .and_then(|t| t.format(&Rfc3339).ok())
+                .unwrap_or_default();
             error!(
                 suspended_until,
                 "prover is SUSPENDED for performance below the network requirements; \
-                 bidding is paused until the suspension expires"
+                 bidding is paused until {ends_at}"
             );
         } else if !is_suspended && previous > 0 {
             info!("prover suspension expired; resuming bidding");

--- a/bin/bidder/src/lib.rs
+++ b/bin/bidder/src/lib.rs
@@ -11,19 +11,23 @@ use tokio::{
     time::{interval, sleep, MissedTickBehavior},
 };
 use tonic::transport::Channel;
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use spn_network_types::{
     prover_network_client::ProverNetworkClient, BidRequest, BidRequestBody, FulfillmentStatus,
     GetNonceRequest, GetOwnerRequest, GetProofRequestParamsRequest, GetProvePriceRequest,
-    MessageFormat, ProofMode, Signable, TransactionVariant,
+    GetProverRequirementsRequest, GetProverStatusRequest, MessageFormat, ProofMode, ProofRequest,
+    Signable, TransactionVariant,
 };
+
+use crate::requirements::PerformanceRequirements;
 use spn_pricing::{round_down_to_tick, ProvePrice};
 use spn_utils::time_now;
 
 pub mod config;
 pub mod grpc;
 pub mod metrics;
+pub mod requirements;
 
 /// How long to wait between checking if there are any requested proofs to bid on.
 ///
@@ -38,6 +42,11 @@ const REQUEST_LIMIT: u32 = 100;
 
 /// Synchronous prime-fetch cap at startup so a slow RPC can't hang the bidder.
 const PRIME_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Cadence of the poll that fetches the network's published performance requirements
+/// and this prover's suspension status. Policy changes are rare ops events, so this
+/// is deliberately not a knob.
+const REQUIREMENTS_REFRESH_SECS: u64 = 60;
 
 #[derive(Clone)]
 pub struct Bidder {
@@ -80,6 +89,18 @@ pub struct Bidder {
     /// Cache of the last fetched PROVE/USD price. Populated by the refresh task spawned
     /// in `run()` when the USD bid is enabled.
     prove_usd_cache: Arc<RwLock<Option<ProvePrice>>>,
+    /// The network's published performance requirements. `None` (RPC unavailable, not
+    /// yet fetched, or enforcement disabled) degrades to unclamped bidding.
+    requirements: Arc<RwLock<Option<PerformanceRequirements>>>,
+    /// Whether the whitelister judges this prover against the performance
+    /// requirements (whitelisted and not high-availability). Exempt provers bid
+    /// unclamped up to the requester's deadline — they are the network's catch-all
+    /// for requests the governed provers decline. Starts `true` so an unknown status
+    /// errs toward clamping.
+    governed: Arc<RwLock<bool>>,
+    /// Unix timestamp until which this prover is suspended; 0 when not suspended.
+    /// While set in the future, the bidder skips bidding entirely.
+    suspended_until: Arc<RwLock<u64>>,
 }
 
 impl Bidder {
@@ -121,6 +142,9 @@ impl Bidder {
             usd_bid,
             tick_size: U256::ZERO,
             prove_usd_cache: Arc::new(RwLock::new(None)),
+            requirements: Arc::new(RwLock::new(None)),
+            governed: Arc::new(RwLock::new(true)),
+            suspended_until: Arc::new(RwLock::new(0)),
         }
     }
 
@@ -231,6 +255,127 @@ impl Bidder {
         });
     }
 
+    /// Fetch the network's performance requirements and this prover's suspension
+    /// status, updating the shared caches. RPC errors keep the previous values so a
+    /// flaky network — or one that doesn't serve these RPCs — never blocks bidding.
+    async fn sync_performance_policy(&self, prover: &[u8]) {
+        self.sync_requirements().await;
+        self.sync_prover_status(prover).await;
+    }
+
+    /// Refresh the requirements cache from `GetProverRequirements`.
+    async fn sync_requirements(&self) {
+        match self
+            .network
+            .clone()
+            .get_prover_requirements(GetProverRequirementsRequest {})
+            .await
+        {
+            Ok(resp) => {
+                let parsed = PerformanceRequirements::from_response(&resp.into_inner());
+                *self.requirements.write().await = parsed;
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to fetch prover requirements; keeping previous");
+                self.metrics.requirements_sync_errors.increment(1);
+            }
+        }
+    }
+
+    /// Refresh the governed flag and suspension cache from `GetProverStatus`.
+    async fn sync_prover_status(&self, prover: &[u8]) {
+        match self
+            .network
+            .clone()
+            .get_prover_status(GetProverStatusRequest {
+                prover: prover.to_vec(),
+            })
+            .await
+        {
+            Ok(resp) => {
+                let status = resp.into_inner();
+                *self.governed.write().await =
+                    status.is_whitelisted && !status.is_high_availability;
+                self.record_suspension_status(status.suspended_until.unwrap_or(0))
+                    .await;
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to fetch prover status; keeping previous");
+                self.metrics.requirements_sync_errors.increment(1);
+            }
+        }
+    }
+
+    /// Store the freshly fetched suspension timestamp, update the `suspended` gauge,
+    /// and emit edge-triggered logs: one error on entering (or extending) a
+    /// suspension, one info when it lifts. The gauge carries the steady state.
+    async fn record_suspension_status(&self, suspended_until: u64) {
+        let previous = std::mem::replace(&mut *self.suspended_until.write().await, suspended_until);
+        let is_suspended = suspended_until > time_now();
+        self.metrics
+            .suspended
+            .set(if is_suspended { 1.0 } else { 0.0 });
+
+        if is_suspended && suspended_until != previous {
+            error!(
+                suspended_until,
+                "prover is SUSPENDED for performance below the network requirements; \
+                 bidding is paused until the suspension expires"
+            );
+        } else if !is_suspended && previous > 0 {
+            info!("prover suspension expired; resuming bidding");
+        }
+    }
+
+    /// Synchronously seed the requirements/suspension caches once, bounded by
+    /// `PRIME_TIMEOUT` so a slow RPC can't hang startup. Failure leaves the caches
+    /// empty and the bidder starts unclamped until the sync task takes over.
+    async fn prime_performance_policy(&self, prover: &[u8]) {
+        if tokio::time::timeout(PRIME_TIMEOUT, self.sync_performance_policy(prover))
+            .await
+            .is_err()
+        {
+            warn!(
+                timeout_secs = PRIME_TIMEOUT.as_secs(),
+                "timed out priming performance policy caches; starting unclamped",
+            );
+        }
+    }
+
+    /// Spawn the background task that keeps the requirements/suspension caches fresh.
+    fn spawn_performance_policy_sync(&self, prover: Vec<u8>) {
+        let bidder = self.clone();
+        let mut ticker = interval(Duration::from_secs(REQUIREMENTS_REFRESH_SECS));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        tokio::spawn(async move {
+            loop {
+                ticker.tick().await;
+                bidder.sync_performance_policy(&prover).await;
+            }
+        });
+    }
+
+    /// Seconds left to fulfill this request: the requester's deadline, clamped to
+    /// the network's performance budget when one is published — fulfilling later
+    /// than `perf_deadline` counts against our success rate even if the requester's
+    /// deadline allows it. With no published requirements, the requester's deadline
+    /// stands unclamped.
+    fn effective_request_duration(
+        &self,
+        request: &ProofRequest,
+        requirements: Option<&PerformanceRequirements>,
+    ) -> u64 {
+        let Some(req) = requirements else {
+            return request.deadline.saturating_sub(time_now());
+        };
+        let perf = requirements::perf_deadline(request.created_at, request.gas_limit, req);
+        if perf < request.deadline {
+            self.metrics.perf_clamped.increment(1);
+        }
+        perf.min(request.deadline).saturating_sub(time_now())
+    }
+
     /// Runs the bidder loop.
     pub async fn run(mut self) -> Result<()> {
         info!("starting the bidder");
@@ -275,6 +420,9 @@ impl Bidder {
             .owner;
         let prover = Address::from_slice(&prover_bytes);
 
+        self.prime_performance_policy(&prover_bytes).await;
+        self.spawn_performance_policy_sync(prover_bytes.clone());
+
         loop {
             // Check for requests to bid on.
             if let Err(e) = self.bid_requests(prover).await {
@@ -289,6 +437,15 @@ impl Bidder {
     /// Checks for requested proof requests that are in the network and bids on eligible ones.
     #[instrument(skip_all)]
     async fn bid_requests(&mut self, prover: Address) -> Result<()> {
+        // While suspended, every bid is futile — the network won't assign us work.
+        // Skip the pass quietly (this runs every few seconds); the policy sync owns
+        // the loud transition logs and the `suspended` gauge.
+        let suspended_until = *self.suspended_until.read().await;
+        if suspended_until > time_now() {
+            debug!(suspended_until, "prover suspended; skipping bid pass");
+            return Ok(());
+        }
+
         // Get all requests from the network that are biddable.
         let request = spn_network_types::GetFilteredProofRequestsRequest {
             version: Some(self.version.clone()),
@@ -356,20 +513,30 @@ impl Bidder {
         // same price snapshot.
         let bid_amount = self.effective_bid_amount().await;
 
+        // Snapshot the published performance requirements once per pass. `None` — RPC
+        // unavailable, enforcement disabled, or this prover exempt from it (not
+        // whitelisted, or high-availability) — leaves deadlines unclamped: exempt
+        // provers are free to serve requests up to the requester's own deadline.
+        let network_requirements = if *self.governed.read().await {
+            self.requirements.read().await.clone()
+        } else {
+            None
+        };
+
         let mut failure_tasks = Vec::new();
         for request in requests {
             let self_clone = self.clone();
             let mode = request.mode();
+            let request_duration =
+                self.effective_request_duration(&request, network_requirements.as_ref());
             let request_id = hex::encode(request.request_id);
-
-            let request_duration = request.deadline.saturating_sub(time_now());
 
             // In aggressive mode, skip capacity/time checks but optionally enforce min deadline.
             if self.aggressive_mode {
                 if let Some(min_deadline) = self.min_deadline_secs {
                     if request_duration < min_deadline {
                         info!(
-                            "Skipping request 0x{} with deadline in {}s (below minimum {}s)",
+                            "Skipping request 0x{} with effective deadline in {}s (below minimum {}s)",
                             request_id, request_duration, min_deadline
                         );
                         continue;
@@ -380,7 +547,7 @@ impl Bidder {
                 if !self.can_fulfill_proof(active_proofs, request.gas_limit, request_duration, mode)
                 {
                     info!(
-                        "Cannot fulfill request 0x{} with gas limit {} and deadline in {}s",
+                        "Cannot fulfill request 0x{} with gas limit {} and effective deadline in {}s",
                         request_id, request.gas_limit, request_duration
                     );
                     continue;

--- a/bin/bidder/src/metrics.rs
+++ b/bin/bidder/src/metrics.rs
@@ -35,4 +35,15 @@ pub struct BidderMetrics {
     /// Number of bid evaluations where we fell back to the static `bid_amount`
     /// (either dynamic not configured, or the cached price is stale/absent).
     pub static_bid_used_total: Counter,
+
+    /// Bid evaluations where the fulfillment deadline was tightened by the network's
+    /// published performance requirements. Counts evaluations, not distinct requests:
+    /// an unbid request is re-evaluated (and re-counted) every bid pass.
+    pub perf_clamped: Counter,
+
+    /// Whether this prover is currently suspended by the network (1 = suspended).
+    pub suspended: Gauge,
+
+    /// Requirements/status sync errors (caches kept stale, bidding unaffected).
+    pub requirements_sync_errors: Counter,
 }

--- a/bin/bidder/src/requirements.rs
+++ b/bin/bidder/src/requirements.rs
@@ -1,0 +1,119 @@
+use spn_network_types::GetProverRequirementsResponse;
+
+/// The network's published prover performance requirements, fetched from
+/// `GetProverRequirements`. A fulfilled request counts toward the prover's success
+/// rate only if fulfilled within `perf_deadline` of its creation; falling below the
+/// success-rate bar leads to suspension.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerformanceRequirements {
+    /// Whole-request proving rate in MGas/s required whenever it grants more time
+    /// than the floor.
+    pub min_mgas_per_second: f64,
+    /// Minimum time budget in seconds granted to every request.
+    pub floor_latency_seconds: u64,
+}
+
+impl PerformanceRequirements {
+    /// Parse the wire response. Returns `None` when the network enforces no
+    /// requirements (absent sub-message) or the rate doesn't parse — both degrade to
+    /// unclamped bidding.
+    pub fn from_response(resp: &GetProverRequirementsResponse) -> Option<Self> {
+        let req = resp.requirements.as_ref()?;
+        let min_mgas_per_second: f64 = req.min_mgas_per_second.parse().ok()?;
+        if !min_mgas_per_second.is_finite() || min_mgas_per_second <= 0.0 {
+            return None;
+        }
+        Some(Self {
+            min_mgas_per_second,
+            floor_latency_seconds: req.floor_latency_seconds,
+        })
+    }
+}
+
+/// Absolute unix deadline by which a request of `gas_limit` must be fulfilled to
+/// count as successful under the network's performance requirements: the budget is
+/// `max(floor, gas / rate)`.
+///
+/// The network judges on actual `gas_used`, unknown before execution; `gas_limit` is
+/// its upper bound, so when the rate term governs, the computed budget can be looser
+/// than the one the network will apply. Tolerated: the fulfillment check estimates
+/// completion time from the same `gas_limit`, so both sides overestimate together
+/// and the committed pace stays honest.
+pub fn perf_deadline(created_at: u64, gas_limit: u64, req: &PerformanceRequirements) -> u64 {
+    let rate_secs = (gas_limit as f64 / (req.min_mgas_per_second * 1e6)) as u64;
+    created_at.saturating_add(rate_secs.max(req.floor_latency_seconds))
+}
+
+#[cfg(test)]
+mod tests {
+    use spn_network_types::ProverRequirements;
+
+    use super::*;
+
+    fn requirements() -> PerformanceRequirements {
+        PerformanceRequirements {
+            min_mgas_per_second: 24.0,
+            floor_latency_seconds: 420,
+        }
+    }
+
+    fn response() -> GetProverRequirementsResponse {
+        GetProverRequirementsResponse {
+            requirements: Some(ProverRequirements {
+                min_mgas_per_second: "24".to_string(),
+                floor_latency_seconds: 420,
+                min_success_rate_percentage: "98".to_string(),
+                performance_lookback_hours: 1,
+                min_resolved_requests_to_evaluate: 1,
+            }),
+        }
+    }
+
+    #[test]
+    fn parses_enabled_response() {
+        assert_eq!(
+            PerformanceRequirements::from_response(&response()),
+            Some(requirements())
+        );
+    }
+
+    #[test]
+    fn absent_requirements_parse_to_none() {
+        let resp = GetProverRequirementsResponse { requirements: None };
+        assert_eq!(PerformanceRequirements::from_response(&resp), None);
+    }
+
+    #[test]
+    fn invalid_rate_parses_to_none() {
+        for rate in ["", "abc", "0", "-24", "NaN", "inf"] {
+            let mut resp = response();
+            resp.requirements.as_mut().unwrap().min_mgas_per_second = rate.to_string();
+            assert_eq!(
+                PerformanceRequirements::from_response(&resp),
+                None,
+                "rate {rate}"
+            );
+        }
+    }
+
+    #[test]
+    fn small_gas_gets_floor_budget() {
+        // The rate would grant 0s and ~42s respectively; the 420s floor governs.
+        assert_eq!(perf_deadline(1_000, 0, &requirements()), 1_420);
+        assert_eq!(perf_deadline(1_000, 1_000_000_000, &requirements()), 1_420);
+    }
+
+    #[test]
+    fn large_gas_gets_rate_budget() {
+        // 14.4B gas / 24 MGas/s = 600s, above the 420s floor.
+        assert_eq!(
+            perf_deadline(1_000, 14_400_000_000, &requirements()),
+            1_000 + 600
+        );
+    }
+
+    #[test]
+    fn saturates_instead_of_overflowing() {
+        assert_eq!(perf_deadline(u64::MAX, u64::MAX, &requirements()), u64::MAX);
+    }
+}


### PR DESCRIPTION
## Description

The network now publishes its prover performance requirements over RPC (`GetProverRequirements` / `GetProverStatus`, succinctlabs/network#237). Until now the bidder only knew the requester's deadline — it would happily bid on requests the network judges on a tighter budget (`max(gas / min_mgas_per_second, floor)`), rack up "fulfilled too slow" failures, and get suspended. This PR makes the bidder respect the published bar.

## What it does

- Polls the network policy every 60s: the performance requirements and this prover's suspension status.
- Clamps the fulfillment deadline per request to `min(requester_deadline, perf_deadline)` before the existing can_fulfill_proof check, so we don't bid on work we'd be punished for winning.
- Gates the clamp on governed status: the whitelister only judges provers that are whitelisted and not high-availability. 
- Skips bidding entirely while suspended, with edge-triggered logging (one error on entry, one info on lift, per-poll warn in between) instead of spamming every 3s pass.
- New metrics: `perf_clamped`, `suspended`, `requirements_sync_errors`.

## Before / after

| Behavior | Before | After |
|---|---|---|
| Deadline used for bid decision | requester's deadline | `min(requester deadline, network perf budget)` for governed provers |
| Bidding while suspended | yes (futile — bids rejected or work judged while suspended) | skipped, with clear logs + `suspended` gauge |
| Knowledge of network policy | none (hardcoded assumptions) | polled from `GetProverRequirements` every 60s |
| HA / non-whitelisted provers | n/a | explicitly unclamped (exempt from enforcement) |