### PR TITLE
feat(bidder): gas-aware admission from published network policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,10 @@ BIDDER_SP1_PRIVATE_KEY=
 BIDDER_LOG_FORMAT=Pretty
 BIDDER_DOMAIN=SPN_MAINNET_V1_DOMAIN
 ## Core bidding configuration
+## Sustained cluster proving rate in MGas/s (roughly 1-5 per GPU; err low)
 BIDDER_THROUGHPUT_MGAS=1
-BIDDER_MAX_CONCURRENT_PROOFS=1
+## Per-node CPU-worker RAM in GB, comma-separated (e.g. "96,96" for two nodes)
+BIDDER_CPU_WORKER_MAX_WEIGHTS=96
 BIDDER_BID_AMOUNT=500000000
 ## Time buffers and mode toggles (optional; defaults shown)
 BIDDER_BUFFER_SEC=30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9498,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9524,7 +9524,7 @@ source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9498,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9519,12 +9519,12 @@ dependencies = [
 [[package]]
 name = "spn-bidding"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 
 [[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,7 +1853,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1873,7 +1873,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -4291,7 +4291,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6287,8 +6287,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.12.1",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6334,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -9519,7 +9519,7 @@ dependencies = [
 [[package]]
 name = "spn-bidding"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#98490b21fd08a1cf3205f43abc4588fcc5e368da"
+source = "git+https://github.com/succinctlabs/network?branch=main#96be7d2328729d56dcb66578e593184c160945c3"
 
 [[package]]
 name = "spn-metrics"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,7 +1853,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1873,7 +1873,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4291,7 +4291,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6287,8 +6287,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6334,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -8193,6 +8193,8 @@ dependencies = [
  "hex",
  "rustls 0.23.36",
  "serde",
+ "sp1-cluster-common",
+ "spn-bidding",
  "spn-metrics",
  "spn-network-types",
  "spn-pricing",
@@ -9484,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "spn-artifact-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
 dependencies = [
  "prost 0.13.5",
  "prost-build",
@@ -9496,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "spn-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9515,9 +9517,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spn-bidding"
+version = "0.1.0"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
+
+[[package]]
 name = "spn-metrics"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
 dependencies = [
  "axum 0.7.9",
  "eyre",
@@ -9536,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "spn-network-types"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9554,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "spn-pricing"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -9565,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "spn-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/network?branch=main#336ce79d206d82deb995568263138d3e058bba22"
+source = "git+https://github.com/succinctlabs/network?branch=farhad%2Fprogram-gas-stats-proto#0925cf4364328aed4ce5fbf9782f4e7e034d6133"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,12 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-# TEMPORARY: all network deps track the network PR branch (succinctlabs/network#238)
-# so spn-bidding and the GetProgramGasEstimates types resolve pre-merge; flip back
-# to branch = "main" once it merges.
-spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
-spn-bidding = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
-spn-utils = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
+spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-bidding = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "main", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 
 # SP1
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ p3-matrix = "=0.3.3-succinct"
 
 # SPN
 spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "main" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
 spn-bidding = { git = "https://github.com/succinctlabs/network", branch = "main" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
 spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "main", features = ["network"] }
 spn-pricing = { git = "https://github.com/succinctlabs/network", branch = "main" }
 spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,15 @@ p3-field = "=0.3.3-succinct"
 p3-matrix = "=0.3.3-succinct"
 
 # SPN
-spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "main" }
-spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "main" }
-spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "main", features = ["network"] }
-spn-pricing = { git = "https://github.com/succinctlabs/network", branch = "main" }
-spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
+# TEMPORARY: all network deps track the network PR branch (succinctlabs/network#238)
+# so spn-bidding and the GetProgramGasEstimates types resolve pre-merge; flip back
+# to branch = "main" once it merges.
+spn-artifacts = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
+spn-metrics = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
+spn-bidding = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
+spn-network-types = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto", features = ["network"] }
+spn-pricing = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
+spn-utils = { git = "https://github.com/succinctlabs/network", branch = "farhad/program-gas-stats-proto" }
 
 # SP1
 #
@@ -157,3 +161,4 @@ opt-level = 3
 
 [profile.dev.build-override]
 opt-level = 3
+

--- a/bin/bidder/Cargo.toml
+++ b/bin/bidder/Cargo.toml
@@ -7,6 +7,8 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
+sp1-cluster-common = { workspace = true }
+spn-bidding = { workspace = true }
 spn-metrics = { workspace = true }
 spn-network-types = { workspace = true, features = ["network"] }
 spn-pricing = { workspace = true }

--- a/bin/bidder/src/config.rs
+++ b/bin/bidder/src/config.rs
@@ -34,10 +34,12 @@ pub struct Settings {
     /// Base safety buffer in seconds applied to all proofs
     #[serde(default = "default_buffer_sec")]
     pub buffer_sec: u64,
-    /// Additional buffer for Groth16 proofs in seconds
+    /// Duration of the Groth16 wrap stage in seconds. Admission counts it once as
+    /// the request's own wrap time and once per queued cycle behind in-flight wraps.
     #[serde(default = "default_groth16_buffer_sec")]
     pub groth16_buffer_sec: u64,
-    /// Additional buffer for Plonk proofs in seconds
+    /// Duration of the Plonk wrap stage in seconds. Admission counts it once as
+    /// the request's own wrap time and once per queued cycle behind in-flight wraps.
     #[serde(default = "default_plonk_buffer_sec")]
     pub plonk_buffer_sec: u64,
     /// Whether to bid on Groth16 proofs

--- a/bin/bidder/src/config.rs
+++ b/bin/bidder/src/config.rs
@@ -13,10 +13,21 @@ pub struct Settings {
     pub log_format: LogFormat,
     #[serde(deserialize_with = "deserialize_domain")]
     pub domain: B256,
-    /// Total cluster throughput in million gas per second
+    /// Total sustained proving throughput of the cluster in million gas per second.
+    /// Admission divides a request's expected gas by this rate to estimate completion
+    /// time, so it should reflect measured end-to-end throughput, not a peak. As a
+    /// rough anchor, a single datacenter GPU sustains on the order of 1–5 MGas/s
+    /// depending on the model; sum your fleet and err low — overstating admits more
+    /// work than the cluster can finish before deadlines, understating only leaves
+    /// capacity idle.
     pub throughput_mgas: f64,
-    /// Maximum number of concurrent proofs the cluster can handle
-    pub max_concurrent_proofs: u32,
+    /// Comma-separated per-node CPU-worker capacities in task-weight units (GB of
+    /// RAM), matching the `max_weight` each CPU worker declares (e.g. "96,96" for
+    /// two 96 GB nodes). Per-node values, not a fleet total: a Groth16/Plonk wrap
+    /// stage must fit within a single node, so "96,96" holds two 60-weight Plonk
+    /// wraps while "192" holds three. The summed total bounds concurrent proofs
+    /// (one weight-1 controller task each).
+    pub cpu_worker_max_weights: String,
     /// Static bid per PGU in wei. Used unconditionally when `usd_bid_enabled` is `false`;
     /// otherwise serves as the safety-net bid when the PROVE/USD cache is missing or stale.
     pub bid_amount: U256,
@@ -40,6 +51,11 @@ pub struct Settings {
     pub aggressive_mode: bool,
     /// Minimum deadline in seconds to bid on (optional safety check, even in aggressive mode)
     pub min_deadline_secs: Option<u64>,
+    /// Multiplier on network-published gas estimates: expected gas = estimate × this,
+    /// still capped by the request's own limits. Leave at 1.0 unless estimates prove
+    /// mis-sized for this cluster.
+    #[serde(default = "default_gas_estimate_multiplier")]
+    pub gas_estimate_multiplier: f64,
     /// USD-denominated bid master switch. `true` (default) routes bids through the
     /// dynamic path when fresh PROVE/USD is available; otherwise falls back to the
     /// static `bid_amount`. `false` keeps the bidder on the static `bid_amount` path
@@ -90,6 +106,10 @@ impl Settings {
             staleness_max_secs: self.usd_bid_staleness_max_secs,
         })
     }
+}
+
+fn default_gas_estimate_multiplier() -> f64 {
+    1.0
 }
 
 fn default_buffer_sec() -> u64 {

--- a/bin/bidder/src/lib.rs
+++ b/bin/bidder/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use crate::{config::UsdBidConfig, metrics::BidderMetrics};
 use alloy::primitives::{Address, U256};
@@ -13,11 +17,15 @@ use tokio::{
 use tonic::transport::Channel;
 use tracing::{debug, error, info, instrument, warn};
 
+use spn_bidding::{
+    admission_outcome, expected_gas, AdmissionOutcome, ClusterState, EstimateCache, EstimateLookup,
+    RequestDemand,
+};
 use spn_network_types::{
     prover_network_client::ProverNetworkClient, BidRequest, BidRequestBody, FulfillmentStatus,
-    GetNonceRequest, GetOwnerRequest, GetProofRequestParamsRequest, GetProvePriceRequest,
-    GetProverRequirementsRequest, GetProverStatusRequest, MessageFormat, ProofMode, ProofRequest,
-    Signable, TransactionVariant,
+    GetNonceRequest, GetOwnerRequest, GetProgramGasEstimatesRequest, GetProofRequestParamsRequest,
+    GetProvePriceRequest, GetProverRequirementsRequest, GetProverStatusRequest, MessageFormat,
+    ProofMode, ProofRequest, Signable, TransactionVariant,
 };
 
 use crate::requirements::PerformanceRequirements;
@@ -40,6 +48,10 @@ const REFRESH_INTERVAL_SEC: u64 = 3;
 /// The maximum number of requests to handle in a single refresh loop.
 const REQUEST_LIMIT: u32 = 100;
 
+/// Maximum vk_hashes per `GetProgramGasEstimates` call, matching the server's
+/// per-call cap.
+const ESTIMATES_BATCH_LIMIT: usize = 256;
+
 /// Synchronous prime-fetch cap at startup so a slow RPC can't hang the bidder.
 const PRIME_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -57,8 +69,6 @@ pub struct Bidder {
     domain_bytes: Vec<u8>,
     /// Total cluster throughput in million gas per second
     throughput_mgas: f64,
-    /// Maximum number of concurrent proofs the cluster can handle
-    max_concurrent_proofs: u32,
     /// Token bid amount per PGU in wei
     bid_amount: U256,
     /// Base safety buffer in seconds applied to all proofs
@@ -75,6 +85,12 @@ pub struct Bidder {
     aggressive_mode: bool,
     /// Minimum deadline in seconds to bid on (optional safety check, even in aggressive mode)
     min_deadline_secs: Option<u64>,
+    /// Multiplier applied to published gas estimates; validated finite and positive at startup.
+    gas_estimate_multiplier: f64,
+    /// Per-node CPU-worker capacities in task-weight units (GB of RAM).
+    cpu_worker_max_weights: Vec<u32>,
+    /// TTL cache of the network-published per-program gas estimates.
+    estimate_cache: Arc<RwLock<EstimateCache>>,
     /// USD-denominated bid parameters. `Some` routes bids through the dynamic path
     /// (poll `GetProvePrice`, convert target to PROVE wei via
     /// `target * 10^9 / prove_usd_micros`). `None` keeps the bidder on the static
@@ -112,7 +128,6 @@ impl Bidder {
         metrics: BidderMetrics,
         domain_bytes: Vec<u8>,
         throughput_mgas: f64,
-        max_concurrent_proofs: u32,
         bid_amount: U256,
         buffer_sec: u64,
         groth16_buffer_sec: u64,
@@ -122,6 +137,8 @@ impl Bidder {
         aggressive_mode: bool,
         min_deadline_secs: Option<u64>,
         usd_bid: Option<UsdBidConfig>,
+        gas_estimate_multiplier: f64,
+        cpu_worker_max_weights: Vec<u32>,
     ) -> Self {
         Self {
             network,
@@ -130,7 +147,6 @@ impl Bidder {
             metrics,
             domain_bytes,
             throughput_mgas,
-            max_concurrent_proofs,
             bid_amount,
             buffer_sec,
             groth16_buffer_sec,
@@ -140,6 +156,9 @@ impl Bidder {
             aggressive_mode,
             min_deadline_secs,
             usd_bid,
+            gas_estimate_multiplier,
+            cpu_worker_max_weights,
+            estimate_cache: Arc::new(RwLock::new(EstimateCache::new())),
             tick_size: U256::ZERO,
             prove_usd_cache: Arc::new(RwLock::new(None)),
             requirements: Arc::new(RwLock::new(None)),
@@ -148,44 +167,31 @@ impl Bidder {
         }
     }
 
-    /// Calculate if we can fulfill a proof request within its deadline
-    fn can_fulfill_proof(
-        &self,
-        active_proofs: u32,
-        gas_limit: u64,
-        deadline_secs: u64,
-        mode: ProofMode,
-    ) -> bool {
-        // If the proof mode is disabled, we cannot fulfill it
+    /// Whether this bidder serves the proof mode.
+    fn mode_enabled(&self, mode: ProofMode) -> bool {
         match mode {
-            ProofMode::Groth16 if !self.groth16_enabled => return false,
-            ProofMode::Plonk if !self.plonk_enabled => return false,
-            _ => {}
+            ProofMode::Groth16 => self.groth16_enabled,
+            ProofMode::Plonk => self.plonk_enabled,
+            _ => true,
         }
-        // Calculate effective throughput per proof when at max capacity
-        let effective_throughput = self.throughput_mgas / self.max_concurrent_proofs as f64;
+    }
 
-        // Calculate time needed to complete this proof (in seconds)
-        let completion_time_secs = (gas_limit as f64 / 1_000_000.0) / effective_throughput;
-
-        // Add buffers for safety
-        let mut total_time_needed = completion_time_secs + self.buffer_sec as f64;
-
+    /// Duration and task weight of a request's wrap stage; zeros for modes without
+    /// one. Weights come from the cluster's shared task-weight defaults; the consts
+    /// read this process's environment, so a `WORKER_*_WRAP_WEIGHT` override on the
+    /// workers takes effect here only when the same variable is set on the bidder.
+    fn mode_wrap_demand(&self, mode: ProofMode) -> (f64, u32) {
         match mode {
-            ProofMode::Groth16 => {
-                total_time_needed += self.groth16_buffer_sec as f64;
-            }
-            ProofMode::Plonk => {
-                total_time_needed += self.plonk_buffer_sec as f64;
-            }
-            _ => {}
+            ProofMode::Groth16 => (
+                self.groth16_buffer_sec as f64,
+                *sp1_cluster_common::consts::GROTH16_WRAP_WEIGHT as u32,
+            ),
+            ProofMode::Plonk => (
+                self.plonk_buffer_sec as f64,
+                *sp1_cluster_common::consts::PLONK_WRAP_WEIGHT as u32,
+            ),
+            _ => (0.0, 0),
         }
-
-        // Check if we have enough time and capacity
-        let has_capacity = active_proofs < self.max_concurrent_proofs;
-        let has_time = total_time_needed <= deadline_secs as f64;
-
-        has_capacity && has_time
     }
 
     /// Returns the bid amount to use for this iteration.
@@ -272,7 +278,7 @@ impl Bidder {
             .await
         {
             Ok(resp) => {
-                let parsed = PerformanceRequirements::from_response(&resp.into_inner());
+                let parsed = requirements::from_response(&resp.into_inner());
                 *self.requirements.write().await = parsed;
             }
             Err(e) => {
@@ -360,6 +366,81 @@ impl Bidder {
         });
     }
 
+    /// Resolve the network-published gas estimate for every program in this pass:
+    /// fresh cache entries serve directly; the rest are fetched via
+    /// `GetProgramGasEstimates`, chunked to the server's per-call cap. A failed call
+    /// resolves its chunk to `None` for this pass — expected gas falls back to the
+    /// request's own limits — and keeps cached entries serving. Never blocks or
+    /// fails the pass.
+    async fn resolve_gas_estimates(
+        &self,
+        requests: &[ProofRequest],
+        assigned: &[ProofRequest],
+    ) -> HashMap<Vec<u8>, Option<u64>> {
+        let now = Instant::now();
+        let mut vks: Vec<Vec<u8>> = requests
+            .iter()
+            .chain(assigned)
+            .map(|r| r.vk_hash.clone())
+            .collect();
+        vks.sort_unstable();
+        vks.dedup();
+
+        let mut resolved = HashMap::new();
+        let mut misses = Vec::new();
+        {
+            let cache = self.estimate_cache.read().await;
+            for vk in vks {
+                match cache.lookup(&vk, now) {
+                    EstimateLookup::Hit(estimate) => {
+                        resolved.insert(vk, Some(estimate));
+                    }
+                    EstimateLookup::KnownAbsent => {
+                        resolved.insert(vk, None);
+                    }
+                    EstimateLookup::Miss => misses.push(vk),
+                }
+            }
+        }
+        if misses.is_empty() {
+            return resolved;
+        }
+
+        for chunk in misses.chunks(ESTIMATES_BATCH_LIMIT) {
+            match self
+                .network
+                .clone()
+                .get_program_gas_estimates(GetProgramGasEstimatesRequest {
+                    vk_hashes: chunk.to_vec(),
+                })
+                .await
+            {
+                Ok(resp) => {
+                    let mut by_vk: HashMap<Vec<u8>, u64> = resp
+                        .into_inner()
+                        .estimates
+                        .into_iter()
+                        .map(|e| (e.vk_hash, e.gas_estimate))
+                        .collect();
+                    let mut cache = self.estimate_cache.write().await;
+                    for vk in chunk {
+                        let estimate = by_vk.remove(vk);
+                        cache.store(vk.clone(), estimate, now);
+                        resolved.insert(vk.clone(), estimate);
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to fetch program gas estimates; sizing by request limits this pass");
+                    self.metrics.estimate_sync_errors.increment(1);
+                    for vk in chunk {
+                        resolved.insert(vk.clone(), None);
+                    }
+                }
+            }
+        }
+        resolved
+    }
+
     /// Seconds left to fulfill this request: the requester's deadline, clamped to
     /// the network's performance budget when one is published — fulfilling later
     /// than `perf_deadline` counts against our success rate even if the requester's
@@ -368,16 +449,84 @@ impl Bidder {
     fn effective_request_duration(
         &self,
         request: &ProofRequest,
+        expected_gas: u64,
         requirements: Option<&PerformanceRequirements>,
     ) -> u64 {
         let Some(req) = requirements else {
             return request.deadline.saturating_sub(time_now());
         };
-        let perf = requirements::perf_deadline(request.created_at, request.gas_limit, req);
+        let perf = requirements::perf_deadline(request.created_at, expected_gas, req);
         if perf < request.deadline {
             self.metrics.perf_clamped.increment(1);
         }
         perf.min(request.deadline).saturating_sub(time_now())
+    }
+
+    /// Decide whether to bid on a biddable request under gas-aware admission, sizing it
+    /// against the cluster's committed load and the network's performance deadline.
+    /// Returns `true` to bid — reserving the request's expected gas in `cluster` — or
+    /// `false` (with the reason logged) to skip. Records the limit-fallback and
+    /// admission-outcome metrics.
+    fn admit_request(
+        &self,
+        request: &ProofRequest,
+        request_id: &str,
+        mode: ProofMode,
+        estimate: Option<u64>,
+        requirements: Option<&PerformanceRequirements>,
+        cluster: &mut ClusterState,
+    ) -> bool {
+        if !self.mode_enabled(mode) {
+            info!(
+                "Skipping request 0x{} with disabled mode {:?}",
+                request_id, mode
+            );
+            return false;
+        }
+        if estimate.is_none() {
+            self.metrics.expected_gas_from_limit.increment(1);
+        }
+        let expected = expected_gas(
+            estimate,
+            request.gas_limit,
+            request.cycle_limit,
+            self.gas_estimate_multiplier,
+        );
+        // Clamp the schedulable deadline to the network's performance budget for the
+        // gas we actually expect this request to use.
+        let deadline_secs = self.effective_request_duration(request, expected, requirements);
+        let (wrap_secs, wrap_weight) = self.mode_wrap_demand(mode);
+        let outcome = admission_outcome(
+            cluster,
+            &RequestDemand {
+                expected_gas: expected,
+                deadline_secs,
+                buffer_secs: self.buffer_sec as f64,
+                wrap_secs,
+                wrap_weight,
+            },
+        );
+        match outcome {
+            AdmissionOutcome::AdmitLoaded => self.metrics.admitted_loaded.increment(1),
+            AdmissionOutcome::RejectCap => self.metrics.rejected_cap.increment(1),
+            AdmissionOutcome::RejectInfeasible => self.metrics.rejected_infeasible.increment(1),
+            AdmissionOutcome::RejectLoad => self.metrics.rejected_load.increment(1),
+        }
+        if !outcome.admits() {
+            info!(
+                "Cannot fulfill request 0x{} (outcome {:?}, expected {} gas, effective deadline in {}s)",
+                request_id, outcome, expected, deadline_secs
+            );
+            return false;
+        }
+        cluster.active_proofs += 1;
+        cluster.committed_gas = cluster.committed_gas.saturating_add(expected);
+        // Gate on weight, not duration: the initial active_wraps count is by mode,
+        // and a zero per-mode buffer config must not desynchronize the two.
+        if wrap_weight > 0 {
+            cluster.active_wraps += 1;
+        }
+        true
     }
 
     /// Runs the bidder loop.
@@ -394,6 +543,18 @@ impl Bidder {
         // Validate operator-configured bid amount. Catches misconfig at startup instead of
         // producing silently-rejected bids.
         validate_bid_amount(self.bid_amount, self.tick_size).context("bid_amount")?;
+        anyhow::ensure!(
+            self.gas_estimate_multiplier.is_finite() && self.gas_estimate_multiplier > 0.0,
+            "gas_estimate_multiplier must be finite and positive, got {}",
+            self.gas_estimate_multiplier
+        );
+        // The divisor of every completion-time estimate; a negative value would make
+        // admission fail open and bid on everything.
+        anyhow::ensure!(
+            self.throughput_mgas.is_finite() && self.throughput_mgas > 0.0,
+            "throughput_mgas must be finite and positive, got {}",
+            self.throughput_mgas
+        );
 
         match self.usd_bid.as_ref() {
             Some(bid) => {
@@ -411,6 +572,8 @@ impl Bidder {
                 info!(bid_amount = %self.bid_amount, "USD bid disabled; static-only path");
             }
         }
+
+        info!("gas-aware admission enabled");
 
         // Get the prover.
         let prover_bytes = self
@@ -441,9 +604,8 @@ impl Bidder {
     /// Checks for requested proof requests that are in the network and bids on eligible ones.
     #[instrument(skip_all)]
     async fn bid_requests(&mut self, prover: Address) -> Result<()> {
-        // While suspended, every bid is futile — the network won't assign us work.
-        // Skip the pass quietly (this runs every few seconds); the policy sync owns
-        // the loud transition logs and the `suspended` gauge.
+        // While suspended the network will not assign work, so skip the pass. The
+        // policy sync owns the suspension logging and the `suspended` gauge.
         let suspended_until = *self.suspended_until.read().await;
         if suspended_until > time_now() {
             debug!(suspended_until, "prover suspended; skipping bid pass");
@@ -505,7 +667,37 @@ impl Bidder {
             .await?
             .into_inner()
             .requests;
-        let mut active_proofs = assigned_requests.len() as u32;
+
+        // Published gas estimates for every program in this pass (one batched RPC at most).
+        let gas_estimates = self
+            .resolve_gas_estimates(&requests, &assigned_requests)
+            .await;
+        let estimate_for = |vk_hash: &[u8]| gas_estimates.get(vk_hash).copied().flatten();
+
+        // Expected gas of assigned proofs — the load admission accounts for.
+        let committed_gas: u64 = assigned_requests
+            .iter()
+            .map(|r| {
+                expected_gas(
+                    estimate_for(&r.vk_hash),
+                    r.gas_limit,
+                    r.cycle_limit,
+                    self.gas_estimate_multiplier,
+                )
+            })
+            .fold(0u64, |acc, g| acc.saturating_add(g));
+        let active_wraps = assigned_requests
+            .iter()
+            .filter(|r| matches!(r.mode(), ProofMode::Groth16 | ProofMode::Plonk))
+            .count() as u32;
+        let mut cluster = ClusterState {
+            throughput_mgas: self.throughput_mgas,
+            cpu_worker_max_weights: self.cpu_worker_max_weights.clone(),
+            active_proofs: assigned_requests.len() as u32,
+            committed_gas,
+            active_wraps,
+        };
+        self.metrics.committed_gas.set(cluster.committed_gas as f64);
 
         if requests.is_empty() {
             info!("found no biddable requests");
@@ -531,13 +723,17 @@ impl Bidder {
         for request in requests {
             let self_clone = self.clone();
             let mode = request.mode();
-            let request_duration =
-                self.effective_request_duration(&request, network_requirements.as_ref());
-            let request_id = hex::encode(request.request_id);
+            let request_id = hex::encode(&request.request_id);
 
             // In aggressive mode, skip capacity/time checks but optionally enforce min deadline.
             if self.aggressive_mode {
                 if let Some(min_deadline) = self.min_deadline_secs {
+                    // Aggressive mode skips estimate sizing; clamp on the raw gas_limit.
+                    let request_duration = self.effective_request_duration(
+                        &request,
+                        request.gas_limit,
+                        network_requirements.as_ref(),
+                    );
                     if request_duration < min_deadline {
                         info!(
                             "Skipping request 0x{} with effective deadline in {}s (below minimum {}s)",
@@ -546,17 +742,15 @@ impl Bidder {
                         continue;
                     }
                 }
-            } else {
-                // Normal mode: check capacity and time constraints.
-                if !self.can_fulfill_proof(active_proofs, request.gas_limit, request_duration, mode)
-                {
-                    info!(
-                        "Cannot fulfill request 0x{} with gas limit {} and effective deadline in {}s",
-                        request_id, request.gas_limit, request_duration
-                    );
-                    continue;
-                }
-                active_proofs += 1;
+            } else if !self.admit_request(
+                &request,
+                &request_id,
+                mode,
+                estimate_for(&request.vk_hash),
+                network_requirements.as_ref(),
+                &mut cluster,
+            ) {
+                continue;
             }
             failure_tasks.push(tokio::spawn(async move {
                 match self_clone

--- a/bin/bidder/src/lib.rs
+++ b/bin/bidder/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info, instrument, warn};
 
 use spn_bidding::{
     admission_outcome, expected_gas, AdmissionOutcome, ClusterState, EstimateCache, EstimateLookup,
-    RequestDemand,
+    PendingBids, RequestDemand,
 };
 use spn_network_types::{
     prover_network_client::ProverNetworkClient, BidRequest, BidRequestBody, FulfillmentStatus,
@@ -91,6 +91,9 @@ pub struct Bidder {
     cpu_worker_max_weights: Vec<u32>,
     /// TTL cache of the network-published per-program gas estimates.
     estimate_cache: Arc<RwLock<EstimateCache>>,
+    /// Own bids awaiting assignment, reconciled into committed load each pass.
+    /// A synchronous mutex: never locked across an await point.
+    pending_bids: Arc<std::sync::Mutex<PendingBids>>,
     /// USD-denominated bid parameters. `Some` routes bids through the dynamic path
     /// (poll `GetProvePrice`, convert target to PROVE wei via
     /// `target * 10^9 / prove_usd_micros`). `None` keeps the bidder on the static
@@ -159,6 +162,7 @@ impl Bidder {
             gas_estimate_multiplier,
             cpu_worker_max_weights,
             estimate_cache: Arc::new(RwLock::new(EstimateCache::new())),
+            pending_bids: Arc::new(std::sync::Mutex::new(PendingBids::default())),
             tick_size: U256::ZERO,
             prove_usd_cache: Arc::new(RwLock::new(None)),
             requirements: Arc::new(RwLock::new(None)),
@@ -441,6 +445,38 @@ impl Bidder {
         resolved
     }
 
+    /// Record an about-to-be-submitted bid in the pending ledger.
+    fn record_pending_bid(&self, request: &ProofRequest, expected_gas: u64, is_wrap: bool) {
+        self.pending_bids
+            .lock()
+            .expect("pending bids lock poisoned")
+            .record(
+                request.request_id.clone(),
+                expected_gas,
+                is_wrap,
+                request.min_auction_period,
+                Instant::now(),
+            );
+    }
+
+    /// Reconcile the pending ledger with this pass's visible requests, counting
+    /// bids still outstanding into `cluster`'s committed load.
+    fn reconcile_pending_bids(
+        &self,
+        cluster: &mut ClusterState,
+        biddable: &[ProofRequest],
+        assigned: &[ProofRequest],
+    ) {
+        self.pending_bids
+            .lock()
+            .expect("pending bids lock poisoned")
+            .reconcile_into(
+                cluster,
+                biddable.iter().chain(assigned).map(|r| &r.request_id),
+                Instant::now(),
+            );
+    }
+
     /// Seconds left to fulfill this request: the requester's deadline, clamped to
     /// the network's performance budget when one is published — fulfilling later
     /// than `perf_deadline` counts against our success rate even if the requester's
@@ -464,9 +500,9 @@ impl Bidder {
 
     /// Decide whether to bid on a biddable request under gas-aware admission, sizing it
     /// against the cluster's committed load and the network's performance deadline.
-    /// Returns `true` to bid — reserving the request's expected gas in `cluster` — or
-    /// `false` (with the reason logged) to skip. Records the limit-fallback and
-    /// admission-outcome metrics.
+    /// Returns `true` to bid — reserving the request's expected gas in `cluster` and
+    /// in the pending-bid ledger — or `false` (with the reason logged) to skip.
+    /// Records the limit-fallback and admission-outcome metrics.
     fn admit_request(
         &self,
         request: &ProofRequest,
@@ -526,6 +562,7 @@ impl Bidder {
         if wrap_weight > 0 {
             cluster.active_wraps += 1;
         }
+        self.record_pending_bid(request, expected, wrap_weight > 0);
         true
     }
 
@@ -720,6 +757,9 @@ impl Bidder {
             committed_gas,
             active_wraps,
         };
+        // Count our own bids still awaiting assignment so a burst is not
+        // re-admitted while the auction settles.
+        self.reconcile_pending_bids(&mut cluster, &requests, &assigned_requests);
         self.metrics.committed_gas.set(cluster.committed_gas as f64);
 
         if requests.is_empty() {

--- a/bin/bidder/src/lib.rs
+++ b/bin/bidder/src/lib.rs
@@ -601,6 +601,52 @@ impl Bidder {
         }
     }
 
+    /// Fetch every proof request currently assigned to this prover. Assigned proofs
+    /// are admission's load inputs, and controller capacity (Σ cpu_worker_max_weights)
+    /// can exceed one page — paginate so the counts are never truncated. Once the
+    /// count exceeds capacity the loop stops early: admission rejects at the cap from
+    /// the fetched counts alone, so exact totals past it are irrelevant.
+    async fn fetch_assigned_requests(&self, prover: Address) -> Result<Vec<ProofRequest>> {
+        let controller_slots = self
+            .cpu_worker_max_weights
+            .iter()
+            .fold(0u32, |acc, w| acc.saturating_add(*w));
+        let mut assigned = Vec::new();
+        let mut page = 1u32;
+        loop {
+            let batch = self
+                .network
+                .clone()
+                .get_filtered_proof_requests(spn_network_types::GetFilteredProofRequestsRequest {
+                    version: Some(self.version.clone()),
+                    fulfillment_status: Some(FulfillmentStatus::Assigned.into()),
+                    execution_status: None,
+                    execute_fail_cause: None,
+                    minimum_deadline: Some(time_now()),
+                    vk_hash: None,
+                    requester: None,
+                    fulfiller: Some(prover.to_vec()),
+                    limit: Some(REQUEST_LIMIT),
+                    page: Some(page),
+                    from: None,
+                    to: None,
+                    mode: None,
+                    not_bid_by: None,
+                    error: None,
+                    settlement_status: None,
+                })
+                .await?
+                .into_inner()
+                .requests;
+            let full_page = batch.len() as u32 == REQUEST_LIMIT;
+            assigned.extend(batch);
+            if !full_page || assigned.len() as u32 > controller_slots {
+                return Ok(assigned);
+            }
+            page += 1;
+        }
+    }
+
     /// Checks for requested proof requests that are in the network and bids on eligible ones.
     #[instrument(skip_all)]
     async fn bid_requests(&mut self, prover: Address) -> Result<()> {
@@ -643,30 +689,7 @@ impl Bidder {
         // requests we can bid on.
         // Note this is done after the biddable requests query to ensure a proof is not ommitted
         // from both queries if it became assigned just after the assigned query.
-        let assigned_requests = self
-            .network
-            .clone()
-            .get_filtered_proof_requests(spn_network_types::GetFilteredProofRequestsRequest {
-                version: Some(self.version.clone()),
-                fulfillment_status: Some(FulfillmentStatus::Assigned.into()),
-                execution_status: None,
-                execute_fail_cause: None,
-                minimum_deadline: Some(time_now()),
-                vk_hash: None,
-                requester: None,
-                fulfiller: Some(prover.to_vec()),
-                limit: Some(REQUEST_LIMIT),
-                page: None,
-                from: None,
-                to: None,
-                mode: None,
-                not_bid_by: None,
-                error: None,
-                settlement_status: None,
-            })
-            .await?
-            .into_inner()
-            .requests;
+        let assigned_requests = self.fetch_assigned_requests(prover).await?;
 
         // Published gas estimates for every program in this pass (one batched RPC at most).
         let gas_estimates = self

--- a/bin/bidder/src/lib.rs
+++ b/bin/bidder/src/lib.rs
@@ -73,9 +73,9 @@ pub struct Bidder {
     bid_amount: U256,
     /// Base safety buffer in seconds applied to all proofs
     buffer_sec: u64,
-    /// Additional buffer for Groth16 proofs in seconds
+    /// Duration of the Groth16 wrap stage in seconds (own wrap + per queued cycle).
     groth16_buffer_sec: u64,
-    /// Additional buffer for Plonk proofs in seconds
+    /// Duration of the Plonk wrap stage in seconds (own wrap + per queued cycle).
     plonk_buffer_sec: u64,
     /// Whether to bid on Groth16 proofs
     groth16_enabled: bool,

--- a/bin/bidder/src/main.rs
+++ b/bin/bidder/src/main.rs
@@ -74,6 +74,18 @@ async fn main() -> Result<()> {
     let metrics = BidderMetrics::default();
     BidderMetrics::describe();
 
+    // Parse per-node CPU worker weights; fail startup on malformed values.
+    let cpu_worker_max_weights: Vec<u32> = settings
+        .cpu_worker_max_weights
+        .split(',')
+        .map(|w| w.trim().parse::<u32>())
+        .collect::<Result<Vec<_>, _>>()
+        .context("BIDDER_CPU_WORKER_MAX_WEIGHTS must be comma-separated integers")?;
+    anyhow::ensure!(
+        !cpu_worker_max_weights.is_empty() && cpu_worker_max_weights.iter().all(|w| *w > 0),
+        "BIDDER_CPU_WORKER_MAX_WEIGHTS must contain at least one positive weight"
+    );
+
     // Initialize the Bidder with metrics.
     let usd_bid = settings.usd_bid();
     let bidder = Bidder::new(
@@ -83,7 +95,6 @@ async fn main() -> Result<()> {
         metrics,
         settings.domain.to_vec(),
         settings.throughput_mgas,
-        settings.max_concurrent_proofs,
         settings.bid_amount,
         settings.buffer_sec,
         settings.groth16_buffer_sec,
@@ -93,6 +104,8 @@ async fn main() -> Result<()> {
         settings.aggressive_mode,
         settings.min_deadline_secs,
         usd_bid,
+        settings.gas_estimate_multiplier,
+        cpu_worker_max_weights,
     );
 
     // Spawn the bidder task.

--- a/bin/bidder/src/metrics.rs
+++ b/bin/bidder/src/metrics.rs
@@ -47,7 +47,8 @@ pub struct BidderMetrics {
     /// Requirements/status sync errors (caches kept stale, bidding unaffected).
     pub requirements_sync_errors: Counter,
 
-    /// Expected gas committed to currently-assigned proofs (gas-aware admission).
+    /// Expected gas the cluster is committed to: currently-assigned proofs plus
+    /// own bids still awaiting assignment.
     pub committed_gas: Gauge,
 
     /// Expected-gas evaluations that fell back to the request's own limit (no

--- a/bin/bidder/src/metrics.rs
+++ b/bin/bidder/src/metrics.rs
@@ -46,4 +46,28 @@ pub struct BidderMetrics {
 
     /// Requirements/status sync errors (caches kept stale, bidding unaffected).
     pub requirements_sync_errors: Counter,
+
+    /// Expected gas committed to currently-assigned proofs (gas-aware admission).
+    pub committed_gas: Gauge,
+
+    /// Expected-gas evaluations that fell back to the request's own limit (no
+    /// published estimate for the program).
+    pub expected_gas_from_limit: Counter,
+
+    /// Requests admitted because they fit under conservative committed load.
+    pub admitted_loaded: Counter,
+
+    /// Requests rejected as solo-infeasible (can't fit the deadline even alone).
+    pub rejected_infeasible: Counter,
+
+    /// Requests rejected because committed load would miss the deadline.
+    pub rejected_load: Counter,
+
+    /// Requests rejected with no controller slot free (proof count is bounded by
+    /// CPU-worker weight).
+    pub rejected_cap: Counter,
+
+    /// Program gas estimate fetch errors (uncached programs size by their own limits
+    /// for the pass, bidding unaffected).
+    pub estimate_sync_errors: Counter,
 }

--- a/bin/bidder/src/requirements.rs
+++ b/bin/bidder/src/requirements.rs
@@ -1,47 +1,17 @@
+//! Thin adapter from the wire `GetProverRequirementsResponse` to the shared
+//! [`spn_bidding`] requirements math. The policy itself (parsing rules,
+//! `perf_deadline`) lives in `spn-bidding` so both SPN bidders share one
+//! implementation.
+
 use spn_network_types::GetProverRequirementsResponse;
 
-/// The network's published prover performance requirements, fetched from
-/// `GetProverRequirements`. A fulfilled request counts toward the prover's success
-/// rate only if fulfilled within `perf_deadline` of its creation; falling below the
-/// success-rate bar leads to suspension.
-#[derive(Debug, Clone, PartialEq)]
-pub struct PerformanceRequirements {
-    /// Whole-request proving rate in MGas/s required whenever it grants more time
-    /// than the floor.
-    pub min_mgas_per_second: f64,
-    /// Minimum time budget in seconds granted to every request.
-    pub floor_latency_seconds: u64,
-}
+pub use spn_bidding::{perf_deadline, PerformanceRequirements};
 
-impl PerformanceRequirements {
-    /// Parse the wire response. Returns `None` when the network enforces no
-    /// requirements (absent sub-message) or the rate doesn't parse — both degrade to
-    /// unclamped bidding.
-    pub fn from_response(resp: &GetProverRequirementsResponse) -> Option<Self> {
-        let req = resp.requirements.as_ref()?;
-        let min_mgas_per_second: f64 = req.min_mgas_per_second.parse().ok()?;
-        if !min_mgas_per_second.is_finite() || min_mgas_per_second <= 0.0 {
-            return None;
-        }
-        Some(Self {
-            min_mgas_per_second,
-            floor_latency_seconds: req.floor_latency_seconds,
-        })
-    }
-}
-
-/// Absolute unix deadline by which a request of `gas_limit` must be fulfilled to
-/// count as successful under the network's performance requirements: the budget is
-/// `max(floor, gas / rate)`.
-///
-/// The network judges on actual `gas_used`, unknown before execution; `gas_limit` is
-/// its upper bound, so when the rate term governs, the computed budget can be looser
-/// than the one the network will apply. Tolerated: the fulfillment check estimates
-/// completion time from the same `gas_limit`, so both sides overestimate together
-/// and the committed pace stays honest.
-pub fn perf_deadline(created_at: u64, gas_limit: u64, req: &PerformanceRequirements) -> u64 {
-    let rate_secs = (gas_limit as f64 / (req.min_mgas_per_second * 1e6)) as u64;
-    created_at.saturating_add(rate_secs.max(req.floor_latency_seconds))
+/// Parse the wire response. Returns `None` when the network enforces no requirements
+/// (absent sub-message) or the rate doesn't parse — both degrade to unclamped bidding.
+pub fn from_response(resp: &GetProverRequirementsResponse) -> Option<PerformanceRequirements> {
+    let req = resp.requirements.as_ref()?;
+    PerformanceRequirements::from_parts(&req.min_mgas_per_second, req.floor_latency_seconds)
 }
 
 #[cfg(test)]
@@ -49,13 +19,6 @@ mod tests {
     use spn_network_types::ProverRequirements;
 
     use super::*;
-
-    fn requirements() -> PerformanceRequirements {
-        PerformanceRequirements {
-            min_mgas_per_second: 24.0,
-            floor_latency_seconds: 420,
-        }
-    }
 
     fn response() -> GetProverRequirementsResponse {
         GetProverRequirementsResponse {
@@ -72,48 +35,17 @@ mod tests {
     #[test]
     fn parses_enabled_response() {
         assert_eq!(
-            PerformanceRequirements::from_response(&response()),
-            Some(requirements())
+            from_response(&response()),
+            Some(PerformanceRequirements {
+                min_mgas_per_second: 24.0,
+                floor_latency_seconds: 420,
+            })
         );
     }
 
     #[test]
     fn absent_requirements_parse_to_none() {
         let resp = GetProverRequirementsResponse { requirements: None };
-        assert_eq!(PerformanceRequirements::from_response(&resp), None);
-    }
-
-    #[test]
-    fn invalid_rate_parses_to_none() {
-        for rate in ["", "abc", "0", "-24", "NaN", "inf"] {
-            let mut resp = response();
-            resp.requirements.as_mut().unwrap().min_mgas_per_second = rate.to_string();
-            assert_eq!(
-                PerformanceRequirements::from_response(&resp),
-                None,
-                "rate {rate}"
-            );
-        }
-    }
-
-    #[test]
-    fn small_gas_gets_floor_budget() {
-        // The rate would grant 0s and ~42s respectively; the 420s floor governs.
-        assert_eq!(perf_deadline(1_000, 0, &requirements()), 1_420);
-        assert_eq!(perf_deadline(1_000, 1_000_000_000, &requirements()), 1_420);
-    }
-
-    #[test]
-    fn large_gas_gets_rate_budget() {
-        // 14.4B gas / 24 MGas/s = 600s, above the 420s floor.
-        assert_eq!(
-            perf_deadline(1_000, 14_400_000_000, &requirements()),
-            1_000 + 600
-        );
-    }
-
-    #[test]
-    fn saturates_instead_of_overflowing() {
-        assert_eq!(perf_deadline(u64::MAX, u64::MAX, &requirements()), u64::MAX);
+        assert_eq!(from_response(&resp), None);
     }
 }

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -249,7 +249,7 @@ bidder:
           name: cluster-secrets
           key: PRIVATE_KEY
     BIDDER_THROUGHPUT_MGAS: 1
-    BIDDER_MAX_CONCURRENT_PROOFS: 1
+    BIDDER_CPU_WORKER_MAX_WEIGHTS: "96"
     BIDDER_BID_AMOUNT: 1
   image:
     tag: "base-v2.5.4"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -234,8 +234,10 @@ services:
       - BIDDER_METRICS_ADDR=0.0.0.0:9090
       - BIDDER_RPC_GRPC_ADDR=${RPC_GRPC_ADDR}
       - BIDDER_SP1_PRIVATE_KEY=${SP1_PRIVATE_KEY}
+      # Sustained cluster proving rate in MGas/s (roughly 1-5 per GPU; err low).
       - BIDDER_THROUGHPUT_MGAS=1
-      - BIDDER_MAX_CONCURRENT_PROOFS=1
+      # Per-node CPU-worker RAM in GB, comma-separated (e.g. "96,96" for two nodes).
+      - BIDDER_CPU_WORKER_MAX_WEIGHTS=96
       # Static bid in wei/PGU. Safety-net when the USD bid falls back (cache missing
       # or stale), or the unconditional bid if you opt out of the USD bid below.
       - BIDDER_BID_AMOUNT=500000000


### PR DESCRIPTION
Depends on succinctlabs/network#238

## What

Replaces the bidder's flat `max_concurrent_proofs` admission with gas-aware schedulability from the shared spn-bidding crate.

Each pass, the bidder now:

- sizes every request from the network's published per-program gas estimates (`GetProgramGasEstimates`, one batched call per pass behind a client TTL cache), falling back to the request's own gas/cycle limits when a program has no history
- rejects anything that would miss its effective deadline, given the gas already committed to assigned proofs. The requester deadline is clamped to the network's published performance requirements when this prover is governed; exempt (HA) provers bid unclamped
- models wrap-stage capacity: Groth16/Plonk wraps are RAM-packed per CPU node, so a fleet of two 96 GB nodes correctly holds fewer Plonk wraps than one 192 GB node
- derives the concurrent-proof cap from controller slots (each active proof holds a weight-1 controller task, so Σ CPU worker max weights bounds proof count)

## Config changes

- New, required: `BIDDER_CPU_WORKER_MAX_WEIGHTS` — comma-separated per-node CPU worker capacity in GB (e.g. "96,96"). Per-node, not a total; wrap packing needs the node boundaries.
- New, optional: `BIDDER_GAS_ESTIMATE_MULTIPLIER` (default 1.0) — scales published estimates if they prove mis-sized for your cluster.
- Deleted: `BIDDER_MAX_CONCURRENT_PROOFS` — the cap is now derived, not guessed.