### PR TITLE
fix(worker): channel-silence watchdog and sub resubscribe

### DIFF
--- a/bin/coordinator/src/server.rs
+++ b/bin/coordinator/src/server.rs
@@ -332,6 +332,15 @@ impl<P: AssignmentPolicy + Send + Sync + 'static>
             let coordinator = self.coordinator.clone();
             let (outer_tx, outer_rx) = mpsc::unbounded_channel::<ServerSubMessage>();
 
+            // Greet every (re)opened stream immediately so the client's
+            // heartbeat window never races the periodic sender.
+            let _ = tx.send(Ok(ServerSubMessage {
+                msg_id: "msg".create_type_id::<V7>().to_string(),
+                message: Some(server_sub_message::Message::ServerHeartbeat(
+                    proto::ServerSubHeartbeat {},
+                )),
+            }));
+
             if let Some(mut sub) = self.subscribers.get_mut(&request.sub_id) {
                 // If the subscriber already exists, replace the handler.
                 sub.sender_handle.abort();
@@ -346,13 +355,6 @@ impl<P: AssignmentPolicy + Send + Sync + 'static>
                 );
             } else {
                 let map = Arc::new(DashMap::new());
-
-                let _ = tx.send(Ok(ServerSubMessage {
-                    msg_id: "msg".create_type_id::<V7>().to_string(),
-                    message: Some(server_sub_message::Message::ServerHeartbeat(
-                        proto::ServerSubHeartbeat {},
-                    )),
-                }));
 
                 // Spawn a task to forward messages to the stream and resend any unacked messages.
                 let handle = spawn_subscriber_channel_task(

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -175,7 +175,17 @@ async fn run_worker_inner(
 ) -> eyre::Result<()> {
     let main_handle = tokio::spawn({
         let tasks: Arc<DashMap<(String, String), ActiveTask>> = Arc::new(DashMap::new());
-        let mut channel = worker_client.open().await?;
+        // `open()` is single-attempt; retry here so a worker booting before
+        // the coordinator is reachable waits instead of crash-looping.
+        let mut channel = loop {
+            match worker_client.open().await {
+                Ok(channel) => break channel,
+                Err(e) => {
+                    tracing::warn!("Failed to open coordinator channel, retrying: {}", e);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        };
         let tasks = tasks.clone();
         let token = token.clone();
         async move {
@@ -295,6 +305,7 @@ async fn run_worker_inner(
                                                 }
                                                 Err(e) => {
                                                     tracing::error!("Failed to reconnect: {}", e);
+                                                    last_progress = Instant::now();
                                                     tokio::time::sleep(Duration::from_secs(1)).await;
                                                     continue;
                                                 }

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -180,6 +180,16 @@ async fn run_worker_inner(
         let token = token.clone();
         async move {
             let mut last_heartbeat = Instant::now();
+            // A reconnect can "succeed" (channel opens) yet never carry
+            // another message — we would loop forever, looking healthy from
+            // outside. Progress = an inbound message, or a failed connect
+            // (unreachable coordinator is an outage, not a wedge: keep
+            // retrying). Sustained silence while reconnects succeed means
+            // wedged channel state: exit for a clean restart. The coordinator
+            // evicts silent workers and requeues their tasks long before this
+            // fires.
+            let mut last_progress = Instant::now();
+            const MAX_CHANNEL_SILENCE: Duration = Duration::from_secs(5 * 60);
             let mut heartbeat_ticker = tokio::time::interval(Duration::from_secs(5));
             let mut closed = false;
             let mut drain_started_at: Option<Instant> = None;
@@ -189,7 +199,9 @@ async fn run_worker_inner(
                 tokio::select! {
                     msg = channel.recv() => {
                         match msg {
-                            Some(server_msg) => match server_msg.message {
+                            Some(server_msg) => {
+                                last_progress = Instant::now();
+                                match server_msg.message {
                                 Some(server_message::Message::NewTask(task)) => {
                                     let data = task.data().unwrap();
                                     tracing::info!("Received task: {}", task.task_id);
@@ -293,7 +305,8 @@ async fn run_worker_inner(
                                     last_heartbeat = Instant::now();
                                 }
                                 None => {}
-                            },
+                                }
+                            }
                             None => {
                                 tracing::error!("Server closed connection");
                                 // Try to reconnect with exponential backoff
@@ -305,6 +318,7 @@ async fn run_worker_inner(
                                     }
                                     Err(e) => {
                                         tracing::error!("Failed to reconnect: {}", e);
+                                        last_progress = Instant::now();
                                         tokio::time::sleep(Duration::from_secs(1)).await;
                                         continue;
                                     }
@@ -341,6 +355,20 @@ async fn run_worker_inner(
                                 last_drain_log_count = Some(in_flight);
                             }
                         }
+                        // Draining has its own timeout (drain_timeout); don't preempt it.
+                        if !closed && last_progress.elapsed() > MAX_CHANNEL_SILENCE {
+                            tracing::error!(
+                                "No message from coordinator for {:?} despite successful reconnects; exiting for a clean restart",
+                                last_progress.elapsed()
+                            );
+                            // Best-effort trace flush; exit(1) would skip the post-loop shutdown.
+                            let _ = tokio::time::timeout(
+                                Duration::from_secs(5),
+                                tokio::task::spawn_blocking(opentelemetry::global::shutdown_tracer_provider),
+                            )
+                            .await;
+                            std::process::exit(1);
+                        }
                         if last_heartbeat.elapsed() > Duration::from_secs(10) {
                             tracing::error!("Heartbeat timed out, reconnecting...");
                             match worker_client.open().await {
@@ -350,6 +378,7 @@ async fn run_worker_inner(
                                 }
                                 Err(e) => {
                                     tracing::error!("Failed to reconnect: {}", e);
+                                    last_progress = Instant::now();
                                     tokio::time::sleep(Duration::from_secs(1)).await;
                                     continue;
                                 }

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -420,10 +420,20 @@ impl WorkerClient for WorkerServiceClient {
                                 }
                                 Err(e) => {
                                     tracing::error!("Connection error: {:?}", e);
+                                    // Re-subscribe with the tasks we still own: the
+                                    // coordinator may have evicted this sub while we
+                                    // were away, and a bare reopen would recreate it
+                                    // with no subscriptions, silently dropping their
+                                    // results.
+                                    let resub = OpenSubRequest {
+                                        sub_id: sub_id.clone(),
+                                        proof_id: request.proof_id.clone(),
+                                        task_ids: tasks_set.lock().await.iter().cloned().collect(),
+                                    };
                                     match backoff::future::retry(retry::infinite(), || async {
                                         connection
                                             .clone()
-                                            .open_sub(request.clone())
+                                            .open_sub(resub.clone())
                                             .await
                                             .map_err(status_to_backoff_error)
                                     })
@@ -450,10 +460,17 @@ impl WorkerClient for WorkerServiceClient {
                         _ = interval.tick() => {
                             if last_heartbeat.elapsed().unwrap_or_default() > Duration::from_secs(10) {
                                 tracing::warn!("No heartbeats received from subscriber {}, reconnecting", sub_id);
+                                // See the stream-error branch: reopen must carry our
+                                // live tasks in case the coordinator evicted this sub.
+                                let resub = OpenSubRequest {
+                                    sub_id: sub_id.clone(),
+                                    proof_id: request.proof_id.clone(),
+                                    task_ids: tasks_set.lock().await.iter().cloned().collect(),
+                                };
                                 match backoff::future::retry(retry::infinite(), || async {
                                     connection
                                         .clone()
-                                        .open_sub(request.clone())
+                                        .open_sub(resub.clone())
                                         .await
                                         .map_err(status_to_backoff_error)
                                 })

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -425,15 +425,17 @@ impl WorkerClient for WorkerServiceClient {
                                     // were away, and a bare reopen would recreate it
                                     // with no subscriptions, silently dropping their
                                     // results.
-                                    let resub = OpenSubRequest {
-                                        sub_id: sub_id.clone(),
-                                        proof_id: request.proof_id.clone(),
-                                        task_ids: tasks_set.lock().await.iter().cloned().collect(),
-                                    };
+                                    // Snapshot inside the retry so tasks added
+                                    // mid-retry are included.
                                     match backoff::future::retry(retry::infinite(), || async {
+                                        let resub = OpenSubRequest {
+                                            sub_id: sub_id.clone(),
+                                            proof_id: request.proof_id.clone(),
+                                            task_ids: tasks_set.lock().await.iter().cloned().collect(),
+                                        };
                                         connection
                                             .clone()
-                                            .open_sub(resub.clone())
+                                            .open_sub(resub)
                                             .await
                                             .map_err(status_to_backoff_error)
                                     })
@@ -462,15 +464,15 @@ impl WorkerClient for WorkerServiceClient {
                                 tracing::warn!("No heartbeats received from subscriber {}, reconnecting", sub_id);
                                 // See the stream-error branch: reopen must carry our
                                 // live tasks in case the coordinator evicted this sub.
-                                let resub = OpenSubRequest {
-                                    sub_id: sub_id.clone(),
-                                    proof_id: request.proof_id.clone(),
-                                    task_ids: tasks_set.lock().await.iter().cloned().collect(),
-                                };
                                 match backoff::future::retry(retry::infinite(), || async {
+                                    let resub = OpenSubRequest {
+                                        sub_id: sub_id.clone(),
+                                        proof_id: request.proof_id.clone(),
+                                        task_ids: tasks_set.lock().await.iter().cloned().collect(),
+                                    };
                                     connection
                                         .clone()
-                                        .open_sub(resub.clone())
+                                        .open_sub(resub)
                                         .await
                                         .map_err(status_to_backoff_error)
                                 })

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -11,7 +11,7 @@ use sp1_cluster_common::proto::{
     AckSubRequest, CloseRequest, CompleteTaskRequest, FailTaskRequest, HeartbeatRequest,
     OpenRequest, OpenSubRequest, ServerMessage, TaskData, UpdateSubRequest, WorkerType,
 };
-use sp1_cluster_common::util::{backoff_retry, status_to_backoff_error};
+use sp1_cluster_common::util::status_to_backoff_error;
 use sp1_prover::worker::{
     ProofId, RawTaskRequest, SubscriberBuilder, TaskContext, TaskId, TaskMetadata, WorkerClient,
 };
@@ -71,6 +71,10 @@ impl WorkerServiceClient {
         })
     }
 
+    /// Single connection attempt — no internal retry. Callers own the retry
+    /// loop so every failed attempt is observable; the worker's silence
+    /// watchdog distinguishes an outage (connects failing) from a wedged
+    /// channel (connects succeeding, no messages) and must see the failures.
     pub async fn open(&self) -> Result<mpsc::UnboundedReceiver<ServerMessage>> {
         // Prepare for receiving server messages
         let (server_tx, server_rx) = mpsc::unbounded_channel();
@@ -88,12 +92,7 @@ impl WorkerServiceClient {
             git_sha: crate::VERGEN_GIT_SHA.to_string(),
             image_tag: std::env::var("IMAGE_TAG").unwrap_or_default(),
         };
-        let response = backoff_retry(retry::infinite(), || {
-            let mut client = self.client.clone();
-            let init_msg = init_msg.clone();
-            async move { client.open(init_msg).await }
-        })
-        .await?;
+        let response = self.client.clone().open(init_msg).await?;
         let mut inbound = response.into_inner();
 
         // Spawn a receive task to pump server messages into `server_tx`


### PR DESCRIPTION
## Background

Each prover node runs a worker process holding two kinds of gRPC streams to the coordinator: a **main channel** (coordinator pushes a heartbeat every 5s, plus task assignments) and per-proof **subscriber streams** (deliver task results). Silence is therefore diagnostic: a healthy worker hears something every few seconds. The worker's only recovery for silence is to reconnect the stream.

## Why

A CPU worker went silent and stayed wedged for **3 hours** until manually redeployed. Every 15s:

```
ERROR bin/node/src/lib.rs:345: Heartbeat timed out, reconnecting...
WARN  client.rs:445: No heartbeats received from subscriber sub_01kxe72x…, reconnecting
```

Two details tell the story:
- **No reconnect ever failed.** Every `open()`/`open_sub()` succeeded — the channel established, then never delivered a single message. So the worker's recovery loop concluded "fixed!" every 15 seconds, forever, while ECS saw a healthy container.
- **The same subscriber IDs recycled for 3 hours** — stale objects in process memory that hundreds of "successful" reconnects never actually replaced.

## Fixes

1. **Channel-silence watchdog** (`bin/node/src/lib.rs`) . A healthy channel carries a heartbeat every 5s, so silence is diagnostic. A `last_progress` clock resets only on an inbound message or a **failed** connect (unreachable coordinator = outage → keep retrying). Successful reconnects don't reset it — that's the wedge signature. 5 min of silence → flush traces → `exit(1)` → ECS restarts fresh (what the manual redeploy proved sufficient). Skipped while draining. Task-safe: the coordinator requeues a silent worker's tasks at ~30s.

2. **Lossless subscriber reconnect** (`crates/worker/src/client.rs`). The coordinator evicts subs after 20s; reconnect re-sent the original request with `task_ids: []`, recreating the sub with zero subscriptions — results for still-owned tasks were silently dropped. Reconnect now snapshots the owned task set inside the retry; `add_subscriptions` replays anything finalized meanwhile, so nothing is lost.

3. **Greet reopened streams** (`bin/coordinator/src/server.rs`). The immediate heartbeat went only to new subs; reopened ones waited up to 10s against a 10s client timeout. Now sent to every (re)opened stream.

Still open: *why* streams delivered nothing...