### PR TITLE
fix(node): send heartbeats from a dedicated thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-air",
 ]
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7780,7 +7780,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-fri",
 ]
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "futures",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-matrix",
 ]
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "futures",
@@ -7953,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "slop-algebra",
 ]
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "futures",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8008,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8016,7 +8016,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "derive-where",
  "futures",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8478,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8647,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8723,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8828,7 +8828,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "clap",
  "serde",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8960,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "futures",
  "rayon",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "bincode",
  "blake3",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9205,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=7ea83d064#7ea83d064628f79a240d2063993f3f156b3f32ee"
+source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-air",
 ]
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7780,7 +7780,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-fri",
 ]
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "futures",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-matrix",
 ]
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "futures",
@@ -7953,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "slop-algebra",
 ]
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "futures",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8008,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8016,7 +8016,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "derive-where",
  "futures",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8478,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8647,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8723,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8828,7 +8828,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "clap",
  "serde",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8960,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "futures",
  "rayon",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "bincode",
  "blake3",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9205,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=08d0c88aa#08d0c88aa6b36e3a4991b04a0f6812097d0ac514"
+source = "git+https://github.com/succinctlabs/sp1?rev=ae8da3427#ae8da34278cde1e074e72ac0360e533a192e24bd"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,25 +48,23 @@ spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 
 # SP1
 #
-# Pinned to the sp1#2862 merge commit on main (7ea83d064 = v6.3.1 + the
-# ClusterService manifest RPCs; the old WorkerService.GetClusterComponentInfo is
-# removed). The whole sp1 family must share one source or the workspace gets two
-# sp1-prover-types packages and E0308 mismatches. Switch back to released crates
-# once a release including sp1#2862 is cut.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa", features = ["network"] }
+# The whole sp1 family must share one source, or the workspace resolves two
+# sp1-prover-types packages and every crossing type mismatches. Pinned to a main
+# commit ahead of the latest release; move to released crates once one catches up.
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "ae8da3427" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,20 +53,20 @@ spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 # removed). The whole sp1 family must share one source or the workspace gets two
 # sp1-prover-types packages and E0308 mismatches. Switch back to released crates
 # once a release including sp1#2862 is cut.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064", features = ["network"] }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "7ea83d064" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "08d0c88aa" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/bin/api/src/service.rs
+++ b/bin/api/src/service.rs
@@ -357,7 +357,10 @@ impl ClusterService for ClusterServiceImpl {
         &self,
         request: Request<SetClusterComponentInfoRequest>,
     ) -> Result<Response<()>, Status> {
-        let components = request.into_inner().components;
+        let SetClusterComponentInfoRequest {
+            components,
+            capacity,
+        } = request.into_inner();
         let updated_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|e| Status::internal(format!("system time before unix epoch: {e}")))?
@@ -370,6 +373,7 @@ impl ClusterService for ClusterServiceImpl {
             .unwrap_or_else(|e| e.into_inner()) = ClusterComponentManifest {
             components,
             updated_at,
+            capacity,
         };
         Ok(Response::new(()))
     }
@@ -431,6 +435,7 @@ mod tests {
                 entry("coordinator", "abc1234"),
                 entry("cpu-node", "abc1234"),
             ],
+            capacity: None,
         }))
         .await
         .unwrap();
@@ -450,11 +455,13 @@ mod tests {
         let svc = service();
         svc.set_cluster_component_info(Request::new(SetClusterComponentInfoRequest {
             components: vec![entry("coordinator", "oldsha"), entry("gpu-node", "oldsha")],
+            capacity: None,
         }))
         .await
         .unwrap();
         svc.set_cluster_component_info(Request::new(SetClusterComponentInfoRequest {
             components: vec![entry("coordinator", "newsha")],
+            capacity: None,
         }))
         .await
         .unwrap();

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -105,6 +105,17 @@ const MAX_TASK_RETRIES: u8 = 3;
 /// Configurable per-coordinator via `Settings::worker_heartbeat_timeout_secs`.
 pub const DEFAULT_WORKER_HEARTBEAT_TIMEOUT: u64 = 30;
 
+/// How often workers are prompted to prove they are alive.
+pub const SERVER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Below this, healthy workers get evicted.
+///
+/// A worker only answers when prompted, and covering for a failed heartbeat
+/// path costs it an interval to attempt a beat, an RPC deadline to give up on
+/// it, another interval for the next prompt, and a second deadline for the
+/// covering beat. Four intervals holds that with margin to spare.
+pub const MIN_WORKER_HEARTBEAT_TIMEOUT: u64 = 4 * SERVER_HEARTBEAT_INTERVAL.as_secs();
+
 /// The default weight of a GPU instance
 pub const DEFAULT_GPU_INSTANCE_WEIGHT: u32 = 24;
 
@@ -492,8 +503,24 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             .execute_only_mode = execute_only_mode;
     }
 
-    /// Set the dead-worker heartbeat timeout (seconds).
+    /// Set the dead-worker heartbeat timeout (seconds), never below
+    /// [`MIN_WORKER_HEARTBEAT_TIMEOUT`].
+    ///
+    /// Clamped rather than honoured, because under the floor every healthy
+    /// worker is evicted and requeued on a loop — a cluster-wide outage, not
+    /// the faster failure detection the setting reads like.
     pub async fn set_worker_heartbeat_timeout(&self, secs: u64) {
+        let secs = if secs < MIN_WORKER_HEARTBEAT_TIMEOUT {
+            tracing::warn!(
+                "worker heartbeat timeout {}s is under the {}s floor; using the floor, since \
+                 workers cannot prove liveness that fast",
+                secs,
+                MIN_WORKER_HEARTBEAT_TIMEOUT
+            );
+            MIN_WORKER_HEARTBEAT_TIMEOUT
+        } else {
+            secs
+        };
         self.state
             .write()
             .instrument(tracing::debug_span!("acquire_write"))
@@ -2352,6 +2379,19 @@ mod tests {
         let c = Arc::new(coordinator());
         let err = c.close_worker("nonexistent".into()).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_timeout_cannot_be_set_below_the_floor() {
+        let c = Arc::new(coordinator());
+
+        c.set_worker_heartbeat_timeout(5).await;
+
+        assert_eq!(
+            c.state.read().await.worker_heartbeat_timeout_secs,
+            MIN_WORKER_HEARTBEAT_TIMEOUT,
+            "a timeout no worker can meet was accepted"
+        );
     }
 
     #[tokio::test]

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -692,6 +692,23 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         Ok(())
     }
 
+    /// Total weight of the tasks this coordinator has assigned to a worker.
+    ///
+    /// Heartbeats carry the worker's own count, but it snapshots that before
+    /// taking delivery of tasks already sent to it. Trusting the snapshot
+    /// would free capacity that is spoken for and pile more work on a worker
+    /// that is already behind.
+    fn assigned_weight(
+        state: &CoordinatorState<P>,
+        active_tasks: &HashSet<(String, String)>,
+    ) -> u32 {
+        active_tasks
+            .iter()
+            .filter_map(|(proof_id, task_id)| state.proofs.get(proof_id)?.tasks.get(task_id))
+            .map(|task| task.data.weight)
+            .sum()
+    }
+
     /// Handle a heartbeat from a worker.
     pub async fn handle_heartbeat(
         self: &Arc<Self>,
@@ -716,7 +733,6 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        worker.weight = current_weight;
 
         // Handle any tasks the worker is working on that are not tracked in the coordinator, and
         // cancel them.
@@ -774,8 +790,19 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 }
             }
         }
+        let assigned = Self::assigned_weight(&state, &worker.active_tasks);
+        if assigned != current_weight {
+            tracing::debug!(
+                "worker {} reports weight {} against {} assigned",
+                worker_id,
+                current_weight,
+                assigned
+            );
+        }
+
         let mut should_assign = false;
         let worker = state.workers.get_mut(worker_id).unwrap();
+        worker.weight = assigned;
         if !tasks_to_remove.is_empty() {
             for tuple in tasks_to_remove {
                 worker.active_tasks.remove(&tuple);
@@ -2325,6 +2352,34 @@ mod tests {
         let c = Arc::new(coordinator());
         let err = c.close_worker("nonexistent".into()).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_weight_follows_assignments_not_the_worker_snapshot() {
+        let c = Arc::new(coordinator());
+        let _rx = {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_task(&mut state, "p1", "t1", Some("w1"));
+            state
+                .proofs
+                .get_mut("p1")
+                .unwrap()
+                .tasks
+                .get_mut("t1")
+                .unwrap()
+                .data
+                .weight = 10;
+            insert_dead_worker(&mut state, "w1", WorkerType::Gpu, &[("p1", "t1")])
+        };
+
+        // A worker that has not yet taken delivery reports no tasks, no weight.
+        c.handle_heartbeat("w1", &[], &[], 0).await.unwrap();
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.workers["w1"].weight, 10,
+            "an under-reported snapshot freed capacity that is already assigned"
+        );
     }
 
     #[tokio::test]

--- a/bin/coordinator/src/util.rs
+++ b/bin/coordinator/src/util.rs
@@ -61,7 +61,7 @@ pub fn spawn_heartbeat_task<P: AssignmentPolicy>(
             loop {
                 coordinator.send_heartbeats().await;
                 tokio::select! {
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                    _ = tokio::time::sleep(crate::SERVER_HEARTBEAT_INTERVAL) => {}
                     _ = token.cancelled() => break,
                 }
             }

--- a/bin/network-gateway/src/status.rs
+++ b/bin/network-gateway/src/status.rs
@@ -45,6 +45,7 @@ pub fn cluster_fulfillment_filter(
         S::Assigned => vec![],
         S::Fulfilled => vec![C::Completed],
         S::Unfulfillable => vec![C::Failed, C::Cancelled],
+        S::Reverted | S::Expired => vec![C::Failed],
     }
 }
 

--- a/bin/node/src/heartbeat.rs
+++ b/bin/node/src/heartbeat.rs
@@ -1,0 +1,341 @@
+//! Worker liveness, decoupled from everything that can starve it.
+//!
+//! A saturated worker holds every runtime thread in long polls for tens of
+//! seconds at a time. Beats sent from that runtime go silent under exactly
+//! that load, and the coordinator declares a live worker dead and re-delivers
+//! its tasks. These beats come from a thread that shares nothing with prover
+//! work, so a silent worker is genuinely stuck, not merely busy.
+//!
+//! Trade-off: the beats keep the worker registered even when its delivery
+//! stream wedges, so recovering from that falls to the main loop's reconnect
+//! and silence watchdogs.
+
+use crate::config::NodeConfig;
+use crate::ActiveTask;
+use dashmap::DashMap;
+use sp1_cluster_common::proto::HeartbeatRequest;
+use sp1_cluster_worker::client::WorkerServiceClient;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+/// Interval between liveness heartbeats sent from the dedicated thread.
+///
+/// The coordinator evicts a worker after `COORDINATOR_WORKER_HEARTBEAT_TIMEOUT_SECS`
+/// (default 30s) without a heartbeat, so this interval leaves ~6 beats of margin
+/// before a false eviction.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+/// Per-attempt deadline. A missed beat is dropped, never retried — the next
+/// tick is a fresher liveness signal than a stale delivery.
+const HEARTBEAT_RPC_TIMEOUT: Duration = Duration::from_secs(3);
+/// Two missed beats, after which the main loop covers.
+///
+/// Handing over costs this plus a prompt, so the coordinator's eviction
+/// timeout has to exceed `BEATS_STALE_AFTER + HEARTBEAT_INTERVAL` or it
+/// evicts a worker that was about to be covered. Its 30s default leaves 2x.
+const BEATS_STALE_AFTER: Duration = Duration::from_secs(10);
+
+/// Stops the heartbeat thread when dropped.
+///
+/// Ties the beats to the worker loop's lifetime, not the worker token: a
+/// draining worker must keep beating or the coordinator evicts it mid-drain,
+/// and a dropped loop (harness kill) must go silent so eviction notices.
+#[must_use = "dropping this stops the heartbeat thread"]
+pub(crate) struct HeartbeatHandle {
+    stop: CancellationToken,
+    clock: Arc<BeatClock>,
+}
+
+impl HeartbeatHandle {
+    /// Beats from an OS thread with its own runtime until the handle drops.
+    ///
+    /// Fate-shared: if the thread dies on its own — connect failure or panic —
+    /// the guard cancels `worker_token` so the worker restarts instead of
+    /// running without proactive liveness.
+    pub(crate) fn spawn(
+        node_config: NodeConfig,
+        tasks: Arc<DashMap<(String, String), ActiveTask>>,
+        worker_token: CancellationToken,
+    ) -> std::io::Result<Self> {
+        let stop = CancellationToken::new();
+        let clock = Arc::new(BeatClock::new());
+        let (thread_stop, thread_clock) = (stop.clone(), clock.clone());
+        std::thread::Builder::new()
+            .name("worker-heartbeat".into())
+            .spawn(move || {
+                let _cancel_on_exit = sp1_cluster_worker::utils::DeferGuard::new(
+                    (thread_stop.clone(), worker_token),
+                    |(stop, worker_token)| {
+                        if !stop.is_cancelled() && !worker_token.is_cancelled() {
+                            tracing::error!("heartbeat thread exited; shutting worker down");
+                            worker_token.cancel();
+                        }
+                    },
+                );
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build heartbeat runtime");
+                rt.block_on(heartbeat_loop(
+                    node_config,
+                    tasks,
+                    thread_clock,
+                    thread_stop,
+                ));
+            })?;
+        Ok(Self { stop, clock })
+    }
+
+    /// Shares when the thread last beat, so the main loop can cover for it.
+    pub(crate) fn clock(&self) -> Arc<BeatClock> {
+        self.clock.clone()
+    }
+}
+
+impl Drop for HeartbeatHandle {
+    fn drop(&mut self) {
+        self.stop.cancel();
+    }
+}
+
+/// When the dedicated thread last landed a beat.
+///
+/// The thread owns its own connection, which can die while the delivery stream
+/// stays healthy, and a worker that stops beating gets evicted no matter how
+/// alive it is. Tracks only the dedicated path: fallback beats deliberately do
+/// not refresh it, so the main loop keeps covering until the thread recovers.
+pub(crate) struct BeatClock(Mutex<Option<Instant>>);
+
+impl BeatClock {
+    /// Starts stale: until the thread proves its connection works, the main
+    /// loop covers. A worker that boots into a broken connection has only
+    /// until the eviction timeout, which is shorter than [`BEATS_STALE_AFTER`]
+    /// on some clusters.
+    fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    fn record_ok(&self) {
+        *self.0.lock().unwrap() = Some(Instant::now());
+    }
+
+    /// True when beats stopped landing, so the main loop should cover on the
+    /// stream it knows works.
+    pub(crate) fn is_stale(&self) -> bool {
+        self.0
+            .lock()
+            .unwrap()
+            .is_none_or(|last_ok| last_ok.elapsed() > BEATS_STALE_AFTER)
+    }
+}
+
+/// Sends one beat and reports whether it landed.
+///
+/// Shared with the main loop's fallback so both paths classify and log an
+/// outcome the same way.
+pub(crate) async fn send_beat(
+    client: &WorkerServiceClient,
+    tasks: &DashMap<(String, String), ActiveTask>,
+) -> bool {
+    let request = build_heartbeat_request(&client.worker_id, tasks);
+    match tokio::time::timeout(HEARTBEAT_RPC_TIMEOUT, client.heartbeat_once(request)).await {
+        Ok(Ok(())) => true,
+        // Expected until the main loop's `open()` registers this worker, and
+        // after an eviction until it re-registers. Both self-heal.
+        Ok(Err(status)) if status.code() == tonic::Code::NotFound => {
+            tracing::debug!("heartbeat for unregistered worker: {status}");
+            false
+        }
+        Ok(Err(status)) => {
+            tracing::warn!("heartbeat rejected: {status}");
+            false
+        }
+        Err(_) => {
+            tracing::warn!("heartbeat timed out after {HEARTBEAT_RPC_TIMEOUT:?}");
+            false
+        }
+    }
+}
+
+async fn heartbeat_loop(
+    node_config: NodeConfig,
+    tasks: Arc<DashMap<(String, String), ActiveTask>>,
+    clock: Arc<BeatClock>,
+    stop: CancellationToken,
+) {
+    // Own client on its own channel: a cloned client would share a connection
+    // driven by the runtime this thread must stay independent of.
+    let client = tokio::select! {
+        _ = stop.cancelled() => return,
+        result = WorkerServiceClient::new(
+            node_config.coordinator_rpc.clone(),
+            node_config.worker_id.clone(),
+            node_config.worker_type,
+        ) => match result {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::error!("heartbeat thread failed to connect, exiting: {e}");
+                return;
+            }
+        },
+    };
+
+    // First beat after one full interval. This thread starts before the main
+    // loop registers the worker, so beating immediately always misses.
+    let mut ticker = tokio::time::interval_at(
+        tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+        HEARTBEAT_INTERVAL,
+    );
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = stop.cancelled() => return,
+            _ = ticker.tick() => {}
+        }
+        if send_beat(&client, &tasks).await {
+            clock.record_ok();
+        }
+    }
+}
+
+/// One-pass snapshot so the reported task ids and weight stay consistent — the
+/// coordinator schedules on the weight. Separate passes could tear under
+/// concurrent task churn.
+fn build_heartbeat_request(
+    worker_id: &str,
+    tasks: &DashMap<(String, String), ActiveTask>,
+) -> HeartbeatRequest {
+    let mut active_task_proof_ids = Vec::with_capacity(tasks.len());
+    let mut active_task_ids = Vec::with_capacity(tasks.len());
+    let mut current_weight = 0;
+    for entry in tasks.iter() {
+        let (proof_id, task_id) = entry.key();
+        active_task_proof_ids.push(proof_id.clone());
+        active_task_ids.push(task_id.clone());
+        current_weight += entry.value().0.weight;
+    }
+    HeartbeatRequest {
+        worker_id: worker_id.to_string(),
+        active_task_proof_ids,
+        active_task_ids,
+        current_weight,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sp1_cluster_common::proto::TaskData;
+
+    /// Valid but unreachable, so the thread sits in its connect retry — the
+    /// state a worker boots into when the coordinator is down.
+    fn test_config() -> NodeConfig {
+        NodeConfig {
+            coordinator_rpc: "http://127.0.0.1:1".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// The thread holds a clone of the task map while it runs, so the strong
+    /// count says whether it is still alive.
+    fn wait_for_exit(tasks: &Arc<DashMap<(String, String), ActiveTask>>) -> bool {
+        for _ in 0..100 {
+            if Arc::strong_count(tasks) == 1 {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        false
+    }
+
+    #[test]
+    fn beats_outlive_worker_shutdown() {
+        let tasks = Arc::new(DashMap::new());
+        let worker_token = CancellationToken::new();
+        let handle =
+            HeartbeatHandle::spawn(test_config(), tasks.clone(), worker_token.clone()).unwrap();
+
+        // Drain starts: the worker still runs tasks, so it must still beat or
+        // the coordinator evicts it and requeues work it is finishing.
+        worker_token.cancel();
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            Arc::strong_count(&tasks),
+            2,
+            "heartbeat thread stopped at drain start"
+        );
+
+        drop(handle);
+        assert!(
+            wait_for_exit(&tasks),
+            "heartbeat thread outlived its handle"
+        );
+    }
+
+    #[test]
+    fn stopping_the_thread_leaves_the_worker_running() {
+        let tasks = Arc::new(DashMap::new());
+        let worker_token = CancellationToken::new();
+        let handle =
+            HeartbeatHandle::spawn(test_config(), tasks.clone(), worker_token.clone()).unwrap();
+
+        drop(handle);
+
+        assert!(wait_for_exit(&tasks));
+        assert!(
+            !worker_token.is_cancelled(),
+            "a deliberate stop shut the worker down"
+        );
+    }
+
+    #[test]
+    fn beats_read_stale_until_one_lands() {
+        let clock = BeatClock::new();
+
+        // A worker whose connection never came up must be covered from the
+        // start: on short eviction timeouts it has less than one stale window.
+        assert!(clock.is_stale(), "a fresh clock claimed a beat had landed");
+
+        clock.record_ok();
+        assert!(!clock.is_stale());
+
+        *clock.0.lock().unwrap() =
+            Some(Instant::now() - BEATS_STALE_AFTER - Duration::from_secs(1));
+        assert!(clock.is_stale(), "beats stopped landing but read healthy");
+    }
+
+    #[tokio::test]
+    async fn request_reports_every_task_with_its_weight() {
+        let task = |weight| {
+            (
+                TaskData {
+                    weight,
+                    ..Default::default()
+                },
+                tokio::spawn(std::future::pending::<()>()),
+                Instant::now(),
+            )
+        };
+        let tasks = DashMap::new();
+        tasks.insert(("p1".to_string(), "t1".to_string()), task(3));
+        tasks.insert(("p2".to_string(), "t2".to_string()), task(4));
+
+        let request = build_heartbeat_request("w1", &tasks);
+
+        assert_eq!(request.worker_id, "w1");
+        assert_eq!(request.current_weight, 7);
+        let mut reported: Vec<_> = request
+            .active_task_proof_ids
+            .iter()
+            .zip(&request.active_task_ids)
+            .collect();
+        reported.sort();
+        assert_eq!(
+            reported,
+            vec![
+                (&"p1".to_string(), &"t1".to_string()),
+                (&"p2".to_string(), &"t2".to_string())
+            ]
+        );
+    }
+}

--- a/bin/node/src/heartbeat.rs
+++ b/bin/node/src/heartbeat.rs
@@ -28,11 +28,9 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// Per-attempt deadline. A missed beat is dropped, never retried — the next
 /// tick is a fresher liveness signal than a stale delivery.
 const HEARTBEAT_RPC_TIMEOUT: Duration = Duration::from_secs(3);
-/// Two missed beats, after which the main loop covers.
-///
-/// Handing over costs this plus a prompt, so the coordinator's eviction
-/// timeout has to exceed `BEATS_STALE_AFTER + HEARTBEAT_INTERVAL` or it
-/// evicts a worker that was about to be covered. Its 30s default leaves 2x.
+/// Backstop for a thread that stops beating without reporting a failure —
+/// hung mid-send, or wedged before its first attempt. A thread that is still
+/// running hands over on the failed beat itself, well inside this.
 const BEATS_STALE_AFTER: Duration = Duration::from_secs(10);
 
 /// Stops the heartbeat thread when dropped.
@@ -98,25 +96,28 @@ impl Drop for HeartbeatHandle {
     }
 }
 
-/// When the dedicated thread last landed a beat.
+/// The dedicated thread's last beat, if it landed.
 ///
 /// The thread owns its own connection, which can die while the delivery stream
 /// stays healthy, and a worker that stops beating gets evicted no matter how
-/// alive it is. Tracks only the dedicated path: fallback beats deliberately do
-/// not refresh it, so the main loop keeps covering until the thread recovers.
+/// alive it is. So the main loop watches this and covers when it reads stale.
+///
+/// Holds only what is still worth trusting: a failed beat clears it outright
+/// rather than ageing out, because the eviction timeout is configurable and
+/// can be shorter than any threshold this could wait out. Tracks the dedicated
+/// path alone — fallback beats deliberately do not refresh it, so the main
+/// loop keeps covering until the thread itself recovers.
 pub(crate) struct BeatClock(Mutex<Option<Instant>>);
 
 impl BeatClock {
-    /// Starts stale: until the thread proves its connection works, the main
-    /// loop covers. A worker that boots into a broken connection has only
-    /// until the eviction timeout, which is shorter than [`BEATS_STALE_AFTER`]
-    /// on some clusters.
+    /// Starts stale: the main loop covers until the thread proves its
+    /// connection works.
     fn new() -> Self {
         Self(Mutex::new(None))
     }
 
-    fn record_ok(&self) {
-        *self.0.lock().unwrap() = Some(Instant::now());
+    fn record(&self, landed: bool) {
+        *self.0.lock().unwrap() = landed.then(Instant::now);
     }
 
     /// True when beats stopped landing, so the main loop should cover on the
@@ -192,9 +193,7 @@ async fn heartbeat_loop(
             _ = stop.cancelled() => return,
             _ = ticker.tick() => {}
         }
-        if send_beat(&client, &tasks).await {
-            clock.record_ok();
-        }
+        clock.record(send_beat(&client, &tasks).await);
     }
 }
 
@@ -296,12 +295,31 @@ mod tests {
         // start: on short eviction timeouts it has less than one stale window.
         assert!(clock.is_stale(), "a fresh clock claimed a beat had landed");
 
-        clock.record_ok();
+        clock.record(true);
         assert!(!clock.is_stale());
+    }
 
+    #[test]
+    fn a_failed_beat_hands_over_without_waiting() {
+        let clock = BeatClock::new();
+        clock.record(true);
+
+        clock.record(false);
+
+        // Not "ages out of the window" — the eviction timeout is configurable
+        // and can be shorter than any window we could wait out.
+        assert!(clock.is_stale(), "a failed beat still read healthy");
+    }
+
+    #[test]
+    fn beats_read_stale_once_they_stop_landing() {
+        let clock = BeatClock::new();
+
+        // A thread hung mid-send reports neither success nor failure.
         *clock.0.lock().unwrap() =
             Some(Instant::now() - BEATS_STALE_AFTER - Duration::from_secs(1));
-        assert!(clock.is_stale(), "beats stopped landing but read healthy");
+
+        assert!(clock.is_stale());
     }
 
     #[tokio::test]

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -227,6 +227,13 @@ async fn run_worker_inner(
                     // misreads the stall as a dead channel. Load-bearing: with
                     // random polling, a woken loop can reconnect on stale
                     // `last_heartbeat` and discard messages it has not read.
+                    //
+                    // Accepted cost: while the channel is closed, `recv` is
+                    // ready instantly with `None` every iteration, so the
+                    // watchdog arm starves for the length of a coordinator
+                    // outage. Benign — everything it checks either reports to
+                    // the unreachable coordinator or tolerates a bounded delay,
+                    // and the stall guard skips one silence check at recovery.
                     biased;
                     msg = channel.recv() => {
                         match msg {

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -1,12 +1,13 @@
 pub mod config;
+mod heartbeat;
 
 use config::NodeConfig;
+use heartbeat::{send_beat, HeartbeatHandle};
 
 use dashmap::DashMap;
 use sp1_cluster_artifact::ArtifactClient;
 use sp1_cluster_common::proto::{
-    self, server_message, CloseRequest, CompleteTaskRequest, FailTaskRequest, HeartbeatRequest,
-    TaskData, WorkerType,
+    self, server_message, CloseRequest, CompleteTaskRequest, FailTaskRequest, TaskData, WorkerType,
 };
 use sp1_cluster_worker::client::WorkerServiceClient;
 use sp1_cluster_worker::config::cluster_worker_config;
@@ -166,15 +167,21 @@ pub async fn run_gpu_worker(
     .unwrap()
 }
 
-type ActiveTask = (TaskData, JoinHandle<()>, Instant);
+pub(crate) type ActiveTask = (TaskData, JoinHandle<()>, Instant);
+
 async fn run_worker_inner(
     node_config: NodeConfig,
     token: CancellationToken,
     worker_client: WorkerServiceClient,
     worker: Arc<SP1ClusterWorker<impl WorkerClient, impl ArtifactClient, impl SP1ProverComponents>>,
 ) -> eyre::Result<()> {
+    let tasks: Arc<DashMap<(String, String), ActiveTask>> = Arc::new(DashMap::new());
+
+    // Beats stop when this future ends (return or harness kill).
+    let heartbeat = HeartbeatHandle::spawn(node_config.clone(), tasks.clone(), token.clone())?;
+
     let main_handle = tokio::spawn({
-        let tasks: Arc<DashMap<(String, String), ActiveTask>> = Arc::new(DashMap::new());
+        let beats = heartbeat.clock();
         // `open()` is single-attempt; retry here so a worker booting before
         // the coordinator is reachable waits instead of crash-looping.
         let mut channel = loop {
@@ -190,23 +197,37 @@ async fn run_worker_inner(
         let token = token.clone();
         async move {
             let mut last_heartbeat = Instant::now();
-            // A reconnect can "succeed" (channel opens) yet never carry
-            // another message — we would loop forever, looking healthy from
-            // outside. Progress = an inbound message, or a failed connect
-            // (unreachable coordinator is an outage, not a wedge: keep
-            // retrying). Sustained silence while reconnects succeed means
-            // wedged channel state: exit for a clean restart. The coordinator
-            // evicts silent workers and requeues their tasks long before this
-            // fires.
+            // A reconnect can "succeed" yet carry no message, and the dedicated
+            // thread keeps beating, so the coordinator would hold this worker
+            // forever. Exiting stops the beats and lets it requeue. Progress is
+            // an inbound message or a failed connect — an unreachable
+            // coordinator is an outage, not a wedge, so keep retrying.
+            //
+            // Prompts come every 5s and 10s of quiet forces a reconnect, so 45s
+            // is about four reconnects that each carried nothing: no longer a
+            // slow coordinator. Adding the coordinator's 30s eviction, a wedged
+            // worker's tasks are back in the queue in ~75s.
             let mut last_progress = Instant::now();
-            const MAX_CHANNEL_SILENCE: Duration = Duration::from_secs(5 * 60);
-            let mut heartbeat_ticker = tokio::time::interval(Duration::from_secs(5));
+            const MAX_CHANNEL_SILENCE: Duration = Duration::from_secs(45);
+            const WATCHDOG_PERIOD: Duration = Duration::from_secs(5);
+            // Three periods. Long enough that normal scheduling jitter never
+            // trips it, short enough to catch the stalls that do.
+            const STALLED_TICK_GAP: Duration = Duration::from_secs(15);
+            let mut watchdog_ticker = tokio::time::interval(WATCHDOG_PERIOD);
+            watchdog_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut last_tick = Instant::now();
             let mut closed = false;
             let mut drain_started_at: Option<Instant> = None;
             let mut last_drain_log_count: Option<usize> = None;
             let tasks = tasks.clone();
             loop {
                 tokio::select! {
+                    // Biased so a loop waking from a long stall drains buffered
+                    // messages before any watchdog reads their timestamps and
+                    // misreads the stall as a dead channel. Load-bearing: with
+                    // random polling, a woken loop can reconnect on stale
+                    // `last_heartbeat` and discard messages it has not read.
+                    biased;
                     msg = channel.recv() => {
                         match msg {
                             Some(server_msg) => {
@@ -287,33 +308,16 @@ async fn run_worker_inner(
                                     }
                                 }
                                 Some(server_message::Message::ServerHeartbeat(_)) => {
-                                    let (task_proof_ids, task_ids) = tasks.iter().map(|v| v.key().clone()).unzip();
-                                    let current_weight = tasks.iter().map(|v| v.value().0.weight).sum();
-                                    let request = HeartbeatRequest {
-                                        worker_id: node_config.worker_id.clone(),
-                                        active_task_proof_ids: task_proof_ids,
-                                        active_task_ids: task_ids,
-                                        current_weight,
-                                    };
-                                    if let Err(e) = worker_client.heartbeat(request).await  {
-                                        eprintln!("Failed to send heartbeat: {}", e);
-                                        if e.code() == tonic::Code::NotFound {
-                                            tracing::warn!("Worker not found, reconnecting...");
-                                            match worker_client.open().await {
-                                                Ok(new_channel) => {
-                                                    channel = new_channel;
-                                                }
-                                                Err(e) => {
-                                                    tracing::error!("Failed to reconnect: {}", e);
-                                                    last_progress = Instant::now();
-                                                    tokio::time::sleep(Duration::from_secs(1)).await;
-                                                    continue;
-                                                }
-                                            }
-                                        }
-                                    }
-
+                                    // A prompt proves the delivery stream works; liveness
+                                    // replies are the dedicated heartbeat thread's job.
                                     last_heartbeat = Instant::now();
+                                    // The thread has its own connection, which can fail
+                                    // while this stream is fine, and a worker that stops
+                                    // beating is evicted no matter how alive it is.
+                                    if beats.is_stale() {
+                                        tracing::debug!("dedicated beats stale; beating on the delivery stream");
+                                        send_beat(&worker_client, &tasks).await;
+                                    }
                                 }
                                 None => {}
                                 }
@@ -337,7 +341,21 @@ async fn run_worker_inner(
                             }
                         }
                     }
-                    _ = heartbeat_ticker.tick() => {
+                    _ = watchdog_ticker.tick() => {
+                        // A tick this late means the runtime just woke from a stall,
+                        // so inbound messages may still be sitting in the receive
+                        // pump and `last_progress` reads staler than the channel
+                        // really is. Skip the silence check until ticks recover.
+                        let tick_gap = last_tick.elapsed();
+                        let woke_from_stall = tick_gap > STALLED_TICK_GAP;
+                        if woke_from_stall {
+                            // Logged because it disables the silence check, and a
+                            // worker stalling every tick keeps it disabled.
+                            tracing::warn!(
+                                "watchdog tick {tick_gap:?} late; skipping channel silence check"
+                            );
+                        }
+                        last_tick = Instant::now();
                         // If the worker is closed and there's no tasks, break out of the loop.
                         if closed && tasks.is_empty() {
                             tracing::info!("Worker is closed and has no tasks, breaking out of loop");
@@ -367,7 +385,7 @@ async fn run_worker_inner(
                             }
                         }
                         // Draining has its own timeout (drain_timeout); don't preempt it.
-                        if !closed && last_progress.elapsed() > MAX_CHANNEL_SILENCE {
+                        if !closed && !woke_from_stall && last_progress.elapsed() > MAX_CHANNEL_SILENCE {
                             tracing::error!(
                                 "No message from coordinator for {:?} despite successful reconnects; exiting for a clean restart",
                                 last_progress.elapsed()

--- a/bin/test-cluster/src/scenarios/worker_death.rs
+++ b/bin/test-cluster/src/scenarios/worker_death.rs
@@ -21,13 +21,14 @@ pub fn scenario() -> Scenario {
 /// work is requeued, then bring a worker back and verify the proof still completes.
 ///
 /// Deterministic single-victim design: exactly one CPU node, so the killed node is
-/// guaranteed to own the controller task. The heartbeat timeout is shortened to 5s so the
-/// requeue path doesn't idle for the prod default of 30s.
+/// guaranteed to own the controller task. The heartbeat timeout drops to the floor so the
+/// requeue path doesn't idle for the prod default of 30s — any lower and the surviving
+/// worker gets evicted too.
 async fn run() -> anyhow::Result<()> {
     let mut cluster = Cluster::builder()
         .cpu_nodes(1)
         .gpu_nodes(1)
-        .worker_heartbeat_timeout_secs(5)
+        .worker_heartbeat_timeout_secs(sp1_cluster_coordinator::MIN_WORKER_HEARTBEAT_TIMEOUT)
         .start()
         .await?;
     let api = cluster.api_client().await?;

--- a/crates/common/src/client.rs
+++ b/crates/common/src/client.rs
@@ -166,6 +166,10 @@ impl ClusterServiceClient {
             let mut client = self.rpc.clone();
             let request = proto::SetClusterComponentInfoRequest {
                 components: components.clone(),
+                // This coordinator doesn't build GPU capacity snapshots yet; the
+                // field is optional on the wire ("absent when the coordinator has
+                // no capacity data to report").
+                capacity: None,
             };
             async move { client.set_cluster_component_info(request).await }
         })

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -1076,6 +1076,7 @@ mod tests {
         let manifest = sp1_cluster_common::proto::ClusterComponentManifest {
             components: vec![],
             updated_at: 0,
+            capacity: None,
         };
         assert!(fresh_manifest_components(manifest, 1_000_000).is_err());
     }
@@ -1087,6 +1088,7 @@ mod tests {
         let manifest = sp1_cluster_common::proto::ClusterComponentManifest {
             components: vec![cluster_entry("coordinator", "coordsha")],
             updated_at: now - MAX_MANIFEST_AGE_SECS - 1,
+            capacity: None,
         };
         assert!(fresh_manifest_components(manifest, now).is_err());
     }
@@ -1100,6 +1102,7 @@ mod tests {
                 cluster_entry("cpu-node", "cpusha"),
             ],
             updated_at: now - 30,
+            capacity: None,
         };
         let components = fresh_manifest_components(manifest, now).unwrap();
         assert_eq!(components.len(), 2);
@@ -1112,6 +1115,7 @@ mod tests {
         let manifest = sp1_cluster_common::proto::ClusterComponentManifest {
             components: vec![cluster_entry("coordinator", "coordsha")],
             updated_at: now + 30,
+            capacity: None,
         };
         assert!(fresh_manifest_components(manifest, now).is_ok());
     }

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -25,7 +25,7 @@ use tonic::Status;
 
 /// Retry policies. Each call site picks one explicitly — no shared default,
 /// so failure semantics can't be inherited silently.
-/// `infinite` for calls that must eventually land (heartbeat, reports).
+/// `infinite` for calls that must eventually land (task reports, close).
 /// `bounded` for calls whose `Err` is a signal the caller acts on.
 mod retry {
     use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
@@ -120,23 +120,17 @@ impl WorkerServiceClient {
         Ok(server_rx)
     }
 
+    /// Single heartbeat attempt — no internal retry. Callers own the cadence;
+    /// a periodic sender should drop a missed beat, not retry a stale one.
+    pub async fn heartbeat_once(&self, request: HeartbeatRequest) -> Result<(), Status> {
+        self.client.clone().heartbeat(request).await.map(|_| ())
+    }
+
     pub async fn close(&self, request: CloseRequest) -> anyhow::Result<()> {
         backoff::future::retry(retry::infinite(), || async {
             self.client
                 .clone()
                 .close(request.clone())
-                .await
-                .map_err(status_to_backoff_error)
-        })
-        .await?;
-        Ok(())
-    }
-
-    pub async fn heartbeat(&self, request: HeartbeatRequest) -> Result<(), Status> {
-        backoff::future::retry(retry::infinite(), || async {
-            self.client
-                .clone()
-                .heartbeat(request.clone())
                 .await
                 .map_err(status_to_backoff_error)
         })

--- a/crates/worker/src/client.rs
+++ b/crates/worker/src/client.rs
@@ -80,6 +80,7 @@ impl WorkerServiceClient {
         let (server_tx, server_rx) = mpsc::unbounded_channel();
 
         // Perform the initial "Open" request
+        let (gpu_name, gpu_memory_total_bytes) = gpu_identity();
         let init_msg = OpenRequest {
             worker_id: self.worker_id.clone(),
             worker_type: self.worker_type as i32,
@@ -91,6 +92,8 @@ impl WorkerServiceClient {
             version: env!("CARGO_PKG_VERSION").to_string(),
             git_sha: crate::VERGEN_GIT_SHA.to_string(),
             image_tag: std::env::var("IMAGE_TAG").unwrap_or_default(),
+            gpu_name,
+            gpu_memory_total_bytes,
         };
         let response = self.client.clone().open(init_msg).await?;
         let mut inbound = response.into_inner();
@@ -670,6 +673,35 @@ async fn drive_message_stream<S, F, Fut>(
         }
         break;
     }
+}
+
+/// GPU identity self-reported in the Open handshake (sp1#2903): device name
+/// (e.g. "NVIDIA L4") and total device memory. Empty values mean "worker does
+/// not report" on the wire, which is what CPU builds send. Query failures also
+/// degrade to empty rather than blocking the handshake: a GPU worker that
+/// can't see its device will fail loudly at task time anyway.
+#[cfg(feature = "gpu")]
+fn gpu_identity() -> (String, u64) {
+    let gpu_name = match sp1_gpu_cudart::cuda_device_name() {
+        Ok(name) => name.to_string(),
+        Err(e) => {
+            tracing::warn!("failed to query CUDA device name for Open request: {e}");
+            String::new()
+        }
+    };
+    let gpu_memory_total_bytes = match sp1_gpu_cudart::cuda_memory_info() {
+        Ok((_free, total)) => total as u64,
+        Err(e) => {
+            tracing::warn!("failed to query CUDA memory info for Open request: {e}");
+            0
+        }
+    };
+    (gpu_name, gpu_memory_total_bytes)
+}
+
+#[cfg(not(feature = "gpu"))]
+fn gpu_identity() -> (String, u64) {
+    (String::new(), 0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Worker heartbeats currently ride the main select loop on the shared tokio runtime, so heavy prover load (long non-yielding polls: splicing, ~240MB chunk serialization) can starve the beat past the coordinator's 30s timeout — a live worker gets declared dead and its in-flight tasks are re-delivered. This is the trigger behind the 2026-07-15 and 07-27 incidents where a redelivered `CoreExecute` wedged proving for 4h (worker e8f297c1… was declared dead with a heartbeat only 35s late while it kept executing). This PR moves liveness onto a dedicated OS thread that load cannot starve.