### PR TITLE
fix: use workspace version for coordinator and node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-coordinator"
-version = "0.1.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8385,7 +8385,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-node"
-version = "0.1.0"
+version = "2.6.0"
 dependencies = [
  "cfg-if",
  "ctrlc",

--- a/bin/coordinator/Cargo.toml
+++ b/bin/coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp1-cluster-coordinator"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp1-cluster-node"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [features]


### PR DESCRIPTION
`bin/coordinator` and `bin/node` were pinned at `version = "0.1.0"` while the workspace sits at `2.6.0`, so the coordinator reported `0.1.0` as its build version in prover component telemetry.