### PR TITLE
fix(redis): atomic chunked upload publish

### DIFF
--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -1154,48 +1154,18 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires Redis at REDIS_URL"]
-    async fn boundary_sizes_and_overwrite() {
-        let inline = Fixture::new("boundary-inline");
-        let inline_data = vec![5; CHUNK_SIZE];
-        inline.upload(&inline_data).await.unwrap();
-        assert_eq!(
-            inline.chunk_fields().await,
-            0,
-            "exactly CHUNK_SIZE goes inline, not chunked"
-        );
-        assert_eq!(inline.download().await, inline_data);
-        inline.delete().await;
-
-        let chunked = Fixture::new("boundary-overwrite");
-        for fill in [6u8, 7] {
-            chunked.upload(&vec![fill; CHUNK_SIZE + 1]).await.unwrap();
-        }
-        assert_eq!(
-            chunked.download().await,
-            vec![7; CHUNK_SIZE + 1],
-            "re-upload replaces via RENAME"
-        );
-        assert_eq!(
-            chunked.chunk_fields().await,
-            2,
-            "CHUNK_SIZE+1 splits into two chunks"
-        );
-        chunked.delete().await;
-    }
-
-    #[tokio::test]
-    #[ignore = "requires Redis at REDIS_URL"]
     async fn overwrite_across_chunk_boundary_evicts_other_representation() {
         let fx = Fixture::new("boundary-crossing");
 
         let chunked_data = vec![8; CHUNK_SIZE + 1];
         fx.upload(&chunked_data).await.unwrap();
-        let inline_data = vec![9; 16];
+        // Exactly CHUNK_SIZE: the largest inline artifact.
+        let inline_data = vec![9; CHUNK_SIZE];
         fx.upload(&inline_data).await.unwrap();
         assert_eq!(
             fx.chunk_fields().await,
             0,
-            "inline upload evicts the chunk hash"
+            "exactly CHUNK_SIZE goes inline and evicts the chunk hash"
         );
         assert_eq!(
             fx.download().await,

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use deadpool_redis::redis::{AsyncCommands, SetExpiry, SetOptions};
 use deadpool_redis::{Config, Connection as RedisConnection, Pool, PoolConfig, Runtime};
+use mti::prelude::{MagicTypeIdExt, V7};
 use sp1_cluster_common::util::backoff_retry;
 use sp1_prover_types::{ArtifactClient, ArtifactId, ArtifactType, ShardPermit};
 use tokio::sync::{Mutex, OnceCell, Semaphore};
@@ -61,6 +62,14 @@ const ADMISSION_MAX_WAIT: Duration = Duration::from_secs(2 * 60);
 /// Throttle for "blocking upload" warn logs while waiting.
 const ADMISSION_LOG_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Per-attempt deadline for one artifact write.
+const TRANSFER_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Staging keys outlive one upload attempt, nothing more: an abandoned attempt
+/// (timeout, crash) reclaims its artifact-sized memory in minutes, not the 6h
+/// retention window. Retention is set on the published key after RENAME.
+const STAGING_TTL_SECONDS: i64 = 2 * TRANSFER_TIMEOUT.as_secs() as i64;
+
 /// FNV-1a hash
 #[inline]
 fn hash_string(s: &str) -> usize {
@@ -73,6 +82,45 @@ fn hash_string(s: &str) -> usize {
 fn get_connection_idx(id: &str, num_redis_nodes: usize) -> usize {
     let hash = hash_string(id);
     hash % num_redis_nodes
+}
+
+#[inline]
+fn chunk_key(id: &str) -> String {
+    format!("{id}:chunks")
+}
+
+/// Fresh per attempt, so concurrent or abandoned uploads of the same artifact
+/// never share staging state.
+#[inline]
+fn staging_chunk_key(id: &str) -> String {
+    format!("{}:{}", chunk_key(id), "stage".create_type_id::<V7>())
+}
+
+/// Marks a failure retryable; whether a retry actually runs is the backoff
+/// policy's budget, not this classification.
+#[inline]
+fn transient(e: impl Into<anyhow::Error>) -> backoff::Error<anyhow::Error> {
+    backoff::Error::transient(e.into())
+}
+
+/// HSET + EXPIRE in one MULTI: HSETEX isn't available on managed Redis, and
+/// atomicity keeps a cancelled task from leaving the hash without its TTL.
+/// One artifact = one hash, so whole-hash TTL ≡ per-field TTL.
+async fn stage_chunk(
+    mut conn: RedisConnection,
+    staging_key: String,
+    chunk_idx: usize,
+    chunk: Vec<u8>,
+) -> Result<()> {
+    deadpool_redis::redis::pipe()
+        .atomic()
+        .hset(&staging_key, chunk_idx, chunk)
+        .ignore()
+        .expire(&staging_key, STAGING_TTL_SECONDS)
+        .ignore()
+        .query_async::<()>(&mut conn)
+        .await?;
+    Ok(())
 }
 
 /// Per-node admission state. Mutex serializes the check-then-reserve;
@@ -336,7 +384,7 @@ impl RedisArtifactClient {
             .await
             .map_err(|e| {
                 tracing::warn!("Failed to get redis connection: {:?}", e);
-                backoff::Error::transient(e.into())
+                transient(e)
             })?;
         Ok(result)
     }
@@ -351,16 +399,13 @@ impl RedisArtifactClient {
         let key = key.to_string();
 
         // Check if it's a hash (chunked) or regular key
-        let total_chunks: usize = conn
-            .hlen(format!("{key}:chunks"))
-            .await
-            .map_err(|e| backoff::Error::transient(e.into()))?;
+        let total_chunks: usize = conn.hlen(chunk_key(&key)).await.map_err(transient)?;
 
         if total_chunks == 0 {
             let result = conn
                 .get::<_, Option<Vec<u8>>>(&key)
                 .await
-                .map_err(|e| backoff::Error::transient(e.into()))?
+                .map_err(transient)?
                 .ok_or_else(|| backoff::Error::permanent(anyhow!("artifact not found: {}", key)))?;
             tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
             return Ok(result);
@@ -377,7 +422,11 @@ impl RedisArtifactClient {
             let id_clone = key.to_string();
             let mut conn = self.get_redis_connection(&id_clone).await?;
             join_set.spawn(async move {
-                let chunk: Vec<u8> = conn.hget(format!("{key}:chunks"), chunk_idx).await?;
+                // An absent field deserializes as an empty Vec, not an error —
+                // Option is the only way to notice the hash vanished mid-read.
+                let chunk: Option<Vec<u8>> = conn.hget(chunk_key(&key), chunk_idx).await?;
+                let chunk = chunk
+                    .ok_or_else(|| anyhow!("chunk {chunk_idx} of artifact {key} disappeared"))?;
                 Ok::<(usize, Vec<u8>), anyhow::Error>((chunk_idx, chunk))
             });
         }
@@ -391,7 +440,7 @@ impl RedisArtifactClient {
         // Collect chunks in order
         let mut chunks = vec![Vec::new(); total_chunks];
         while let Some(res) = join_set.join_next().await {
-            let (idx, chunk) = res.map_err(|e| backoff::Error::transient(e.into()))??;
+            let (idx, chunk) = res.map_err(transient)??;
             tracing::info!(
                 "idx: {}, chunk: {}, elapsed: {:?}",
                 idx,
@@ -413,57 +462,165 @@ impl RedisArtifactClient {
         key: &str,
         serialized: &[u8],
     ) -> Result<(), backoff::Error<anyhow::Error>> {
-        let mut conn = self.get_redis_connection(key).await?;
         let now = std::time::Instant::now();
-        let key = key.to_string();
-        let size = serialized.len();
 
         if serialized.len() <= CHUNK_SIZE {
-            let mut options = SetOptions::default();
-            if !matches!(artifact_type, ArtifactType::Program) {
-                options = options.with_expiration(SetExpiry::EX(*ARTIFACT_TIMEOUT_SECONDS));
-            }
-
-            conn.set_options::<_, _, ()>(key, serialized, options)
-                .await
-                .map_err(|e| backoff::Error::transient(e.into()))?;
+            self.upload_inline(artifact_type, key, serialized).await?;
         } else {
-            drop(conn);
-            let chunks = serialized.chunks(CHUNK_SIZE);
-            let mut join_set = JoinSet::new();
+            self.upload_chunked(artifact_type, key, serialized).await?;
+        }
 
-            // HSET + EXPIRE because HSETEX isn't available on managed Redis.
-            // One artifact = one hash, so whole-hash TTL ≡ per-field TTL.
-            for (chunk_idx, chunk) in chunks.enumerate() {
-                let key = key.clone();
-                let chunk = chunk.to_vec();
-                let mut conn = self.get_redis_connection(&key).await?;
-                join_set.spawn(async move {
-                    let hash_key = format!("{key}:chunks");
-                    let _: usize = conn.hset(&hash_key, chunk_idx, chunk).await?;
-                    if !matches!(artifact_type, ArtifactType::Program) {
-                        let _: bool = conn
-                            .expire(&hash_key, *ARTIFACT_TIMEOUT_SECONDS as i64)
-                            .await?;
-                    }
-                    Ok::<(), anyhow::Error>(())
-                });
-            }
-            tracing::info!("spawned all chunks, elapsed: {:?}", now.elapsed());
+        tracing::info!(
+            "upload took {:?}, size: {}",
+            now.elapsed(),
+            serialized.len()
+        );
+        Ok(())
+    }
 
-            // Wait for all uploads to complete
-            while let Some(res) = join_set.join_next().await {
-                res.map_err(|e| backoff::Error::transient(e.into()))??;
-                tracing::info!("joined chunk, elapsed: {:?}", now.elapsed());
+    /// One SET, with retention baked into the write.
+    async fn upload_inline(
+        &self,
+        artifact_type: ArtifactType,
+        key: &str,
+        serialized: &[u8],
+    ) -> Result<(), backoff::Error<anyhow::Error>> {
+        let mut conn = self.get_redis_connection(key).await?;
+        let mut options = SetOptions::default();
+        if !matches!(artifact_type, ArtifactType::Program) {
+            options = options.with_expiration(SetExpiry::EX(*ARTIFACT_TIMEOUT_SECONDS));
+        }
+        conn.set_options::<_, _, ()>(key, serialized, options)
+            .await
+            .map_err(transient)
+    }
+
+    /// Two-phase write for artifacts above [`CHUNK_SIZE`]: stage every chunk
+    /// under a private key, then publish atomically. Readers can never observe
+    /// a partial artifact at its final key.
+    async fn upload_chunked(
+        &self,
+        artifact_type: ArtifactType,
+        artifact_id: &str,
+        serialized: &[u8],
+    ) -> Result<(), backoff::Error<anyhow::Error>> {
+        let staging_key = staging_chunk_key(artifact_id);
+        let chunk_count = serialized.len().div_ceil(CHUNK_SIZE);
+        self.stage_chunks(artifact_id, &staging_key, serialized)
+            .await?;
+        self.publish_staged(artifact_type, artifact_id, &staging_key, chunk_count)
+            .await
+    }
+
+    /// Write every chunk into the staging hash concurrently; on a failed
+    /// write, reclaim the hash and report the first error. A spawn-path
+    /// failure skips reclaim — the staging TTL covers it.
+    async fn stage_chunks(
+        &self,
+        artifact_id: &str,
+        staging_key: &str,
+        serialized: &[u8],
+    ) -> Result<(), backoff::Error<anyhow::Error>> {
+        let now = std::time::Instant::now();
+        let mut join_set = JoinSet::new();
+
+        for (chunk_idx, chunk) in serialized.chunks(CHUNK_SIZE).enumerate() {
+            let conn = self.get_redis_connection(artifact_id).await?;
+            join_set.spawn(stage_chunk(
+                conn,
+                staging_key.to_string(),
+                chunk_idx,
+                chunk.to_vec(),
+            ));
+        }
+        tracing::info!("spawned all chunks, elapsed: {:?}", now.elapsed());
+
+        // Drain every task before touching the staging key below — exiting
+        // early would let an in-flight HSET recreate it after the unlink.
+        let mut first_error: Option<anyhow::Error> = None;
+        while let Some(joined) = join_set.join_next().await {
+            match joined.unwrap_or_else(|join_error| Err(join_error.into())) {
+                Ok(()) => tracing::info!("joined chunk, elapsed: {:?}", now.elapsed()),
+                Err(error) if first_error.is_some() => {
+                    tracing::warn!("additional chunk failure: {error}")
+                }
+                Err(error) => first_error = Some(error),
             }
         }
 
-        tracing::info!("upload took {:?}, size: {}", now.elapsed(), size);
+        let Some(error) = first_error else {
+            return Ok(());
+        };
+        self.reclaim_staging(artifact_id, staging_key).await;
+        Err(transient(error))
+    }
+
+    /// Best-effort: a missed unlink expires with the staging TTL.
+    async fn reclaim_staging(&self, artifact_id: &str, staging_key: &str) {
+        let Ok(mut conn) = self.get_redis_connection(artifact_id).await else {
+            return;
+        };
+        if let Err(e) = conn.unlink::<_, usize>(staging_key).await {
+            tracing::warn!("failed to unlink staging key {staging_key}: {e}");
+        }
+    }
+
+    /// Publish the staged hash: completeness check, RENAME, retention — one
+    /// server-side script, so even a cancelled client leaves nothing or
+    /// everything.
+    ///
+    /// Split commands would break both guarantees: a crash after RENAME
+    /// leaves the artifact expiring on the staging TTL, and `exists()`-gated
+    /// callers skip the re-upload that would heal it; a hash that lost
+    /// fields must never publish at all. RENAME needs both keys on one node
+    /// — true here (both route by artifact id), impossible on Redis Cluster.
+    async fn publish_staged(
+        &self,
+        artifact_type: ArtifactType,
+        artifact_id: &str,
+        staging_key: &str,
+        chunk_count: usize,
+    ) -> Result<(), backoff::Error<anyhow::Error>> {
+        const PUBLISH_SCRIPT: &str = r"
+            if redis.call('HLEN', KEYS[1]) ~= tonumber(ARGV[1]) then return 0 end
+            redis.call('RENAME', KEYS[1], KEYS[2])
+            if tonumber(ARGV[2]) > 0 then
+                redis.call('EXPIRE', KEYS[2], ARGV[2])
+            else
+                redis.call('PERSIST', KEYS[2])
+            end
+            return 1
+        ";
+
+        let retention_seconds = if matches!(artifact_type, ArtifactType::Program) {
+            0
+        } else {
+            *ARTIFACT_TIMEOUT_SECONDS as i64
+        };
+        let final_key = chunk_key(artifact_id);
+        let mut conn = self.get_redis_connection(artifact_id).await?;
+        let published: i64 = deadpool_redis::redis::cmd("EVAL")
+            .arg(PUBLISH_SCRIPT)
+            .arg(2)
+            .arg(staging_key)
+            .arg(&final_key)
+            .arg(chunk_count)
+            .arg(retention_seconds)
+            .query_async(&mut conn)
+            .await
+            .map_err(transient)?;
+        if published == 0 {
+            // Return this connection before reclaim borrows another from the
+            // same pool — holding both can exhaust it.
+            drop(conn);
+            self.reclaim_staging(artifact_id, staging_key).await;
+            return Err(transient(anyhow!(
+                "staging hash {staging_key} incomplete or missing at publish"
+            )));
+        }
         Ok(())
     }
 }
-
-const TRANSFER_TIMEOUT: Duration = Duration::from_secs(60);
 
 impl RedisArtifactClient {
     /// Admit (block on backpressure), then backoff+timeout the actual write.
@@ -493,7 +650,7 @@ impl RedisArtifactClient {
                         e,
                         artifact_id
                     );
-                    Err(backoff::Error::transient(anyhow!(
+                    Err(transient(anyhow!(
                         "Upload timed out after {:?}",
                         e
                     )))
@@ -573,7 +730,7 @@ impl ArtifactClient for RedisArtifactClient {
                         timeout_duration,
                         artifact_id
                     );
-                    Err(backoff::Error::transient(anyhow!(
+                    Err(transient(anyhow!(
                         "Download timed out after {:?}",
                         timeout_duration
                     )))
@@ -606,9 +763,10 @@ impl ArtifactClient for RedisArtifactClient {
             .map_err(|e| anyhow!(e))?;
         let mut conn2 = conn.clone();
         let key = artifact.id();
-        let (res, chunks) =
-            tokio::try_join!(conn.exists(key), conn2.exists(format!("{key}:chunks")))?;
-        Ok(res || chunks)
+        // A chunk hash only appears at its final key via RENAME of a fully
+        // written staging hash, so its presence alone means complete.
+        let (inline, chunks) = tokio::try_join!(conn.exists(key), conn2.exists(chunk_key(key)))?;
+        Ok(inline || chunks)
     }
 
     async fn delete(&self, artifact: &impl ArtifactId, _: ArtifactType) -> Result<()> {
@@ -618,8 +776,7 @@ impl ArtifactClient for RedisArtifactClient {
             .map_err(|e| anyhow!(e))?;
         let mut conn2 = conn.clone();
         let key = artifact.id();
-        let _: (u64, u64) =
-            tokio::try_join!(conn.unlink(key), conn2.unlink(format!("{key}:chunks")))?;
+        let _: (u64, u64) = tokio::try_join!(conn.unlink(key), conn2.unlink(chunk_key(key)))?;
         Ok(())
     }
 
@@ -635,7 +792,7 @@ impl ArtifactClient for RedisArtifactClient {
             let node_idx = get_connection_idx(artifact.id(), self.connection_pools.len());
             let entry = node_groups.entry(node_idx).or_default();
             entry.push(artifact.id().to_string());
-            entry.push(format!("{}:chunks", artifact.id()));
+            entry.push(chunk_key(artifact.id()));
         }
 
         // Delete from each node in parallel
@@ -667,15 +824,12 @@ impl ArtifactClient for RedisArtifactClient {
             let mut conn = self.get_redis_connection(id).await?;
 
             // Add task_id to the set of references
-            let _: () = conn
-                .sadd(&redis_key, key)
-                .await
-                .map_err(|e| backoff::Error::transient(e.into()))?;
+            let _: () = conn.sadd(&redis_key, key).await.map_err(transient)?;
 
             // Set expiration to prevent memory leaks
             conn.expire::<_, ()>(&redis_key, *ARTIFACT_TIMEOUT_SECONDS as i64)
                 .await
-                .map_err(|e| backoff::Error::transient(e.into()))?;
+                .map_err(transient)?;
 
             Ok(())
         })
@@ -698,22 +852,14 @@ impl ArtifactClient for RedisArtifactClient {
             let redis_key = format!("refs:{artifact_id}");
 
             // Remove task_id from the set
-            let _: () = conn
-                .srem(&redis_key, key)
-                .await
-                .map_err(|e| backoff::Error::transient(e.into()))?;
+            let _: () = conn.srem(&redis_key, key).await.map_err(transient)?;
 
             // Check if set is empty
-            let count: i64 = conn
-                .scard(&redis_key)
-                .await
-                .map_err(|e| backoff::Error::transient(e.into()))?;
+            let count: i64 = conn.scard(&redis_key).await.map_err(transient)?;
 
             if count <= 0 {
                 // Clean up the set key
-                conn.del::<_, ()>(&redis_key)
-                    .await
-                    .map_err(|e| backoff::Error::transient(e.into()))?;
+                conn.del::<_, ()>(&redis_key).await.map_err(transient)?;
 
                 Ok(true) // Should delete
             } else {
@@ -742,5 +888,274 @@ impl crate::CompressedUpload for RedisArtifactClient {
         // Data is already zstd-compressed, write directly to transport layer
         self.upload_to_transport(artifact_type, artifact.id(), &data)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Live-Redis tests, in-file because they exercise private items.
+    //! Run with a local Redis:
+    //! `cargo test -p sp1-cluster-artifact --release -- --ignored --test-threads=1`
+
+    use sp1_prover_types::Artifact;
+
+    use super::*;
+
+    /// One artifact under test: a unique key, its client, and the Redis
+    /// probes the assertions need. Keys are typeid-unique per run, so tests
+    /// neither collide nor need a database reset.
+    struct Fixture {
+        client: RedisArtifactClient,
+        key: String,
+        artifact_type: ArtifactType,
+    }
+
+    impl Fixture {
+        fn new(name: &str) -> Self {
+            let url =
+                std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/".into());
+            Self {
+                client: RedisArtifactClient::new(vec![url], 2),
+                key: name.create_type_id::<V7>().to_string(),
+                artifact_type: ArtifactType::UnspecifiedArtifactType,
+            }
+        }
+
+        fn program(name: &str) -> Self {
+            Self {
+                artifact_type: ArtifactType::Program,
+                ..Self::new(name)
+            }
+        }
+
+        fn artifact(&self) -> Artifact {
+            Artifact::from(self.key.clone())
+        }
+
+        async fn upload(&self, data: &[u8]) -> Result<(), backoff::Error<anyhow::Error>> {
+            self.client
+                .par_upload_file(self.artifact_type, &self.key, data)
+                .await
+        }
+
+        async fn download(&self) -> Vec<u8> {
+            self.client
+                .par_download_file(self.artifact_type, &self.key)
+                .await
+                .unwrap()
+        }
+
+        async fn exists(&self) -> bool {
+            self.client
+                .exists(&self.artifact(), self.artifact_type)
+                .await
+                .unwrap()
+        }
+
+        async fn delete(&self) {
+            self.client
+                .delete(&self.artifact(), self.artifact_type)
+                .await
+                .unwrap();
+        }
+
+        async fn conn(&self) -> RedisConnection {
+            self.client.get_redis_connection(&self.key).await.unwrap()
+        }
+
+        async fn chunk_fields(&self) -> usize {
+            self.conn().await.hlen(chunk_key(&self.key)).await.unwrap()
+        }
+
+        async fn chunk_ttl(&self) -> i64 {
+            self.conn().await.ttl(chunk_key(&self.key)).await.unwrap()
+        }
+
+        /// Staging keys left under this artifact's chunk namespace.
+        async fn staging_keys(&self) -> Vec<String> {
+            self.conn()
+                .await
+                .keys(format!("{}:*", chunk_key(&self.key)))
+                .await
+                .unwrap()
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn chunked_upload_publishes_complete_and_readable() {
+        let fx = Fixture::new("chunked-upload");
+        let data = vec![42; CHUNK_SIZE + 1];
+        fx.upload(&data).await.unwrap();
+
+        assert!(fx.exists().await, "a complete upload must satisfy exists()");
+        assert_eq!(fx.download().await, data);
+        assert_eq!(
+            fx.chunk_fields().await,
+            data.len().div_ceil(CHUNK_SIZE),
+            "the published hash holds chunk fields only"
+        );
+        let ttl = fx.chunk_ttl().await;
+        assert!(
+            ttl > STAGING_TTL_SECONDS,
+            "the published hash must carry retention, not the staging TTL (got {ttl})"
+        );
+        let leftovers = fx.staging_keys().await;
+        assert!(
+            leftovers.is_empty(),
+            "staging keys must not survive publish: {leftovers:?}"
+        );
+
+        fx.delete().await;
+        assert!(!fx.exists().await, "delete must remove the chunk hash");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn chunked_program_upload_persists() {
+        let fx = Fixture::program("chunked-program");
+        fx.upload(&vec![7; CHUNK_SIZE + 1]).await.unwrap();
+
+        assert_eq!(
+            fx.chunk_ttl().await,
+            -1,
+            "program artifacts are retained without expiry"
+        );
+
+        fx.delete().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn concurrent_same_id_uploads_never_mix() {
+        let fx = std::sync::Arc::new(Fixture::new("concurrent-upload"));
+        let mut writers = tokio::task::JoinSet::new();
+        for fill in [1u8, 2, 3, 4] {
+            let fx = fx.clone();
+            writers.spawn(async move { fx.upload(&vec![fill; CHUNK_SIZE + 7]).await });
+        }
+        while let Some(res) = writers.join_next().await {
+            res.unwrap().unwrap();
+        }
+
+        let downloaded = fx.download().await;
+        assert_eq!(downloaded.len(), CHUNK_SIZE + 7);
+        assert!(
+            downloaded.iter().all(|b| *b == downloaded[0]),
+            "the final artifact must be exactly one writer's data, never a mix"
+        );
+        let ttl = fx.chunk_ttl().await;
+        assert!(
+            ttl > STAGING_TTL_SECONDS,
+            "retention must win, got ttl {ttl}"
+        );
+        assert!(fx.staging_keys().await.is_empty());
+
+        fx.delete().await;
+    }
+
+    /// Deterministic companion to the cancellation test: the TTL invariant
+    /// itself, without depending on where a race lands.
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn staged_chunk_always_carries_ttl() {
+        let fx = Fixture::new("staged-chunk-ttl");
+        let staging_key = staging_chunk_key(&fx.key);
+        stage_chunk(fx.conn().await, staging_key.clone(), 0, vec![1, 2, 3])
+            .await
+            .unwrap();
+
+        let mut conn = fx.conn().await;
+        let ttl: i64 = conn.ttl(&staging_key).await.unwrap();
+        assert!(
+            ttl > 0 && ttl <= STAGING_TTL_SECONDS,
+            "every staged chunk write must leave the hash expiring, got ttl {ttl}"
+        );
+        let _: usize = conn.unlink(&staging_key).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn cancelled_upload_leaves_only_expiring_staging() {
+        let fx = Fixture::new("cancelled-upload");
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(5),
+            fx.upload(&vec![9; 2 * CHUNK_SIZE + 1]),
+        )
+        .await;
+        assert!(cancelled.is_err(), "5ms must cancel a 64MB upload");
+
+        assert!(!fx.exists().await, "a cancelled upload must never publish");
+        // Best-effort sweep: the cancel may land before any staging write, so
+        // this loop can be empty — staged_chunk_always_carries_ttl pins the
+        // TTL invariant deterministically.
+        let mut conn = fx.conn().await;
+        for staging_key in fx.staging_keys().await {
+            let ttl: i64 = conn.ttl(&staging_key).await.unwrap();
+            assert!(
+                ttl > 0 && ttl <= STAGING_TTL_SECONDS,
+                "orphaned staging key {staging_key} must carry the staging TTL, got {ttl}"
+            );
+            let _: usize = conn.unlink(&staging_key).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn incomplete_staging_never_publishes() {
+        let fx = Fixture::new("incomplete-staging");
+        let staging_key = staging_chunk_key(&fx.key);
+        let mut conn = fx.conn().await;
+        let _: usize = conn.hset(&staging_key, 0, b"only-chunk").await.unwrap();
+
+        fx.client
+            .publish_staged(
+                ArtifactType::UnspecifiedArtifactType,
+                &fx.key,
+                &staging_key,
+                2,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            !fx.exists().await,
+            "an incomplete staging hash must never publish"
+        );
+        let staging_remains: bool = conn.exists(&staging_key).await.unwrap();
+        assert!(
+            !staging_remains,
+            "a failed publish must reclaim its staging"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn boundary_sizes_and_overwrite() {
+        let inline = Fixture::new("boundary-inline");
+        let inline_data = vec![5; CHUNK_SIZE];
+        inline.upload(&inline_data).await.unwrap();
+        assert_eq!(
+            inline.chunk_fields().await,
+            0,
+            "exactly CHUNK_SIZE goes inline, not chunked"
+        );
+        assert_eq!(inline.download().await, inline_data);
+        inline.delete().await;
+
+        let chunked = Fixture::new("boundary-overwrite");
+        for fill in [6u8, 7] {
+            chunked.upload(&vec![fill; CHUNK_SIZE + 1]).await.unwrap();
+        }
+        assert_eq!(
+            chunked.download().await,
+            vec![7; CHUNK_SIZE + 1],
+            "re-upload replaces via RENAME"
+        );
+        assert_eq!(
+            chunked.chunk_fields().await,
+            2,
+            "CHUNK_SIZE+1 splits into two chunks"
+        );
+        chunked.delete().await;
     }
 }

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -615,10 +615,13 @@ impl RedisArtifactClient {
         const PUBLISH_SCRIPT: &str = r"
             local have = redis.call('HLEN', KEYS[2])
             if have == tonumber(ARGV[1]) then
-                redis.call('UNLINK', KEYS[1])
+                redis.call('UNLINK', KEYS[1], KEYS[3])
                 return 2
             end
-            if redis.call('HLEN', KEYS[1]) ~= tonumber(ARGV[1]) then return 0 end
+            if redis.call('HLEN', KEYS[1]) ~= tonumber(ARGV[1]) then
+                redis.call('UNLINK', KEYS[1])
+                return 0
+            end
             if have > 0 then
                 redis.call('UNLINK', KEYS[2])
             end
@@ -654,10 +657,6 @@ impl RedisArtifactClient {
             2 => tracing::debug!("artifact {artifact_id} already published; kept the first copy"),
             1 => {}
             _ => {
-                // Return this connection before reclaim borrows another from
-                // the same pool — holding both can exhaust it.
-                drop(conn);
-                self.reclaim_staging(artifact_id, staging_key).await;
                 return Err(transient(anyhow!(
                     "staging hash {staging_key} incomplete or missing at publish"
                 )));

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -84,6 +84,13 @@ fn get_connection_idx(id: &str, num_redis_nodes: usize) -> usize {
     hash % num_redis_nodes
 }
 
+/// Hash field holding the chunk count the writer committed to. Its presence
+/// marks a hash as fully published, which no count of data fields can prove:
+/// an interrupted writer that appended straight to the final key leaves a
+/// short hash whose length may still match some other upload's count. Never
+/// collides with a chunk field, which is a decimal index.
+const CHUNK_COUNT_FIELD: &str = "__n";
+
 #[inline]
 fn chunk_key(id: &str) -> String {
     format!("{id}:chunks")
@@ -402,8 +409,17 @@ impl RedisArtifactClient {
         let now = std::time::Instant::now();
         let key = key.to_string();
 
-        // Check if it's a hash (chunked) or regular key
-        let mut total_chunks: usize = conn.hlen(chunk_key(&key)).await.map_err(transient)?;
+        // The declared count is authoritative. Falling back to HLEN reads a
+        // hash an older writer wrote field-by-field into the final key, which
+        // can be short.
+        let declared: Option<usize> = conn
+            .hget(chunk_key(&key), CHUNK_COUNT_FIELD)
+            .await
+            .map_err(transient)?;
+        let mut total_chunks = match declared {
+            Some(n) => n,
+            None => conn.hlen(chunk_key(&key)).await.map_err(transient)?,
+        };
 
         if total_chunks == 0 {
             let inline: Option<Vec<u8>> = conn.get(&key).await.map_err(transient)?;
@@ -411,10 +427,14 @@ impl RedisArtifactClient {
                 tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
                 return Ok(result);
             }
-            // A chunked publish can land between the HLEN and the GET,
+            // A chunked publish can land between the lookup and the GET,
             // evicting the inline value; one re-check separates that race
             // from a genuinely absent artifact.
-            total_chunks = conn.hlen(chunk_key(&key)).await.map_err(transient)?;
+            total_chunks = conn
+                .hget::<_, _, Option<usize>>(chunk_key(&key), CHUNK_COUNT_FIELD)
+                .await
+                .map_err(transient)?
+                .unwrap_or(0);
             if total_chunks == 0 {
                 return Err(backoff::Error::permanent(anyhow!(
                     "artifact not found: {}",
@@ -595,14 +615,13 @@ impl RedisArtifactClient {
     /// complete artifact stuck on the staging TTL, which `exists()`-gated
     /// callers would never re-upload.
     ///
-    /// A complete published hash never changes until delete or expiry;
-    /// readers' non-isolated HLEN + HGETs can see it vanish (loud
-    /// absent-field error) but never mutate. A repeat publish reclaims its
-    /// staging and succeeds. "First writer" means a hash with the expected
-    /// field count — a partial written straight to the final key by an
-    /// earlier code generation is debris and gets replaced, not protected.
-    /// RENAME needs both keys on one node — true here (routed by artifact
-    /// id), impossible on Redis Cluster.
+    /// A published hash never changes until delete or expiry; readers' non-
+    /// isolated lookups can see it vanish (loud absent-field error) but never
+    /// mutate. A repeat publish reclaims its staging and succeeds.
+    /// [`CHUNK_COUNT_FIELD`] is what marks a hash published, so a short hash
+    /// left at the final key by an interrupted older writer is always debris
+    /// and gets replaced, whatever its length. RENAME needs both keys on one
+    /// node — true here (routed by artifact id), impossible on Redis Cluster.
     async fn publish_staged(
         &self,
         artifact_type: ArtifactType,
@@ -613,8 +632,7 @@ impl RedisArtifactClient {
         // UNLINK, never RENAME's implicit delete, frees a replaced value
         // asynchronously; the trailing UNLINK evicts a stale inline twin.
         const PUBLISH_SCRIPT: &str = r"
-            local have = redis.call('HLEN', KEYS[2])
-            if have == tonumber(ARGV[1]) then
+            if redis.call('HEXISTS', KEYS[2], ARGV[3]) == 1 then
                 redis.call('UNLINK', KEYS[1], KEYS[3])
                 return 2
             end
@@ -622,9 +640,8 @@ impl RedisArtifactClient {
                 redis.call('UNLINK', KEYS[1])
                 return 0
             end
-            if have > 0 then
-                redis.call('UNLINK', KEYS[2])
-            end
+            redis.call('HSET', KEYS[1], ARGV[3], ARGV[1])
+            redis.call('UNLINK', KEYS[2])
             redis.call('RENAME', KEYS[1], KEYS[2])
             if tonumber(ARGV[2]) > 0 then
                 redis.call('EXPIRE', KEYS[2], ARGV[2])
@@ -650,6 +667,7 @@ impl RedisArtifactClient {
             .arg(artifact_id)
             .arg(chunk_count)
             .arg(retention_seconds)
+            .arg(CHUNK_COUNT_FIELD)
             .query_async(&mut conn)
             .await
             .map_err(transient)?;
@@ -807,10 +825,14 @@ impl ArtifactClient for RedisArtifactClient {
             .map_err(|e| anyhow!(e))?;
         let mut conn2 = conn.clone();
         let key = artifact.id();
-        // A chunk hash only appears at its final key via RENAME of a fully
-        // written staging hash, so its presence alone means complete.
-        let (inline, chunks) = tokio::try_join!(conn.exists(key), conn2.exists(chunk_key(key)))?;
-        Ok(inline || chunks)
+        // The marker, not the key: a hash an interrupted older writer left at
+        // the final key exists but is short, and reporting it present is what
+        // makes callers skip the re-upload that would repair it.
+        let (inline, published) = tokio::try_join!(
+            conn.exists(key),
+            conn2.hexists(chunk_key(key), CHUNK_COUNT_FIELD)
+        )?;
+        Ok(inline || published)
     }
 
     async fn delete(&self, artifact: &impl ArtifactId, _: ArtifactType) -> Result<()> {
@@ -1011,6 +1033,15 @@ mod tests {
             self.conn().await.hlen(chunk_key(&self.key)).await.unwrap()
         }
 
+        /// The count the publisher committed to, absent on an unpublished hash.
+        async fn declared_chunks(&self) -> Option<usize> {
+            self.conn()
+                .await
+                .hget(chunk_key(&self.key), CHUNK_COUNT_FIELD)
+                .await
+                .unwrap()
+        }
+
         async fn chunk_ttl(&self) -> i64 {
             self.conn().await.ttl(chunk_key(&self.key)).await.unwrap()
         }
@@ -1034,10 +1065,16 @@ mod tests {
 
         assert!(fx.exists().await, "a complete upload must satisfy exists()");
         assert_eq!(fx.download().await, data);
+        let chunks = data.len().div_ceil(CHUNK_SIZE);
+        assert_eq!(
+            fx.declared_chunks().await,
+            Some(chunks),
+            "publish declares the count"
+        );
         assert_eq!(
             fx.chunk_fields().await,
-            data.len().div_ceil(CHUNK_SIZE),
-            "the published hash holds chunk fields only"
+            chunks + 1,
+            "the published hash holds the chunks plus the count marker"
         );
         let ttl = fx.chunk_ttl().await;
         assert!(
@@ -1176,20 +1213,28 @@ mod tests {
     #[ignore = "requires Redis at REDIS_URL"]
     async fn partial_debris_at_final_key_is_repaired() {
         let fx = Fixture::new("debris-repair");
+        let data = vec![3; CHUNK_SIZE + 1];
+        let chunks = data.len().div_ceil(CHUNK_SIZE);
+
+        // Field count matching the incoming upload's: the case a length check
+        // alone cannot tell apart from a complete hash.
         let mut conn = fx.conn().await;
-        let _: usize = conn
-            .hset(chunk_key(&fx.key), 0, b"old-writer partial")
-            .await
-            .unwrap();
+        for idx in 0..chunks {
+            let _: usize = conn
+                .hset(chunk_key(&fx.key), idx, b"old-writer partial")
+                .await
+                .unwrap();
+        }
+        assert!(!fx.exists().await, "an unmarked hash is not published");
         drop(conn);
 
-        let data = vec![3; CHUNK_SIZE + 1];
         fx.upload(&data).await.unwrap();
         assert_eq!(
             fx.download().await,
             data,
-            "an incomplete hash is debris, not a protected first writer"
+            "debris is replaced, never adopted as the first writer"
         );
+        assert_eq!(fx.declared_chunks().await, Some(chunks));
 
         fx.delete().await;
     }

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -13,7 +13,21 @@ use tokio::sync::{Mutex, OnceCell, Semaphore};
 use tokio::task::JoinSet;
 use tracing::{instrument, Instrument};
 
-const CHUNK_SIZE: usize = 32 * 1024 * 1024;
+/// Values above this go into a chunk hash instead of one Redis string.
+/// Override via `ARTIFACT_CHUNK_SIZE_BYTES`, which lets a test environment
+/// reach the chunked path on workloads whose artifacts never approach the
+/// default.
+const DEFAULT_CHUNK_SIZE: usize = 32 * 1024 * 1024;
+
+/// Resolved once; a zero or unparseable override falls back to the default,
+/// since a zero chunk size would split every artifact into empty fields.
+static CHUNK_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("ARTIFACT_CHUNK_SIZE_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_CHUNK_SIZE)
+});
 
 /// Default Redis artifact retention. Override via `ARTIFACT_TIMEOUT_SECONDS`.
 ///
@@ -500,7 +514,7 @@ impl RedisArtifactClient {
     ) -> Result<(), backoff::Error<anyhow::Error>> {
         let now = std::time::Instant::now();
 
-        if serialized.len() <= CHUNK_SIZE {
+        if serialized.len() <= *CHUNK_SIZE {
             self.upload_inline(artifact_type, key, serialized).await?;
         } else {
             self.upload_chunked(artifact_type, key, serialized).await?;
@@ -549,7 +563,7 @@ impl RedisArtifactClient {
         serialized: &[u8],
     ) -> Result<(), backoff::Error<anyhow::Error>> {
         let staging_key = staging_chunk_key(artifact_id);
-        let chunk_count = serialized.len().div_ceil(CHUNK_SIZE);
+        let chunk_count = serialized.len().div_ceil(*CHUNK_SIZE);
         self.stage_chunks(artifact_id, &staging_key, serialized)
             .await?;
         self.publish_staged(artifact_type, artifact_id, &staging_key, chunk_count)
@@ -568,7 +582,7 @@ impl RedisArtifactClient {
         let now = std::time::Instant::now();
         let mut join_set = JoinSet::new();
 
-        for (chunk_idx, chunk) in serialized.chunks(CHUNK_SIZE).enumerate() {
+        for (chunk_idx, chunk) in serialized.chunks(*CHUNK_SIZE).enumerate() {
             let conn = self.get_redis_connection(artifact_id).await?;
             join_set.spawn(stage_chunk(
                 conn,
@@ -1060,12 +1074,12 @@ mod tests {
     #[ignore = "requires Redis at REDIS_URL"]
     async fn chunked_upload_publishes_complete_and_readable() {
         let fx = Fixture::new("chunked-upload");
-        let data = vec![42; CHUNK_SIZE + 1];
+        let data = vec![42; *CHUNK_SIZE + 1];
         fx.upload(&data).await.unwrap();
 
         assert!(fx.exists().await, "a complete upload must satisfy exists()");
         assert_eq!(fx.download().await, data);
-        let chunks = data.len().div_ceil(CHUNK_SIZE);
+        let chunks = data.len().div_ceil(*CHUNK_SIZE);
         assert_eq!(
             fx.declared_chunks().await,
             Some(chunks),
@@ -1095,7 +1109,7 @@ mod tests {
     #[ignore = "requires Redis at REDIS_URL"]
     async fn chunked_program_upload_persists() {
         let fx = Fixture::program("chunked-program");
-        fx.upload(&vec![7; CHUNK_SIZE + 1]).await.unwrap();
+        fx.upload(&vec![7; *CHUNK_SIZE + 1]).await.unwrap();
 
         assert_eq!(
             fx.chunk_ttl().await,
@@ -1113,14 +1127,14 @@ mod tests {
         let mut writers = tokio::task::JoinSet::new();
         for fill in [1u8, 2, 3, 4] {
             let fx = fx.clone();
-            writers.spawn(async move { fx.upload(&vec![fill; CHUNK_SIZE + 7]).await });
+            writers.spawn(async move { fx.upload(&vec![fill; *CHUNK_SIZE + 7]).await });
         }
         while let Some(res) = writers.join_next().await {
             res.unwrap().unwrap();
         }
 
         let downloaded = fx.download().await;
-        assert_eq!(downloaded.len(), CHUNK_SIZE + 7);
+        assert_eq!(downloaded.len(), *CHUNK_SIZE + 7);
         assert!(
             downloaded.iter().all(|b| *b == downloaded[0]),
             "the final artifact must be exactly one writer's data, never a mix"
@@ -1161,7 +1175,7 @@ mod tests {
         let fx = Fixture::new("cancelled-upload");
         let cancelled = tokio::time::timeout(
             Duration::from_millis(5),
-            fx.upload(&vec![9; 2 * CHUNK_SIZE + 1]),
+            fx.upload(&vec![9; 2 * *CHUNK_SIZE + 1]),
         )
         .await;
         assert!(cancelled.is_err(), "5ms must cancel a 64MB upload");
@@ -1213,8 +1227,8 @@ mod tests {
     #[ignore = "requires Redis at REDIS_URL"]
     async fn partial_debris_at_final_key_is_repaired() {
         let fx = Fixture::new("debris-repair");
-        let data = vec![3; CHUNK_SIZE + 1];
-        let chunks = data.len().div_ceil(CHUNK_SIZE);
+        let data = vec![3; *CHUNK_SIZE + 1];
+        let chunks = data.len().div_ceil(*CHUNK_SIZE);
 
         // Field count matching the incoming upload's: the case a length check
         // alone cannot tell apart from a complete hash.
@@ -1243,9 +1257,9 @@ mod tests {
     #[ignore = "requires Redis at REDIS_URL"]
     async fn published_hash_is_immutable() {
         let fx = Fixture::new("first-writer");
-        let first = vec![1; CHUNK_SIZE + 1];
+        let first = vec![1; *CHUNK_SIZE + 1];
         fx.upload(&first).await.unwrap();
-        fx.upload(&vec![2; CHUNK_SIZE + 1]).await.unwrap();
+        fx.upload(&vec![2; *CHUNK_SIZE + 1]).await.unwrap();
 
         assert_eq!(
             fx.download().await,
@@ -1265,10 +1279,10 @@ mod tests {
     async fn overwrite_across_chunk_boundary_evicts_other_representation() {
         let fx = Fixture::new("boundary-crossing");
 
-        let chunked_data = vec![8; CHUNK_SIZE + 1];
+        let chunked_data = vec![8; *CHUNK_SIZE + 1];
         fx.upload(&chunked_data).await.unwrap();
         // Exactly CHUNK_SIZE: the largest inline artifact.
-        let inline_data = vec![9; CHUNK_SIZE];
+        let inline_data = vec![9; *CHUNK_SIZE];
         fx.upload(&inline_data).await.unwrap();
         assert_eq!(
             fx.chunk_fields().await,

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -403,16 +403,24 @@ impl RedisArtifactClient {
         let key = key.to_string();
 
         // Check if it's a hash (chunked) or regular key
-        let total_chunks: usize = conn.hlen(chunk_key(&key)).await.map_err(transient)?;
+        let mut total_chunks: usize = conn.hlen(chunk_key(&key)).await.map_err(transient)?;
 
         if total_chunks == 0 {
-            let result = conn
-                .get::<_, Option<Vec<u8>>>(&key)
-                .await
-                .map_err(transient)?
-                .ok_or_else(|| backoff::Error::permanent(anyhow!("artifact not found: {}", key)))?;
-            tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
-            return Ok(result);
+            let inline: Option<Vec<u8>> = conn.get(&key).await.map_err(transient)?;
+            if let Some(result) = inline {
+                tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
+                return Ok(result);
+            }
+            // A chunked publish can land between the HLEN and the GET,
+            // evicting the inline value; one re-check separates that race
+            // from a genuinely absent artifact.
+            total_chunks = conn.hlen(chunk_key(&key)).await.map_err(transient)?;
+            if total_chunks == 0 {
+                return Err(backoff::Error::permanent(anyhow!(
+                    "artifact not found: {}",
+                    key
+                )));
+            }
         }
         // Return this connection before the chunk loop borrows more from the
         // same pool — holding it across those acquisitions can wedge a
@@ -587,9 +595,12 @@ impl RedisArtifactClient {
     /// complete artifact stuck on the staging TTL, which `exists()`-gated
     /// callers would never re-upload.
     ///
-    /// A published hash never changes until delete or expiry; readers' non-
-    /// isolated HLEN + HGETs can see it vanish (loud absent-field error) but
-    /// never mutate. A repeat publish reclaims its staging and succeeds.
+    /// A complete published hash never changes until delete or expiry;
+    /// readers' non-isolated HLEN + HGETs can see it vanish (loud
+    /// absent-field error) but never mutate. A repeat publish reclaims its
+    /// staging and succeeds. "First writer" means a hash with the expected
+    /// field count — a partial written straight to the final key by an
+    /// earlier code generation is debris and gets replaced, not protected.
     /// RENAME needs both keys on one node — true here (routed by artifact
     /// id), impossible on Redis Cluster.
     async fn publish_staged(
@@ -599,15 +610,18 @@ impl RedisArtifactClient {
         staging_key: &str,
         chunk_count: usize,
     ) -> Result<(), backoff::Error<anyhow::Error>> {
-        // The first-writer guard keeps RENAME from replacing a hash (no
-        // synchronous large-value delete inside the script); the trailing
-        // UNLINK evicts a stale inline twin.
+        // UNLINK, never RENAME's implicit delete, frees a replaced value
+        // asynchronously; the trailing UNLINK evicts a stale inline twin.
         const PUBLISH_SCRIPT: &str = r"
-            if redis.call('EXISTS', KEYS[2]) == 1 then
+            local have = redis.call('HLEN', KEYS[2])
+            if have == tonumber(ARGV[1]) then
                 redis.call('UNLINK', KEYS[1])
                 return 2
             end
             if redis.call('HLEN', KEYS[1]) ~= tonumber(ARGV[1]) then return 0 end
+            if have > 0 then
+                redis.call('UNLINK', KEYS[2])
+            end
             redis.call('RENAME', KEYS[1], KEYS[2])
             if tonumber(ARGV[2]) > 0 then
                 redis.call('EXPIRE', KEYS[2], ARGV[2])
@@ -1157,6 +1171,28 @@ mod tests {
             !staging_remains,
             "a failed publish must reclaim its staging"
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn partial_debris_at_final_key_is_repaired() {
+        let fx = Fixture::new("debris-repair");
+        let mut conn = fx.conn().await;
+        let _: usize = conn
+            .hset(chunk_key(&fx.key), 0, b"old-writer partial")
+            .await
+            .unwrap();
+        drop(conn);
+
+        let data = vec![3; CHUNK_SIZE + 1];
+        fx.upload(&data).await.unwrap();
+        assert_eq!(
+            fx.download().await,
+            data,
+            "an incomplete hash is debris, not a protected first writer"
+        );
+
+        fx.delete().await;
     }
 
     #[tokio::test]

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -389,11 +389,10 @@ impl RedisArtifactClient {
         Ok(result)
     }
 
-    /// Chunked reads are not isolated: HLEN and the HGETs are separate
-    /// commands, so a concurrent same-id republish can interleave. Artifact
-    /// ids are content-addressed — a replacement carries identical bytes —
-    /// and a torn read of unequal generations fails loudly downstream at
-    /// zstd decode.
+    /// Chunked reads are not isolated — HLEN and the HGETs are separate
+    /// commands — but a published hash is immutable (first writer wins in
+    /// `publish_staged`), so the hash under a reader can only vanish, never
+    /// change. A vanished hash surfaces as a loud absent-field error.
     async fn par_download_file(
         &self,
         _: ArtifactType,
@@ -582,15 +581,17 @@ impl RedisArtifactClient {
         }
     }
 
-    /// Publish the staged hash: completeness check, RENAME, retention — one
-    /// server-side script, so even a cancelled client leaves nothing or
-    /// everything.
+    /// Publish the staged hash in one server-side script: first-writer
+    /// guard, completeness check, RENAME, retention. A cancelled client
+    /// leaves nothing or everything — split commands could publish a
+    /// complete artifact stuck on the staging TTL, which `exists()`-gated
+    /// callers would never re-upload.
     ///
-    /// Split commands would break both guarantees: a crash after RENAME
-    /// leaves the artifact expiring on the staging TTL, and `exists()`-gated
-    /// callers skip the re-upload that would heal it; a hash that lost
-    /// fields must never publish at all. RENAME needs both keys on one node
-    /// — true here (both route by artifact id), impossible on Redis Cluster.
+    /// A published hash never changes until delete or expiry; readers' non-
+    /// isolated HLEN + HGETs can see it vanish (loud absent-field error) but
+    /// never mutate. A repeat publish reclaims its staging and succeeds.
+    /// RENAME needs both keys on one node — true here (routed by artifact
+    /// id), impossible on Redis Cluster.
     async fn publish_staged(
         &self,
         artifact_type: ArtifactType,
@@ -598,13 +599,15 @@ impl RedisArtifactClient {
         staging_key: &str,
         chunk_count: usize,
     ) -> Result<(), backoff::Error<anyhow::Error>> {
-        // UNLINK, not RENAME's implicit delete: replacing a large hash would
-        // otherwise free it synchronously inside the script, stalling the
-        // node. The trailing UNLINK evicts a stale inline value so the two
-        // representations never coexist.
+        // The first-writer guard keeps RENAME from replacing a hash (no
+        // synchronous large-value delete inside the script); the trailing
+        // UNLINK evicts a stale inline twin.
         const PUBLISH_SCRIPT: &str = r"
+            if redis.call('EXISTS', KEYS[2]) == 1 then
+                redis.call('UNLINK', KEYS[1])
+                return 2
+            end
             if redis.call('HLEN', KEYS[1]) ~= tonumber(ARGV[1]) then return 0 end
-            redis.call('UNLINK', KEYS[2])
             redis.call('RENAME', KEYS[1], KEYS[2])
             if tonumber(ARGV[2]) > 0 then
                 redis.call('EXPIRE', KEYS[2], ARGV[2])
@@ -633,14 +636,18 @@ impl RedisArtifactClient {
             .query_async(&mut conn)
             .await
             .map_err(transient)?;
-        if published == 0 {
-            // Return this connection before reclaim borrows another from the
-            // same pool — holding both can exhaust it.
-            drop(conn);
-            self.reclaim_staging(artifact_id, staging_key).await;
-            return Err(transient(anyhow!(
-                "staging hash {staging_key} incomplete or missing at publish"
-            )));
+        match published {
+            2 => tracing::debug!("artifact {artifact_id} already published; kept the first copy"),
+            1 => {}
+            _ => {
+                // Return this connection before reclaim borrows another from
+                // the same pool — holding both can exhaust it.
+                drop(conn);
+                self.reclaim_staging(artifact_id, staging_key).await;
+                return Err(transient(anyhow!(
+                    "staging hash {staging_key} incomplete or missing at publish"
+                )));
+            }
         }
         Ok(())
     }
@@ -1150,6 +1157,27 @@ mod tests {
             !staging_remains,
             "a failed publish must reclaim its staging"
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn published_hash_is_immutable() {
+        let fx = Fixture::new("first-writer");
+        let first = vec![1; CHUNK_SIZE + 1];
+        fx.upload(&first).await.unwrap();
+        fx.upload(&vec![2; CHUNK_SIZE + 1]).await.unwrap();
+
+        assert_eq!(
+            fx.download().await,
+            first,
+            "a repeat publish keeps the first copy"
+        );
+        assert!(
+            fx.staging_keys().await.is_empty(),
+            "a repeat publish reclaims its staging"
+        );
+
+        fx.delete().await;
     }
 
     #[tokio::test]

--- a/crates/artifact/src/redis.rs
+++ b/crates/artifact/src/redis.rs
@@ -389,6 +389,11 @@ impl RedisArtifactClient {
         Ok(result)
     }
 
+    /// Chunked reads are not isolated: HLEN and the HGETs are separate
+    /// commands, so a concurrent same-id republish can interleave. Artifact
+    /// ids are content-addressed — a replacement carries identical bytes —
+    /// and a torn read of unequal generations fails loudly downstream at
+    /// zstd decode.
     async fn par_download_file(
         &self,
         _: ArtifactType,
@@ -410,6 +415,10 @@ impl RedisArtifactClient {
             tracing::info!("download took {:?}, size: {}", now.elapsed(), result.len());
             return Ok(result);
         }
+        // Return this connection before the chunk loop borrows more from the
+        // same pool — holding it across those acquisitions can wedge a
+        // saturated pool.
+        drop(conn);
 
         // Get total chunks
         let mut result = Vec::new();
@@ -478,7 +487,9 @@ impl RedisArtifactClient {
         Ok(())
     }
 
-    /// One SET, with retention baked into the write.
+    /// One SET, with retention baked into the write. The UNLINK evicts a
+    /// stale chunked copy — readers prefer the chunk hash, so leaving one
+    /// behind would shadow this write.
     async fn upload_inline(
         &self,
         artifact_type: ArtifactType,
@@ -490,7 +501,13 @@ impl RedisArtifactClient {
         if !matches!(artifact_type, ArtifactType::Program) {
             options = options.with_expiration(SetExpiry::EX(*ARTIFACT_TIMEOUT_SECONDS));
         }
-        conn.set_options::<_, _, ()>(key, serialized, options)
+        deadpool_redis::redis::pipe()
+            .atomic()
+            .set_options(key, serialized, options)
+            .ignore()
+            .unlink(chunk_key(key))
+            .ignore()
+            .query_async::<()>(&mut conn)
             .await
             .map_err(transient)
     }
@@ -581,14 +598,20 @@ impl RedisArtifactClient {
         staging_key: &str,
         chunk_count: usize,
     ) -> Result<(), backoff::Error<anyhow::Error>> {
+        // UNLINK, not RENAME's implicit delete: replacing a large hash would
+        // otherwise free it synchronously inside the script, stalling the
+        // node. The trailing UNLINK evicts a stale inline value so the two
+        // representations never coexist.
         const PUBLISH_SCRIPT: &str = r"
             if redis.call('HLEN', KEYS[1]) ~= tonumber(ARGV[1]) then return 0 end
+            redis.call('UNLINK', KEYS[2])
             redis.call('RENAME', KEYS[1], KEYS[2])
             if tonumber(ARGV[2]) > 0 then
                 redis.call('EXPIRE', KEYS[2], ARGV[2])
             else
                 redis.call('PERSIST', KEYS[2])
             end
+            redis.call('UNLINK', KEYS[3])
             return 1
         ";
 
@@ -601,9 +624,10 @@ impl RedisArtifactClient {
         let mut conn = self.get_redis_connection(artifact_id).await?;
         let published: i64 = deadpool_redis::redis::cmd("EVAL")
             .arg(PUBLISH_SCRIPT)
-            .arg(2)
+            .arg(3)
             .arg(staging_key)
             .arg(&final_key)
+            .arg(artifact_id)
             .arg(chunk_count)
             .arg(retention_seconds)
             .query_async(&mut conn)
@@ -1157,5 +1181,41 @@ mod tests {
             "CHUNK_SIZE+1 splits into two chunks"
         );
         chunked.delete().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis at REDIS_URL"]
+    async fn overwrite_across_chunk_boundary_evicts_other_representation() {
+        let fx = Fixture::new("boundary-crossing");
+
+        let chunked_data = vec![8; CHUNK_SIZE + 1];
+        fx.upload(&chunked_data).await.unwrap();
+        let inline_data = vec![9; 16];
+        fx.upload(&inline_data).await.unwrap();
+        assert_eq!(
+            fx.chunk_fields().await,
+            0,
+            "inline upload evicts the chunk hash"
+        );
+        assert_eq!(
+            fx.download().await,
+            inline_data,
+            "chunked→inline serves the inline value"
+        );
+
+        fx.upload(&chunked_data).await.unwrap();
+        assert_eq!(
+            fx.download().await,
+            chunked_data,
+            "inline→chunked serves the chunk hash"
+        );
+        // Acquired after download: holding a fixture connection across it
+        // starves the pool of 2.
+        let mut conn = fx.conn().await;
+        let inline_remains: bool = conn.exists(&fx.key).await.unwrap();
+        assert!(!inline_remains, "chunked publish evicts the inline value");
+        drop(conn);
+
+        fx.delete().await;
     }
 }


### PR DESCRIPTION
## Problem

Chunked uploads (>32 MB) wrote their pieces straight into the final key. Between the first chunk and the last, the key exists but the data is incomplete — and nothing could tell the difference. `exists()` said true, so the gateway warm-cache and redelivery recovery (#165) skipped the upload that would have fixed it. Readers got silently truncated bytes, since missing chunk fields come back as empty rather than an error.

## Change

Chunks now stage under a per-attempt key, then one Lua script publishes them: check complete, rename, set retention. Cancel the client anywhere and you get nothing or everything.

The published hash carries `__n`, the chunk count its writer committed to. That's what marks it complete — a field count can't, since a half-finished writer's hash might coincidentally have the right number of pieces. Anything carrying `__n` is never replaced, so a hash can't change under a reader mid-download.