### PR TITLE
fix: treat duplicate proof create as scheduled

### DIFF
--- a/bin/api/src/service.rs
+++ b/bin/api/src/service.rs
@@ -126,8 +126,17 @@ impl ClusterService for ClusterServiceImpl {
                 Ok(Response::new(()))
             }
             Err(e) => {
-                error!("Failed to create proof request: {:?}", e);
-                Err(Status::internal("Failed to create proof request"))
+                // A duplicate insert means the request is already scheduled, so
+                // callers can treat it as success rather than a real failure.
+                if e.as_database_error()
+                    .is_some_and(|db| db.is_unique_violation())
+                {
+                    info!("Proof request already exists: {}", req.proof_id);
+                    Err(Status::already_exists("proof request already exists"))
+                } else {
+                    error!("Failed to create proof request: {:?}", e);
+                    Err(Status::internal("Failed to create proof request"))
+                }
             }
         }
     }

--- a/bin/network-gateway/src/service/prover_network.rs
+++ b/bin/network-gateway/src/service/prover_network.rs
@@ -235,10 +235,18 @@ where
             scheduled_by: None,
             stdin_private: body.stdin_private,
         };
-        self.cluster
-            .create_proof_request(create)
-            .await
-            .map_err(|e| Status::internal(format!("cluster create_proof_request failed: {e}")))?;
+        if let Err(e) = self.cluster.create_proof_request(create).await {
+            // The id is minted in this call, so an existing row can only be an
+            // earlier attempt of this call that committed but timed out client-side.
+            let own_committed_attempt = e
+                .downcast_ref::<tonic::Status>()
+                .is_some_and(|s| s.code() == tonic::Code::AlreadyExists);
+            if !own_committed_attempt {
+                return Err(Status::internal(format!(
+                    "cluster create_proof_request failed: {e}"
+                )));
+            }
+        }
 
         info!(
             proof_id,

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -734,10 +734,17 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                     hex::encode(request.requester()),
                 );
                 match self_clone.schedule_request(request).await {
-                    Ok(_) => {
+                    Ok(ScheduleOutcome::Created) => {
                         info!("scheduled request 0x{}", request_id_hex);
                         self_clone.metrics.requests_scheduled.increment(1);
                         self_clone.metrics.total_requests_processed.increment(1);
+                    }
+                    Ok(ScheduleOutcome::AlreadyInCluster) => {
+                        info!(
+                            "request 0x{} already in cluster (create raced dedup list)",
+                            request_id_hex
+                        );
+                        self_clone.metrics.requests_already_in_cluster.increment(1);
                     }
                     Err(e) => {
                         error!("failed to schedule request 0x{}: {:?}", request_id_hex, e);
@@ -845,7 +852,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
     async fn schedule_request(
         &self,
         request: <N as FulfillmentNetwork>::NetworkRequest,
-    ) -> Result<()> {
+    ) -> Result<ScheduleOutcome> {
         use crate::network::NetworkRequest;
         let request_id = request.request_id();
         let program_artifact_id = extract_artifact_name(request.program_uri())?;
@@ -883,7 +890,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         }
 
         // Schedule the request to start proving.
-        self.cluster
+        match self
+            .cluster
             .create_proof_request(ProofRequestCreateRequest {
                 proof_id: request_id,
                 program_artifact_id,
@@ -897,11 +905,26 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                 scheduled_by: self.name.clone(),
                 stdin_private: request.stdin_private(),
             })
-            .map_err(|e| anyhow!("failed to create proof request: {}", e))
-            .await?;
-
-        Ok(())
+            .await
+        {
+            Ok(()) => Ok(ScheduleOutcome::Created),
+            Err(e)
+                if e.downcast_ref::<tonic::Status>()
+                    .is_some_and(|s| s.code() == tonic::Code::AlreadyExists) =>
+            {
+                Ok(ScheduleOutcome::AlreadyInCluster)
+            }
+            Err(e) => Err(anyhow!("failed to create proof request: {}", e)),
+        }
     }
+}
+
+/// Outcome of scheduling one request in the cluster.
+enum ScheduleOutcome {
+    Created,
+    /// The row already existed — the create raced the LIMIT-1000 dedup list.
+    /// The request is being handled; nothing was scheduled by this attempt.
+    AlreadyInCluster,
 }
 
 #[must_use]

--- a/crates/fulfillment/src/metrics.rs
+++ b/crates/fulfillment/src/metrics.rs
@@ -25,6 +25,10 @@ pub struct FulfillerMetrics {
     /// The number of proof request schedule attempts that failed.
     pub request_schedule_failures: Counter,
 
+    /// The number of schedule attempts that found the request already in the
+    /// cluster. Nonzero means the dedup list is missing live rows.
+    pub requests_already_in_cluster: Counter,
+
     /// The number of proof request cancellations.
     pub requests_cancelled: Counter,
 


### PR DESCRIPTION
When a cluster holds more live rows than the scheduler's `proof_request_list(limit=1000)` snapshot returns, an existing request goes invisible to the dedup check and gets re-created. The API reported that duplicate insert as `Internal`, which
`crates/common/src/util.rs` classifies as transient — so the client retried an insert that had already succeeded, about once a second for as long as the request stayed in flight. Nothing broke; the requests completed normally. The error volume just made a real scheduling failure hard to see.

A unique violation now returns `AlreadyExists`, which that classifier already treats as permanent. `schedule_request` returns `ScheduleOutcome::{Created, AlreadyInCluster}` so a duplicate counts as success without inflating `requests_scheduled`, and `requests_already_in_cluster` replaces the error log as the signal that the snapshot is
truncating. The network-gateway gets the same handling for its own timed-out-but-committed attempt.