### PR TITLE
fix(tasks): never lose or downgrade a completion

### DIFF
--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -1301,7 +1301,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         // Handle manual proof failure.
         if manual_proof_fail {
             tracing::info!("Proof {} controller has no more retries, failing", proof_id);
-            // The reporting pair's release belongs to this function's tail below.
+            // The reporting pair's release belongs to this function's tail.
             self.fail_proof_internal(
                 &mut state,
                 proof_id.clone(),
@@ -3724,8 +3724,7 @@ mod tests {
     }
 
     /// A fatal controller failure tears the proof down mid-`fail_task`; the
-    /// reporting pair's release belongs to `fail_task`'s own tail, not to the
-    /// teardown sweep.
+    /// reporting pair's release belongs to the tail, not the teardown sweep.
     #[tokio::test]
     async fn manual_proof_fail_releases_the_reporting_task_once() {
         let c = Arc::new(Coordinator::<CountingPolicy>::new());

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -660,12 +660,12 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             // Drop task here so we can borrow proof as mutable again.
             if !already_succeeded {
                 P::post_task_success_update_proof(proof, &task_extra, metadata);
+                P::post_task_success_update_state(&mut state, task_type);
             }
-            // Drop proof here so we can borrow state as mutable again.
 
             // Cleanup proof if there's no more active tasks. Drop it after state is released.
             let mut released_assignments = false;
-            let removed = if proof.active_tasks == 0 {
+            let removed = if remaining_tasks == 0 {
                 tracing::info!("Proof {} has no more active tasks, removing", proof_id);
                 P::on_proof_deleted(&mut state, &proof_id);
                 let removed = state.proofs.remove(&proof_id);
@@ -682,10 +682,6 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             } else {
                 None
             };
-
-            if !already_succeeded {
-                P::post_task_success_update_state(&mut state, task_type);
-            }
 
             // Policy weight is charged when a worker takes the task and released when it
             // gives it up. A completion from a worker that no longer holds it — preempted,

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -669,15 +669,24 @@ impl<P: AssignmentPolicy> Coordinator<P> {
 
             P::post_task_success_update_state(&mut state, task_type);
 
-            P::post_task_update_state(
-                &mut state,
-                proof_extra,
-                &task_id,
-                task_extra,
-                task_weight,
-                &proof_id,
-                task_type,
-            );
+            // Policy weight is charged when a worker takes the task and released when it
+            // gives it up. A completion from a worker that no longer holds it — preempted,
+            // or superseded by a redelivery — was already released by whoever took it.
+            let still_owned = state.workers.get(&worker_id).is_some_and(|w| {
+                w.active_tasks
+                    .contains(&(proof_id.clone(), task_id.clone()))
+            });
+            if still_owned {
+                P::post_task_update_state(
+                    &mut state,
+                    proof_extra,
+                    &task_id,
+                    task_extra,
+                    task_weight,
+                    &proof_id,
+                    task_type,
+                );
+            }
 
             tracing::debug!(
                 "Complete task {} for proof {}, {} tasks remaining",
@@ -1086,7 +1095,8 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         }
     }
 
-    /// Mark a task as failed.
+    /// Mark a task as failed. A task already recorded as succeeded keeps its status
+    /// and only releases its worker slot.
     pub async fn fail_task(
         self: &Arc<Self>,
         worker_id: String,
@@ -1123,6 +1133,39 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             return Err(Status::not_found(format!("task {task_id} not found")));
         };
 
+        // A success already recorded is final. Delivery is at-least-once, so a second
+        // execution of a finished task can report failure afterwards — typically because
+        // it found inputs the first execution had already reclaimed.
+        if task.status == TaskStatus::Succeeded {
+            let task_weight = task.data.weight;
+            let task_type = task.data.task_type();
+            let task_extra = task.extra.clone();
+            let proof_extra = proof.extra.clone();
+            tracing::warn!("Ignoring failure for already-succeeded task {}", task_id);
+            // The task really did finish, so release it the way a completion would.
+            P::post_task_update_state(
+                &mut state,
+                proof_extra,
+                &task_id,
+                task_extra,
+                task_weight,
+                &proof_id,
+                task_type,
+            );
+            if let Some(worker) = state.workers.get_mut(&worker_id) {
+                worker
+                    .active_tasks
+                    .remove(&(proof_id.clone(), task_id.clone()));
+                worker.weight = worker.weight.saturating_sub(task_weight);
+                if worker.active_tasks.is_empty() {
+                    let worker = worker.clone();
+                    let updated = P::post_worker_empty(&mut state, worker);
+                    state.workers.insert(worker_id, updated);
+                }
+            }
+            return self.assign_tasks(state).await;
+        }
+
         // If it's a controller task and we won't retry it, we want to manually fail the proof as
         // there's no way to continue.
         let manual_proof_fail = enable_proof_fail(task.data.task_type())
@@ -1131,7 +1174,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         let status = if retryable {
             if task.retries == MAX_TASK_RETRIES {
                 tracing::error!("task {} retries exhausted", task_id);
-                if task.status != TaskStatus::Succeeded && task.status != TaskStatus::FailedFatal {
+                if task.status != TaskStatus::FailedFatal {
                     proof.active_tasks -= 1;
                 }
 
@@ -1142,7 +1185,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 TaskStatus::FailedRetryable
             }
         } else {
-            if task.status != TaskStatus::Succeeded && task.status != TaskStatus::FailedFatal {
+            if task.status != TaskStatus::FailedFatal {
                 proof.active_tasks -= 1;
             }
             TaskStatus::FailedFatal
@@ -1361,26 +1404,35 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         }
         track_latency!("coordinator.fail_proof", {
             let sender = state.proofs_tx.clone();
-            // Cancel all tasks
+            // Vet the blamed task before tearing anything down: `on_proof_deleted` discards
+            // policy state that re-inserting the proof would not restore.
+            if let (Some(task_id), Some(proof)) = (task_id.as_ref(), state.proofs.get(&proof_id)) {
+                let Some(task) = proof.tasks.get(task_id) else {
+                    tracing::warn!(
+                        "Ignoring proof failure, task {} not found in proof {}",
+                        task_id,
+                        proof_id
+                    );
+                    return Err(Status::not_found(format!(
+                        "task {task_id} not found in proof {proof_id}"
+                    )));
+                };
+                // The blamed task already succeeded, so the proof must outlive the
+                // duplicate's report.
+                if task.status == TaskStatus::Succeeded {
+                    tracing::warn!(
+                        "Ignoring proof failure blamed on already-succeeded task {}",
+                        task_id
+                    );
+                    return Ok(());
+                }
+            }
             P::on_proof_deleted(state, &proof_id);
             let proof = state.proofs.remove(&proof_id);
             let Some(proof) = proof else {
                 tracing::warn!("proof {} not found", proof_id);
                 return Ok(());
             };
-            if let Some(task_id) = task_id {
-                if !proof.tasks.contains_key(&task_id) {
-                    tracing::warn!(
-                        "Ignoring proof failure, task {} not found in proof {}",
-                        task_id,
-                        proof_id
-                    );
-                    state.proofs.insert(proof_id.clone(), proof);
-                    return Err(Status::not_found(format!(
-                        "task {task_id} not found in proof {proof_id}"
-                    )));
-                }
-            }
             // Deliver a terminal TaskResult to each task's subscribers so they drain
             // via the normal completion path once the proof is gone.
             for task in proof.tasks.values() {
@@ -2615,6 +2667,36 @@ mod tests {
         );
     }
 
+    fn mark_task_succeeded(
+        state: &mut CoordinatorState<DefaultPolicy>,
+        proof_id: &str,
+        task_id: &str,
+    ) {
+        state
+            .proofs
+            .get_mut(proof_id)
+            .unwrap()
+            .tasks
+            .get_mut(task_id)
+            .unwrap()
+            .status = TaskStatus::Succeeded;
+    }
+
+    fn insert_worker_holding(
+        state: &mut CoordinatorState<DefaultPolicy>,
+        worker_id: &str,
+        proof_id: &str,
+        task_id: &str,
+    ) {
+        insert_live_worker(state, worker_id, WorkerType::Gpu);
+        let task_weight = state.proofs[proof_id].tasks[task_id].data.weight;
+        let worker = state.workers.get_mut(worker_id).unwrap();
+        worker
+            .active_tasks
+            .insert((proof_id.into(), task_id.into()));
+        worker.weight = task_weight;
+    }
+
     /// Like `insert_proof_with_running_task` but explicitly sets the task_type so
     /// the requeue path actually routes through `DefaultPolicy::enqueue_task` into
     /// the matching queue. `TaskType::UnspecifiedTaskType` (the default used by the
@@ -2648,6 +2730,63 @@ mod tests {
             },
         );
         state.proofs.insert(proof_id.into(), proof);
+    }
+
+    /// `BalancedPolicy` is used here because `DefaultPolicy`'s weight accounting is a
+    /// no-op and would hide the double release.
+    fn balanced_proof_on_worker(
+        state: &mut CoordinatorState<policy::balanced::BalancedPolicy>,
+        owner: &str,
+    ) {
+        let mut proof = Proof::new("p1".into(), None, ());
+        // A second task keeps the proof alive past this completion.
+        proof.active_tasks = 2;
+        proof.tasks.insert(
+            "t1".into(),
+            Task {
+                id: "t1".into(),
+                data: TaskData {
+                    proof_id: "p1".into(),
+                    task_type: TaskType::ProveShard as i32,
+                    weight: 8,
+                    ..Default::default()
+                },
+                created_at: SystemTime::now(),
+                status: TaskStatus::Running,
+                retries: 0,
+                subscribers: HashSet::new(),
+                worker: Some(owner.into()),
+                dead_worker_requeue_count: 0,
+                extra: Default::default(),
+            },
+        );
+        state.proofs.insert("p1".into(), proof);
+        // What assigning the task to `owner` charged.
+        state.policy.proof_gpu_weights.insert("p1".into(), 8);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut worker = Worker::new(
+            owner.into(),
+            WorkerType::Gpu,
+            24,
+            tx,
+            WorkerIdentity::default(),
+        );
+        worker.active_tasks.insert(("p1".into(), "t1".into()));
+        worker.weight = 8;
+        state.workers.insert(owner.into(), worker);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        state.workers.insert(
+            "w_stale".into(),
+            Worker::new(
+                "w_stale".into(),
+                WorkerType::Gpu,
+                24,
+                tx,
+                WorkerIdentity::default(),
+            ),
+        );
     }
 
     /// Regression guard: after `cleanup_dead_workers` removes a dead worker and
@@ -2999,5 +3138,263 @@ mod tests {
             "None worker must be skipped"
         );
         assert_eq!(components.len(), 1, "only the coordinator entry remains");
+    }
+
+    /// A preempted worker's late completion must not release weight the preemption
+    /// already released, or the tenant is credited twice and over-admitted.
+    #[tokio::test]
+    async fn completion_from_a_worker_that_lost_the_task_does_not_release_weight() {
+        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            balanced_proof_on_worker(&mut state, "w_owner");
+        }
+
+        c.complete_task(
+            "w_stale".into(),
+            "p1".into(),
+            "t1".into(),
+            policy::TaskMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.policy.proof_gpu_weights.get("p1").copied(),
+            Some(8),
+            "a completion from a worker that no longer holds the task released weight twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn completion_from_the_owning_worker_releases_weight() {
+        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            balanced_proof_on_worker(&mut state, "w_owner");
+        }
+
+        c.complete_task(
+            "w_owner".into(),
+            "p1".into(),
+            "t1".into(),
+            policy::TaskMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.policy.proof_gpu_weights.get("p1").copied(),
+            None,
+            "the owning worker's completion must release the weight it charged"
+        );
+    }
+
+    /// The duplicate's own assignment charged weight that nothing else releases, since
+    /// the completion came from a worker that no longer held the task.
+    #[tokio::test]
+    async fn ignoring_a_duplicates_failure_releases_the_weight_it_charged() {
+        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            balanced_proof_on_worker(&mut state, "w_owner");
+            state
+                .proofs
+                .get_mut("p1")
+                .unwrap()
+                .tasks
+                .get_mut("t1")
+                .unwrap()
+                .status = TaskStatus::Succeeded;
+        }
+
+        c.fail_task("w_owner".into(), "p1".into(), "t1".into(), false)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.policy.proof_gpu_weights.get("p1").copied(),
+            None,
+            "the duplicate's assignment left weight charged to the proof"
+        );
+    }
+
+    /// The path a fatal worker error actually takes: `try_unclaim_proof` sends
+    /// `FailProofRequest` naming the task. A duplicate execution of a finished task must
+    /// not take the proof down with it.
+    #[tokio::test]
+    async fn fail_proof_blamed_on_a_succeeded_task_is_ignored() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+            mark_task_succeeded(&mut state, "p1", "t1");
+        }
+
+        c.fail_proof("p1".into(), Some("t1".into()), true, None)
+            .await
+            .expect("a failure blamed on finished work must be ignored, not error");
+
+        let state = c.state.read().await;
+        let proof = state
+            .proofs
+            .get("p1")
+            .expect("proof must survive a duplicate execution's failure");
+        assert_eq!(
+            proof.tasks.get("t1").unwrap().status,
+            TaskStatus::Succeeded,
+            "the recorded success must be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_proof_blamed_on_an_unknown_task_is_rejected() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+        }
+
+        let result = c
+            .fail_proof("p1".into(), Some("nope".into()), false, None)
+            .await;
+
+        assert!(
+            matches!(result, Err(ref e) if e.code() == tonic::Code::NotFound),
+            "unknown task must be rejected, got: {result:?}"
+        );
+        let state = c.state.read().await;
+        assert!(
+            state.proofs.contains_key("p1"),
+            "proof must survive a failure naming a task it does not own"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_proof_blamed_on_a_running_task_still_fails_the_proof() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+        }
+
+        c.fail_proof("p1".into(), Some("t1".into()), false, None)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert!(
+            !state.proofs.contains_key("p1"),
+            "a genuine failure must still fail the proof"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_task_does_not_downgrade_a_succeeded_task() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+            mark_task_succeeded(&mut state, "p1", "t1");
+            insert_worker_holding(&mut state, "w1", "p1", "t1");
+        }
+
+        c.fail_task("w1".into(), "p1".into(), "t1".into(), false)
+            .await
+            .expect("a late failure must be ignored, not surfaced as an error");
+
+        let state = c.state.read().await;
+        let proof = state
+            .proofs
+            .get("p1")
+            .expect("proof must survive a late failure on a finished task");
+        assert_eq!(
+            proof.tasks.get("t1").unwrap().status,
+            TaskStatus::Succeeded,
+            "recorded success was downgraded by a late failure"
+        );
+        assert_eq!(
+            proof.active_tasks, 1,
+            "ignoring the failure must not touch the proof's task accounting"
+        );
+        assert!(
+            !state
+                .workers
+                .get("w1")
+                .unwrap()
+                .active_tasks
+                .contains(&("p1".into(), "t1".into())),
+            "the finished task must still release its worker slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn ignored_failure_frees_the_worker_for_queued_work() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+            mark_task_succeeded(&mut state, "p1", "t1");
+            insert_worker_holding(&mut state, "w1", "p1", "t1");
+
+            // A second proof waiting on the only GPU worker.
+            insert_proof_with_running_gpu_task(&mut state, "p2", "t2", None);
+            let queued = state
+                .proofs
+                .get("p2")
+                .unwrap()
+                .tasks
+                .get("t2")
+                .unwrap()
+                .clone();
+            c.enqueue_task(&mut state, queued).await;
+        }
+
+        c.fail_task("w1".into(), "p1".into(), "t1".into(), false)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert!(
+            state
+                .workers
+                .get("w1")
+                .unwrap()
+                .active_tasks
+                .contains(&("p2".into(), "t2".into())),
+            "freeing the slot must schedule queued work, not wait for the next event"
+        );
+    }
+
+    #[tokio::test]
+    async fn retryable_failure_does_not_requeue_a_succeeded_task() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+            mark_task_succeeded(&mut state, "p1", "t1");
+            insert_worker_holding(&mut state, "w1", "p1", "t1");
+        }
+
+        c.fail_task("w1".into(), "p1".into(), "t1".into(), true)
+            .await
+            .expect("a late retryable failure must be ignored");
+
+        let state = c.state.read().await;
+        let task = state.proofs.get("p1").unwrap().tasks.get("t1").unwrap();
+        assert_eq!(task.status, TaskStatus::Succeeded);
+        assert_eq!(task.retries, 0, "a succeeded task must not be retried");
+        assert!(
+            !state
+                .workers
+                .get("w1")
+                .unwrap()
+                .active_tasks
+                .contains(&("p1".into(), "t1".into())),
+            "a succeeded task must not be re-assigned"
+        );
     }
 }

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -664,10 +664,21 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             // Drop proof here so we can borrow state as mutable again.
 
             // Cleanup proof if there's no more active tasks. Drop it after state is released.
+            let mut released_assignments = false;
             let removed = if proof.active_tasks == 0 {
                 tracing::info!("Proof {} has no more active tasks, removing", proof_id);
                 P::on_proof_deleted(&mut state, &proof_id);
-                Some(state.proofs.remove(&proof_id))
+                let removed = state.proofs.remove(&proof_id);
+                // A stale completion can finish a proof while a redelivered copy of
+                // its final task still runs elsewhere. With the proof gone, that
+                // worker's own report dies on NotFound, so its assignment must be
+                // released here or its slot and policy weight leak.
+                if let Some(proof) = &removed {
+                    released_assignments = Self::release_remaining_assignments(
+                        &mut state, proof, &proof_id, &worker_id,
+                    );
+                }
+                removed
             } else {
                 None
             };
@@ -702,6 +713,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 remaining_tasks
             );
             // Update worker state.
+            let mut capacity_freed = released_assignments;
             if let Some(worker) = state.workers.get_mut(&worker_id) {
                 if worker
                     .active_tasks
@@ -715,15 +727,10 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                         let updated = P::post_worker_empty(&mut state, worker);
                         state.workers.insert(worker_id, updated);
                     }
-
-                    // Assign tasks now that a worker is available.
-                    self.assign_tasks(state).await?;
+                    capacity_freed = true;
                 } else if task_type != TaskType::MarkerDeferredRecord {
                     // This is only an issue if it's not a marker task.
                     tracing::warn!("worker {} was not working on task {}", worker_id, task_id);
-                    drop(state);
-                } else {
-                    drop(state);
                 }
             } else {
                 // Expected under dead-worker churn (e.g. spot eviction): the worker
@@ -734,6 +741,10 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                     task_id,
                     worker_id
                 );
+            }
+            if capacity_freed {
+                self.assign_tasks(state).await?;
+            } else {
                 drop(state);
             }
 
@@ -745,6 +756,63 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         });
 
         Ok(())
+    }
+
+    /// Returns whether anything was released.
+    fn release_remaining_assignments(
+        state: &mut CoordinatorState<P>,
+        proof: &Proof<P>,
+        proof_id: &str,
+        completing_worker: &str,
+    ) -> bool {
+        let mut released = false;
+        for task in proof.tasks.values() {
+            let Some(owner) = &task.worker else {
+                continue;
+            };
+            if owner == completing_worker {
+                continue;
+            }
+            let Some(worker) = state.workers.get_mut(owner) else {
+                continue;
+            };
+            if !worker
+                .active_tasks
+                .remove(&(proof_id.to_string(), task.id.clone()))
+            {
+                continue;
+            }
+            released = true;
+            if worker
+                .channel
+                .send(Ok(ServerMessage {
+                    message: Some(server_message::Message::CancelTask(CancelTask {
+                        proof_id: proof_id.to_string(),
+                        task_id: task.id.clone(),
+                    })),
+                }))
+                .is_err()
+            {
+                tracing::error!("Failed to send CancelTask to worker {}", worker.id);
+            }
+            worker.weight = worker.weight.saturating_sub(task.data.weight);
+            if worker.active_tasks.is_empty() {
+                let id = worker.id.clone();
+                let worker = worker.clone();
+                let updated = P::post_worker_empty(state, worker);
+                state.workers.insert(id, updated);
+            }
+            P::post_task_update_state(
+                state,
+                proof.extra.clone(),
+                &task.id,
+                task.extra.clone(),
+                task.data.weight,
+                proof_id,
+                task.data.task_type(),
+            );
+        }
+        released
     }
 
     /// Total weight of the tasks this coordinator has assigned to a worker.
@@ -3196,6 +3264,46 @@ mod tests {
             state.policy.proof_gpu_weights.get("p1").copied(),
             None,
             "the owning worker's completion must release the weight it charged"
+        );
+    }
+
+    /// A stale completion that finishes the proof leaves the redelivered copy's
+    /// worker holding a slot and policy weight nothing else releases: with the
+    /// proof gone, that worker's own report dies on NotFound before any cleanup.
+    #[tokio::test]
+    async fn stale_completion_finishing_a_proof_releases_the_redelivered_assignment() {
+        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            balanced_proof_on_worker(&mut state, "w_owner");
+            // t1 is the proof's only live task, so this completion finishes it.
+            state.proofs.get_mut("p1").unwrap().active_tasks = 1;
+        }
+
+        c.complete_task(
+            "w_stale".into(),
+            "p1".into(),
+            "t1".into(),
+            policy::TaskMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+        let state = c.state.read().await;
+        assert!(
+            !state.proofs.contains_key("p1"),
+            "the proof must be removed"
+        );
+        let owner = state.workers.get("w_owner").unwrap();
+        assert!(
+            owner.active_tasks.is_empty(),
+            "the redelivered assignment must be released with the proof"
+        );
+        assert_eq!(owner.weight, 0, "the worker's slot weight must be freed");
+        assert_eq!(
+            state.policy.proof_gpu_weights.get("p1").copied(),
+            None,
+            "the policy weight the redelivery charged must be released"
         );
     }
 

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -1301,8 +1301,16 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         // Handle manual proof failure.
         if manual_proof_fail {
             tracing::info!("Proof {} controller has no more retries, failing", proof_id);
-            self.fail_proof_internal(&mut state, proof_id.clone(), None, true, None)
-                .await?;
+            // The reporting pair's release belongs to this function's tail below.
+            self.fail_proof_internal(
+                &mut state,
+                proof_id.clone(),
+                None,
+                true,
+                None,
+                Some((&worker_id, &task_id)),
+            )
+            .await?;
         }
 
         // Have the policy update any state it needs to.
@@ -1481,6 +1489,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         task_id: Option<String>,
         notify_sender: bool,
         extra_data: Option<String>,
+        skip: Option<(&str, &str)>,
     ) -> Result<(), Status> {
         if state.shutting_down {
             tracing::info!(
@@ -1535,7 +1544,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             // Holder-gated on `active_tasks`, not task status: a Succeeded task can
             // still be held as a redelivered copy, and a requeued Running task's
             // stale `task.worker` must not release a hold that is already gone.
-            Self::release_remaining_assignments(state, &proof, &proof_id, None);
+            Self::release_remaining_assignments(state, &proof, &proof_id, skip);
 
             for task in proof.tasks.values() {
                 self.close_task_channel(&task.id);
@@ -1577,8 +1586,15 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             .instrument(tracing::debug_span!("acquire"))
             .await;
 
-        self.fail_proof_internal(&mut state, proof_id, task_id, notify_sender, extra_data)
-            .await
+        self.fail_proof_internal(
+            &mut state,
+            proof_id,
+            task_id,
+            notify_sender,
+            extra_data,
+            None,
+        )
+        .await
     }
 
     /// Send a task to a worker.
@@ -1954,7 +1970,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 .await;
             for id in proofs_to_remove {
                 if let Err(e) = self
-                    .fail_proof_internal(&mut state, id, None, false, None)
+                    .fail_proof_internal(&mut state, id, None, false, None, None)
                     .await
                 {
                     tracing::error!("Failed to fail expired proof: {}", e);
@@ -3704,6 +3720,31 @@ mod tests {
         assert_eq!(
             state.policy.release_calls, 0,
             "a hold released at preemption must not be released again"
+        );
+    }
+
+    /// A fatal controller failure tears the proof down mid-`fail_task`; the
+    /// reporting pair's release belongs to `fail_task`'s own tail, not to the
+    /// teardown sweep.
+    #[tokio::test]
+    async fn manual_proof_fail_releases_the_reporting_task_once() {
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            counting_proof_with_holds(&mut state, &[("t1", TaskStatus::Running, "w1")]);
+            let proof = state.proofs.get_mut("p1").unwrap();
+            proof.tasks.get_mut("t1").unwrap().data.task_type = TaskType::Controller as i32;
+        }
+
+        c.fail_task("w1".into(), "p1".into(), "t1".into(), false)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert!(!state.proofs.contains_key("p1"), "the proof must be failed");
+        assert_eq!(
+            state.policy.release_calls, 1,
+            "teardown must skip the reporting pair; fail_task's tail releases it"
         );
     }
 

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -3292,6 +3292,74 @@ mod tests {
         );
     }
 
+    /// An execution error unclaims the proof, then the reporter's `fail_task` lands on
+    /// a proof that is already gone.
+    #[tokio::test]
+    async fn fail_task_after_the_proof_was_unclaimed_is_rejected() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_live_worker(&mut state, "w1", WorkerType::Gpu);
+            state
+                .workers
+                .get_mut("w1")
+                .unwrap()
+                .active_tasks
+                .insert(("p1".into(), "t1".into()));
+        }
+
+        let result = c
+            .fail_task("w1".into(), "p1".into(), "t1".into(), false)
+            .await;
+
+        assert!(
+            matches!(result, Err(ref e) if e.code() == tonic::Code::NotFound),
+            "expected NotFound for a proof already unclaimed, got: {result:?}"
+        );
+    }
+
+    /// Backstop when the unclaim RPC never landed: a fatal `fail_task` on a CoreExecute
+    /// task must fail the proof itself.
+    #[tokio::test]
+    async fn fatal_failure_of_a_core_execute_task_fails_the_proof() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            let mut proof = Proof::new("p1".into(), None, ());
+            proof.active_tasks = 1;
+            proof.tasks.insert(
+                "t1".into(),
+                Task {
+                    id: "t1".into(),
+                    data: TaskData {
+                        proof_id: "p1".into(),
+                        task_type: TaskType::CoreExecute as i32,
+                        ..Default::default()
+                    },
+                    created_at: SystemTime::now(),
+                    status: TaskStatus::Running,
+                    retries: 0,
+                    subscribers: HashSet::new(),
+                    worker: Some("w1".into()),
+                    dead_worker_requeue_count: 0,
+                    extra: Default::default(),
+                },
+            );
+            state.proofs.insert("p1".into(), proof);
+            insert_worker_holding(&mut state, "w1", "p1", "t1");
+        }
+
+        c.fail_task("w1".into(), "p1".into(), "t1".into(), false)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert!(
+            !state.proofs.contains_key("p1"),
+            "a fatal CoreExecute failure must fail the proof when nothing else has"
+        );
+    }
+
     #[tokio::test]
     async fn fail_task_does_not_downgrade_a_succeeded_task() {
         let c = Arc::new(coordinator());

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -675,7 +675,10 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 // released here or its slot and policy weight leak.
                 if let Some(proof) = &removed {
                     released_assignments = Self::release_remaining_assignments(
-                        &mut state, proof, &proof_id, &worker_id, &task_id,
+                        &mut state,
+                        proof,
+                        &proof_id,
+                        Some((&worker_id, &task_id)),
                     );
                 }
                 removed
@@ -754,22 +757,21 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         Ok(())
     }
 
-    /// Returns whether anything was released.
+    /// Releases every assignment still held on `proof`'s tasks, except `skip` —
+    /// the (worker, task) pair the caller settles itself. Returns whether
+    /// anything was released.
     fn release_remaining_assignments(
         state: &mut CoordinatorState<P>,
         proof: &Proof<P>,
         proof_id: &str,
-        completing_worker: &str,
-        completed_task: &str,
+        skip: Option<(&str, &str)>,
     ) -> bool {
         let mut released = false;
         for task in proof.tasks.values() {
             let Some(owner) = &task.worker else {
                 continue;
             };
-            // The completer's own hold on the completed task is settled by the
-            // caller; anything else it still holds on this proof is orphaned too.
-            if owner == completing_worker && task.id == completed_task {
+            if Some((owner.as_str(), task.id.as_str())) == skip {
                 continue;
             }
             let Some(worker) = state.workers.get_mut(owner) else {
@@ -1280,7 +1282,18 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         let removed = if !manual_proof_fail && proof.active_tasks == 0 {
             tracing::info!("Proof {} has no more active tasks, removing", proof_id);
             P::on_proof_deleted(&mut state, &proof_id);
-            Some(state.proofs.remove(&proof_id))
+            let removed = state.proofs.remove(&proof_id);
+            // Same orphan as complete_task's removal: another worker can still hold
+            // a redelivered copy of one of this proof's tasks.
+            if let Some(proof) = &removed {
+                Self::release_remaining_assignments(
+                    &mut state,
+                    proof,
+                    &proof_id,
+                    Some((&worker_id, &task_id)),
+                );
+            }
+            removed
         } else {
             None
         };
@@ -1519,53 +1532,10 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                     );
                 }
             }
-            for task in proof.tasks.values() {
-                if task.status == TaskStatus::Running {
-                    if let Some(worker_id) = &task.worker {
-                        if let Some(worker) = state.workers.get_mut(worker_id) {
-                            if worker
-                                .channel
-                                .send(Ok(ServerMessage {
-                                    message: Some(server_message::Message::CancelTask(
-                                        CancelTask {
-                                            proof_id: proof_id.clone(),
-                                            task_id: task.id.clone(),
-                                        },
-                                    )),
-                                }))
-                                .is_err()
-                            {
-                                tracing::error!(
-                                    "Failed to send CancelTask to worker {}",
-                                    worker.id
-                                );
-                            }
-                            worker
-                                .active_tasks
-                                .remove(&(proof_id.clone(), task.id.clone()));
-                            worker.weight = worker.weight.saturating_sub(task.data.weight);
-
-                            // If the worker has no more tasks, handle it.
-                            if worker.active_tasks.is_empty() {
-                                let id = worker.id.clone();
-                                let worker = worker.clone();
-                                let updated = P::post_worker_empty(state, worker);
-                                state.workers.insert(id, updated);
-                            }
-
-                            P::post_task_update_state(
-                                state,
-                                proof.extra.clone(),
-                                &task.id,
-                                task.extra.clone(),
-                                task.data.weight,
-                                &proof_id,
-                                task.data.task_type(),
-                            );
-                        }
-                    }
-                }
-            }
+            // Holder-gated on `active_tasks`, not task status: a Succeeded task can
+            // still be held as a redelivered copy, and a requeued Running task's
+            // stale `task.worker` must not release a hold that is already gone.
+            Self::release_remaining_assignments(state, &proof, &proof_id, None);
 
             for task in proof.tasks.values() {
                 self.close_task_channel(&task.id);
@@ -3647,6 +3617,93 @@ mod tests {
                 .active_tasks
                 .contains(&("p1".into(), "t1".into())),
             "the finished task must still release its worker slot"
+        );
+    }
+
+    /// A fatal failure can drain the proof the same way a completion can; the
+    /// redelivered copy another worker still holds must be released here too.
+    #[tokio::test]
+    async fn failure_finishing_a_proof_releases_other_workers_holds() {
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            counting_proof_with_holds(
+                &mut state,
+                &[
+                    ("t1", TaskStatus::Running, "w2"),
+                    ("t2", TaskStatus::Succeeded, "w1"),
+                ],
+            );
+        }
+
+        c.fail_task("w2".into(), "p1".into(), "t1".into(), false)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert!(
+            !state.proofs.contains_key("p1"),
+            "the proof must be removed"
+        );
+        let holder = state.workers.get("w1").unwrap();
+        assert!(
+            holder.active_tasks.is_empty(),
+            "the redelivered hold must be released with the proof"
+        );
+        assert_eq!(holder.weight, 0);
+        assert_eq!(
+            state.policy.release_calls, 2,
+            "one release per assignment: t1's own and t2's orphan"
+        );
+    }
+
+    /// Proof teardown releases whoever actually holds a task, whatever its
+    /// status: a Succeeded task can still be held as a redelivered copy.
+    #[tokio::test]
+    async fn failing_a_proof_releases_a_succeeded_but_held_redelivery() {
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            counting_proof_with_holds(
+                &mut state,
+                &[
+                    ("t1", TaskStatus::Succeeded, "w1"),
+                    ("t2", TaskStatus::Running, "w2"),
+                ],
+            );
+        }
+
+        c.fail_proof("p1".into(), None, false, None).await.unwrap();
+
+        let state = c.state.read().await;
+        for w in ["w1", "w2"] {
+            let worker = state.workers.get(w).unwrap();
+            assert!(worker.active_tasks.is_empty(), "{w} must be released");
+            assert_eq!(worker.weight, 0, "{w} slot weight must be freed");
+        }
+        assert_eq!(state.policy.release_calls, 2);
+    }
+
+    /// A requeued task keeps a stale `task.worker` until reassignment; teardown
+    /// must not release a hold that preemption already released.
+    #[tokio::test]
+    async fn failing_a_proof_ignores_a_stale_worker_reference() {
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            counting_proof_with_holds(&mut state, &[("t1", TaskStatus::Running, "w1")]);
+            // Preemption released the hold; the task still names w1.
+            let worker = state.workers.get_mut("w1").unwrap();
+            worker.active_tasks.clear();
+            worker.weight = 0;
+        }
+
+        c.fail_proof("p1".into(), None, false, None).await.unwrap();
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.policy.release_calls, 0,
+            "a hold released at preemption must not be released again"
         );
     }
 

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -2720,25 +2720,49 @@ mod tests {
         );
     }
 
-    /// Insert a live (healthy) worker with default capacity. Returns the tx side of
-    /// its message channel; the corresponding rx is dropped (not used in tests that
-    /// only care about state, not sent payloads).
-    fn insert_live_worker(
-        state: &mut CoordinatorState<DefaultPolicy>,
-        worker_id: &str,
-        worker_type: WorkerType,
-    ) {
+    fn gpu_task<P: AssignmentPolicy>(
+        id: &str,
+        proof_id: &str,
+        weight: u32,
+        status: TaskStatus,
+        worker: Option<&str>,
+    ) -> Task<P> {
+        Task {
+            id: id.into(),
+            data: TaskData {
+                proof_id: proof_id.into(),
+                task_type: TaskType::ProveShard as i32,
+                weight,
+                ..Default::default()
+            },
+            created_at: SystemTime::now(),
+            status,
+            retries: 0,
+            subscribers: HashSet::new(),
+            worker: worker.map(String::from),
+            dead_worker_requeue_count: 0,
+            extra: Default::default(),
+        }
+    }
+
+    /// GPU worker with default capacity. The rx side of its message channel is
+    /// dropped, so sends to it fail silently — fine for tests that only assert
+    /// on state, not sent payloads.
+    fn gpu_worker<P: AssignmentPolicy>(id: &str) -> Worker<P> {
         let (tx, _rx) = mpsc::unbounded_channel();
-        state.workers.insert(
-            worker_id.into(),
-            Worker::new(
-                worker_id.into(),
-                worker_type,
-                24,
-                tx,
-                WorkerIdentity::default(),
-            ),
-        );
+        Worker::new(
+            id.into(),
+            WorkerType::Gpu,
+            24,
+            tx,
+            WorkerIdentity::default(),
+        )
+    }
+
+    fn insert_live_worker(state: &mut CoordinatorState<DefaultPolicy>, worker_id: &str) {
+        state
+            .workers
+            .insert(worker_id.into(), gpu_worker(worker_id));
     }
 
     fn mark_task_succeeded(
@@ -2762,7 +2786,7 @@ mod tests {
         proof_id: &str,
         task_id: &str,
     ) {
-        insert_live_worker(state, worker_id, WorkerType::Gpu);
+        insert_live_worker(state, worker_id);
         let task_weight = state.proofs[proof_id].tasks[task_id].data.weight;
         let worker = state.workers.get_mut(worker_id).unwrap();
         worker
@@ -2787,21 +2811,7 @@ mod tests {
         proof.active_tasks = 1;
         proof.tasks.insert(
             task_id.into(),
-            Task {
-                id: task_id.into(),
-                data: TaskData {
-                    proof_id: proof_id.into(),
-                    task_type: TaskType::ProveShard as i32,
-                    ..Default::default()
-                },
-                created_at: SystemTime::now(),
-                status: TaskStatus::Running,
-                retries: 0,
-                subscribers: HashSet::new(),
-                worker: worker_id.map(String::from),
-                dead_worker_requeue_count: 0,
-                extra: Default::default(),
-            },
+            gpu_task(task_id, proof_id, 0, TaskStatus::Running, worker_id),
         );
         state.proofs.insert(proof_id.into(), proof);
     }
@@ -2817,50 +2827,20 @@ mod tests {
         proof.active_tasks = 2;
         proof.tasks.insert(
             "t1".into(),
-            Task {
-                id: "t1".into(),
-                data: TaskData {
-                    proof_id: "p1".into(),
-                    task_type: TaskType::ProveShard as i32,
-                    weight: 8,
-                    ..Default::default()
-                },
-                created_at: SystemTime::now(),
-                status: TaskStatus::Running,
-                retries: 0,
-                subscribers: HashSet::new(),
-                worker: Some(owner.into()),
-                dead_worker_requeue_count: 0,
-                extra: Default::default(),
-            },
+            gpu_task("t1", "p1", 8, TaskStatus::Running, Some(owner)),
         );
         state.proofs.insert("p1".into(), proof);
         // What assigning the task to `owner` charged.
         state.policy.proof_gpu_weights.insert("p1".into(), 8);
 
-        let (tx, _rx) = mpsc::unbounded_channel();
-        let mut worker = Worker::new(
-            owner.into(),
-            WorkerType::Gpu,
-            24,
-            tx,
-            WorkerIdentity::default(),
-        );
+        let mut worker = gpu_worker(owner);
         worker.active_tasks.insert(("p1".into(), "t1".into()));
         worker.weight = 8;
         state.workers.insert(owner.into(), worker);
 
-        let (tx, _rx) = mpsc::unbounded_channel();
-        state.workers.insert(
-            "w_stale".into(),
-            Worker::new(
-                "w_stale".into(),
-                WorkerType::Gpu,
-                24,
-                tx,
-                WorkerIdentity::default(),
-            ),
-        );
+        state
+            .workers
+            .insert("w_stale".into(), gpu_worker("w_stale"));
     }
 
     /// Regression guard: after `cleanup_dead_workers` removes a dead worker and
@@ -2874,7 +2854,7 @@ mod tests {
             let mut state = c.state.write().await;
             insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w_dead"));
             insert_dead_worker(&mut state, "w_dead", WorkerType::Gpu, &[("p1", "t1")]);
-            insert_live_worker(&mut state, "w_live", WorkerType::Gpu);
+            insert_live_worker(&mut state, "w_live");
         }
 
         c.cleanup_dead_workers().await;
@@ -2928,7 +2908,7 @@ mod tests {
             let mut state = c.state.write().await;
             insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w_dead"));
             insert_dead_worker(&mut state, "w_dead", WorkerType::Gpu, &[("p1", "t1")]);
-            insert_live_worker(&mut state, "w_live", WorkerType::Gpu);
+            insert_live_worker(&mut state, "w_live");
         }
 
         // 1. Dead-worker cleanup: w_dead removed, task re-enqueued.
@@ -3283,33 +3263,12 @@ mod tests {
         for (id, status, worker_id) in tasks {
             proof.tasks.insert(
                 (*id).into(),
-                Task {
-                    id: (*id).into(),
-                    data: TaskData {
-                        proof_id: "p1".into(),
-                        task_type: TaskType::ProveShard as i32,
-                        weight: 8,
-                        ..Default::default()
-                    },
-                    created_at: SystemTime::now(),
-                    status: *status,
-                    retries: 0,
-                    subscribers: HashSet::new(),
-                    worker: Some((*worker_id).into()),
-                    dead_worker_requeue_count: 0,
-                    extra: (),
-                },
+                gpu_task(id, "p1", 8, *status, Some(worker_id)),
             );
-            let (tx, _rx) = mpsc::unbounded_channel();
-            let worker = state.workers.entry((*worker_id).into()).or_insert_with(|| {
-                Worker::new(
-                    (*worker_id).into(),
-                    WorkerType::Gpu,
-                    24,
-                    tx,
-                    WorkerIdentity::default(),
-                )
-            });
+            let worker = state
+                .workers
+                .entry((*worker_id).into())
+                .or_insert_with(|| gpu_worker(worker_id));
             worker.active_tasks.insert(("p1".into(), (*id).into()));
             worker.weight += 8;
         }
@@ -3516,21 +3475,7 @@ mod tests {
             proof.active_tasks = 2;
             proof.tasks.insert(
                 "t1".into(),
-                Task {
-                    id: "t1".into(),
-                    data: TaskData {
-                        proof_id: "p1".into(),
-                        task_type: TaskType::ProveShard as i32,
-                        ..Default::default()
-                    },
-                    created_at: SystemTime::now(),
-                    status: TaskStatus::Running,
-                    retries: 0,
-                    subscribers: HashSet::new(),
-                    worker: Some("w_owner".into()),
-                    dead_worker_requeue_count: 0,
-                    extra: (),
-                },
+                gpu_task("t1", "p1", 0, TaskStatus::Running, Some("w_owner")),
             );
             state.proofs.insert("p1".into(), proof);
         }
@@ -3635,7 +3580,7 @@ mod tests {
         let c = Arc::new(coordinator());
         {
             let mut state = c.state.write().await;
-            insert_live_worker(&mut state, "w1", WorkerType::Gpu);
+            insert_live_worker(&mut state, "w1");
             state
                 .workers
                 .get_mut("w1")

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -632,9 +632,12 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 task.data.proof_id,
                 P::debug_proof(&proof.extra),
             );
-            // Don't repeat notify if task is already succeeded, which is possible rarely
-            // for example when tasks are being retried.
-            let subscribers = if task.status == TaskStatus::Succeeded {
+            // A task can complete twice — a retry, or a preempted worker's reporter
+            // landing next to its redelivery's. Only the first report notifies and
+            // runs the success hooks; those record billing and scheduling history,
+            // charged once per task.
+            let already_succeeded = task.status == TaskStatus::Succeeded;
+            let subscribers = if already_succeeded {
                 None
             } else {
                 if task.status != TaskStatus::FailedFatal {
@@ -655,7 +658,9 @@ impl<P: AssignmentPolicy> Coordinator<P> {
             let task_extra = task.extra.clone();
             let proof_extra = proof.extra.clone();
             // Drop task here so we can borrow proof as mutable again.
-            P::post_task_success_update_proof(proof, &task_extra, metadata);
+            if !already_succeeded {
+                P::post_task_success_update_proof(proof, &task_extra, metadata);
+            }
             // Drop proof here so we can borrow state as mutable again.
 
             // Cleanup proof if there's no more active tasks. Drop it after state is released.
@@ -667,7 +672,9 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 None
             };
 
-            P::post_task_success_update_state(&mut state, task_type);
+            if !already_succeeded {
+                P::post_task_success_update_state(&mut state, task_type);
+            }
 
             // Policy weight is charged when a worker takes the task and released when it
             // gives it up. A completion from a worker that no longer holds it — preempted,
@@ -3219,6 +3226,140 @@ mod tests {
             state.policy.proof_gpu_weights.get("p1").copied(),
             None,
             "the duplicate's assignment left weight charged to the proof"
+        );
+    }
+
+    /// Counts success-hook invocations; the built-in policies implement both
+    /// hooks as no-ops, so double-running them is invisible through those.
+    #[derive(Clone, Default)]
+    struct CountingPolicy {
+        success_state_calls: u32,
+    }
+
+    #[async_trait::async_trait]
+    impl AssignmentPolicy for CountingPolicy {
+        type ProofState = u32;
+        type TaskState = ();
+        type WorkerState = ();
+        type ProofResultMetadata = ();
+
+        fn create_proof_state(
+            _state: &CoordinatorState<Self>,
+            _request: &proto::CreateProofRequest,
+        ) -> u32 {
+            0
+        }
+
+        fn enqueue_task(_state: &mut CoordinatorState<Self>, _task: Task<Self>) {}
+
+        fn post_task_success_update_proof(
+            proof: &mut Proof<Self>,
+            _task_extra: &(),
+            _metadata: policy::TaskMetadata,
+        ) {
+            proof.extra += 1;
+        }
+
+        fn post_task_success_update_state(
+            state: &mut CoordinatorState<Self>,
+            _task_type: TaskType,
+        ) {
+            state.policy.success_state_calls += 1;
+        }
+
+        fn post_task_update_state(
+            _state: &mut CoordinatorState<Self>,
+            _proof_extra: u32,
+            _task_id: &str,
+            _task_extra: (),
+            _task_weight: u32,
+            _proof_id: &str,
+            _task_type: TaskType,
+        ) {
+        }
+
+        fn debug_proof(_proof: &u32) -> &str {
+            ""
+        }
+
+        fn post_worker_empty(
+            _state: &mut CoordinatorState<Self>,
+            worker: Worker<Self>,
+        ) -> Worker<Self> {
+            worker
+        }
+
+        async fn assign_tasks(
+            _coord: &Arc<Coordinator<Self>>,
+            state: OwnedRwLockWriteGuard<CoordinatorState<Self>>,
+        ) -> Result<(), Status> {
+            drop(state);
+            Ok(())
+        }
+
+        fn get_proof_result_metadata(_proof: &Proof<Self>) {}
+
+        fn cpu_queue_len(_state: &CoordinatorState<Self>) -> u32 {
+            0
+        }
+
+        fn gpu_queue_len(_state: &CoordinatorState<Self>) -> u32 {
+            0
+        }
+    }
+
+    /// Success hooks record billing and scheduling history, charged once per
+    /// task. A preempted worker's reporter landing next to its redelivery's
+    /// report must not run them twice.
+    #[tokio::test]
+    async fn duplicate_completion_runs_the_success_hooks_once() {
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            let mut proof = Proof::new("p1".into(), None, 0);
+            // A second live task keeps the proof alive across both completions.
+            proof.active_tasks = 2;
+            proof.tasks.insert(
+                "t1".into(),
+                Task {
+                    id: "t1".into(),
+                    data: TaskData {
+                        proof_id: "p1".into(),
+                        task_type: TaskType::ProveShard as i32,
+                        ..Default::default()
+                    },
+                    created_at: SystemTime::now(),
+                    status: TaskStatus::Running,
+                    retries: 0,
+                    subscribers: HashSet::new(),
+                    worker: Some("w_owner".into()),
+                    dead_worker_requeue_count: 0,
+                    extra: (),
+                },
+            );
+            state.proofs.insert("p1".into(), proof);
+        }
+
+        for worker in ["w_owner", "w_stale"] {
+            c.complete_task(
+                worker.into(),
+                "p1".into(),
+                "t1".into(),
+                policy::TaskMetadata::default(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.proofs.get("p1").unwrap().extra,
+            1,
+            "proof billing metadata was recorded per report, not per task"
+        );
+        assert_eq!(
+            state.policy.success_state_calls, 1,
+            "scheduling history was recorded per report, not per task"
         );
     }
 

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -675,7 +675,7 @@ impl<P: AssignmentPolicy> Coordinator<P> {
                 // released here or its slot and policy weight leak.
                 if let Some(proof) = &removed {
                     released_assignments = Self::release_remaining_assignments(
-                        &mut state, proof, &proof_id, &worker_id,
+                        &mut state, proof, &proof_id, &worker_id, &task_id,
                     );
                 }
                 removed
@@ -764,13 +764,16 @@ impl<P: AssignmentPolicy> Coordinator<P> {
         proof: &Proof<P>,
         proof_id: &str,
         completing_worker: &str,
+        completed_task: &str,
     ) -> bool {
         let mut released = false;
         for task in proof.tasks.values() {
             let Some(owner) = &task.worker else {
                 continue;
             };
-            if owner == completing_worker {
+            // The completer's own hold on the completed task is settled by the
+            // caller; anything else it still holds on this proof is orphaned too.
+            if owner == completing_worker && task.id == completed_task {
                 continue;
             }
             let Some(worker) = state.workers.get_mut(owner) else {
@@ -3267,17 +3270,65 @@ mod tests {
         );
     }
 
+    /// Proof "p1" under `CountingPolicy` with the given `(id, status, worker)`
+    /// tasks, each held by its worker at weight 8; `active_tasks` counts the
+    /// non-terminal ones.
+    fn counting_proof_with_holds(
+        state: &mut CoordinatorState<CountingPolicy>,
+        tasks: &[(&str, TaskStatus, &str)],
+    ) {
+        let mut proof = Proof::new("p1".into(), None, 0);
+        proof.active_tasks = tasks
+            .iter()
+            .filter(|(_, status, _)| {
+                *status != TaskStatus::Succeeded && *status != TaskStatus::FailedFatal
+            })
+            .count() as u32;
+        for (id, status, worker_id) in tasks {
+            proof.tasks.insert(
+                (*id).into(),
+                Task {
+                    id: (*id).into(),
+                    data: TaskData {
+                        proof_id: "p1".into(),
+                        task_type: TaskType::ProveShard as i32,
+                        weight: 8,
+                        ..Default::default()
+                    },
+                    created_at: SystemTime::now(),
+                    status: *status,
+                    retries: 0,
+                    subscribers: HashSet::new(),
+                    worker: Some((*worker_id).into()),
+                    dead_worker_requeue_count: 0,
+                    extra: (),
+                },
+            );
+            let (tx, _rx) = mpsc::unbounded_channel();
+            let worker = state.workers.entry((*worker_id).into()).or_insert_with(|| {
+                Worker::new(
+                    (*worker_id).into(),
+                    WorkerType::Gpu,
+                    24,
+                    tx,
+                    WorkerIdentity::default(),
+                )
+            });
+            worker.active_tasks.insert(("p1".into(), (*id).into()));
+            worker.weight += 8;
+        }
+        state.proofs.insert("p1".into(), proof);
+    }
+
     /// A stale completion that finishes the proof leaves the redelivered copy's
     /// worker holding a slot and policy weight nothing else releases: with the
     /// proof gone, that worker's own report dies on NotFound before any cleanup.
     #[tokio::test]
     async fn stale_completion_finishing_a_proof_releases_the_redelivered_assignment() {
-        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
         {
             let mut state = c.state.write().await;
-            balanced_proof_on_worker(&mut state, "w_owner");
-            // t1 is the proof's only live task, so this completion finishes it.
-            state.proofs.get_mut("p1").unwrap().active_tasks = 1;
+            counting_proof_with_holds(&mut state, &[("t1", TaskStatus::Running, "w_owner")]);
         }
 
         c.complete_task(
@@ -3301,9 +3352,47 @@ mod tests {
         );
         assert_eq!(owner.weight, 0, "the worker's slot weight must be freed");
         assert_eq!(
-            state.policy.proof_gpu_weights.get("p1").copied(),
-            None,
-            "the policy weight the redelivery charged must be released"
+            state.policy.release_calls, 1,
+            "the policy weight the redelivery charged must be released exactly once"
+        );
+    }
+
+    /// The completing worker can itself hold another already-terminal task of the
+    /// proof — a redelivery whose stale twin reported first. Finishing the proof
+    /// must release that hold too, not just other workers'.
+    #[tokio::test]
+    async fn finishing_a_proof_releases_the_completers_other_orphans() {
+        let c = Arc::new(Coordinator::<CountingPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            counting_proof_with_holds(
+                &mut state,
+                &[
+                    ("t1", TaskStatus::Running, "w1"),
+                    ("t2", TaskStatus::Succeeded, "w1"),
+                ],
+            );
+        }
+
+        c.complete_task(
+            "w1".into(),
+            "p1".into(),
+            "t1".into(),
+            policy::TaskMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+        let state = c.state.read().await;
+        let worker = state.workers.get("w1").unwrap();
+        assert!(
+            worker.active_tasks.is_empty(),
+            "the orphaned hold on t2 must be released with the proof"
+        );
+        assert_eq!(worker.weight, 0, "both holds' slot weight must be freed");
+        assert_eq!(
+            state.policy.release_calls, 2,
+            "one policy release per assignment: t2's orphan and t1's own"
         );
     }
 
@@ -3342,6 +3431,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct CountingPolicy {
         success_state_calls: u32,
+        release_calls: u32,
     }
 
     #[async_trait::async_trait]
@@ -3376,7 +3466,7 @@ mod tests {
         }
 
         fn post_task_update_state(
-            _state: &mut CoordinatorState<Self>,
+            state: &mut CoordinatorState<Self>,
             _proof_extra: u32,
             _task_id: &str,
             _task_extra: (),
@@ -3384,6 +3474,7 @@ mod tests {
             _proof_id: &str,
             _task_type: TaskType,
         ) {
+            state.policy.release_calls += 1;
         }
 
         fn debug_proof(_proof: &u32) -> &str {

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -2765,36 +2765,6 @@ mod tests {
             .insert(worker_id.into(), gpu_worker(worker_id));
     }
 
-    fn mark_task_succeeded(
-        state: &mut CoordinatorState<DefaultPolicy>,
-        proof_id: &str,
-        task_id: &str,
-    ) {
-        state
-            .proofs
-            .get_mut(proof_id)
-            .unwrap()
-            .tasks
-            .get_mut(task_id)
-            .unwrap()
-            .status = TaskStatus::Succeeded;
-    }
-
-    fn insert_worker_holding(
-        state: &mut CoordinatorState<DefaultPolicy>,
-        worker_id: &str,
-        proof_id: &str,
-        task_id: &str,
-    ) {
-        insert_live_worker(state, worker_id);
-        let task_weight = state.proofs[proof_id].tasks[task_id].data.weight;
-        let worker = state.workers.get_mut(worker_id).unwrap();
-        worker
-            .active_tasks
-            .insert((proof_id.into(), task_id.into()));
-        worker.weight = task_weight;
-    }
-
     /// Like `insert_proof_with_running_task` but explicitly sets the task_type so
     /// the requeue path actually routes through `DefaultPolicy::enqueue_task` into
     /// the matching queue. `TaskType::UnspecifiedTaskType` (the default used by the
@@ -3246,6 +3216,87 @@ mod tests {
         );
     }
 
+    /// Counts success-hook invocations; the built-in policies implement both
+    /// hooks as no-ops, so double-running them is invisible through those.
+    #[derive(Clone, Default)]
+    struct CountingPolicy {
+        success_state_calls: u32,
+        release_calls: u32,
+    }
+
+    #[async_trait::async_trait]
+    impl AssignmentPolicy for CountingPolicy {
+        type ProofState = u32;
+        type TaskState = ();
+        type WorkerState = ();
+        type ProofResultMetadata = ();
+
+        fn create_proof_state(
+            _state: &CoordinatorState<Self>,
+            _request: &proto::CreateProofRequest,
+        ) -> u32 {
+            0
+        }
+
+        fn enqueue_task(_state: &mut CoordinatorState<Self>, _task: Task<Self>) {}
+
+        fn post_task_success_update_proof(
+            proof: &mut Proof<Self>,
+            _task_extra: &(),
+            _metadata: policy::TaskMetadata,
+        ) {
+            proof.extra += 1;
+        }
+
+        fn post_task_success_update_state(
+            state: &mut CoordinatorState<Self>,
+            _task_type: TaskType,
+        ) {
+            state.policy.success_state_calls += 1;
+        }
+
+        fn post_task_update_state(
+            state: &mut CoordinatorState<Self>,
+            _proof_extra: u32,
+            _task_id: &str,
+            _task_extra: (),
+            _task_weight: u32,
+            _proof_id: &str,
+            _task_type: TaskType,
+        ) {
+            state.policy.release_calls += 1;
+        }
+
+        fn debug_proof(_proof: &u32) -> &str {
+            ""
+        }
+
+        fn post_worker_empty(
+            _state: &mut CoordinatorState<Self>,
+            worker: Worker<Self>,
+        ) -> Worker<Self> {
+            worker
+        }
+
+        async fn assign_tasks(
+            _coord: &Arc<Coordinator<Self>>,
+            state: OwnedRwLockWriteGuard<CoordinatorState<Self>>,
+        ) -> Result<(), Status> {
+            drop(state);
+            Ok(())
+        }
+
+        fn get_proof_result_metadata(_proof: &Proof<Self>) {}
+
+        fn cpu_queue_len(_state: &CoordinatorState<Self>) -> u32 {
+            0
+        }
+
+        fn gpu_queue_len(_state: &CoordinatorState<Self>) -> u32 {
+            0
+        }
+    }
+
     /// Proof "p1" under `CountingPolicy` with the given `(id, status, worker)`
     /// tasks, each held by its worker at weight 8; `active_tasks` counts the
     /// non-terminal ones.
@@ -3351,117 +3402,6 @@ mod tests {
         );
     }
 
-    /// The duplicate's own assignment charged weight that nothing else releases, since
-    /// the completion came from a worker that no longer held the task.
-    #[tokio::test]
-    async fn ignoring_a_duplicates_failure_releases_the_weight_it_charged() {
-        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
-        {
-            let mut state = c.state.write().await;
-            balanced_proof_on_worker(&mut state, "w_owner");
-            state
-                .proofs
-                .get_mut("p1")
-                .unwrap()
-                .tasks
-                .get_mut("t1")
-                .unwrap()
-                .status = TaskStatus::Succeeded;
-        }
-
-        c.fail_task("w_owner".into(), "p1".into(), "t1".into(), false)
-            .await
-            .unwrap();
-
-        let state = c.state.read().await;
-        assert_eq!(
-            state.policy.proof_gpu_weights.get("p1").copied(),
-            None,
-            "the duplicate's assignment left weight charged to the proof"
-        );
-    }
-
-    /// Counts success-hook invocations; the built-in policies implement both
-    /// hooks as no-ops, so double-running them is invisible through those.
-    #[derive(Clone, Default)]
-    struct CountingPolicy {
-        success_state_calls: u32,
-        release_calls: u32,
-    }
-
-    #[async_trait::async_trait]
-    impl AssignmentPolicy for CountingPolicy {
-        type ProofState = u32;
-        type TaskState = ();
-        type WorkerState = ();
-        type ProofResultMetadata = ();
-
-        fn create_proof_state(
-            _state: &CoordinatorState<Self>,
-            _request: &proto::CreateProofRequest,
-        ) -> u32 {
-            0
-        }
-
-        fn enqueue_task(_state: &mut CoordinatorState<Self>, _task: Task<Self>) {}
-
-        fn post_task_success_update_proof(
-            proof: &mut Proof<Self>,
-            _task_extra: &(),
-            _metadata: policy::TaskMetadata,
-        ) {
-            proof.extra += 1;
-        }
-
-        fn post_task_success_update_state(
-            state: &mut CoordinatorState<Self>,
-            _task_type: TaskType,
-        ) {
-            state.policy.success_state_calls += 1;
-        }
-
-        fn post_task_update_state(
-            state: &mut CoordinatorState<Self>,
-            _proof_extra: u32,
-            _task_id: &str,
-            _task_extra: (),
-            _task_weight: u32,
-            _proof_id: &str,
-            _task_type: TaskType,
-        ) {
-            state.policy.release_calls += 1;
-        }
-
-        fn debug_proof(_proof: &u32) -> &str {
-            ""
-        }
-
-        fn post_worker_empty(
-            _state: &mut CoordinatorState<Self>,
-            worker: Worker<Self>,
-        ) -> Worker<Self> {
-            worker
-        }
-
-        async fn assign_tasks(
-            _coord: &Arc<Coordinator<Self>>,
-            state: OwnedRwLockWriteGuard<CoordinatorState<Self>>,
-        ) -> Result<(), Status> {
-            drop(state);
-            Ok(())
-        }
-
-        fn get_proof_result_metadata(_proof: &Proof<Self>) {}
-
-        fn cpu_queue_len(_state: &CoordinatorState<Self>) -> u32 {
-            0
-        }
-
-        fn gpu_queue_len(_state: &CoordinatorState<Self>) -> u32 {
-            0
-        }
-    }
-
     /// Success hooks record billing and scheduling history, charged once per
     /// task. A preempted worker's reporter landing next to its redelivery's
     /// report must not run them twice.
@@ -3501,6 +3441,36 @@ mod tests {
             state.policy.success_state_calls, 1,
             "scheduling history was recorded per report, not per task"
         );
+    }
+
+    fn mark_task_succeeded(
+        state: &mut CoordinatorState<DefaultPolicy>,
+        proof_id: &str,
+        task_id: &str,
+    ) {
+        state
+            .proofs
+            .get_mut(proof_id)
+            .unwrap()
+            .tasks
+            .get_mut(task_id)
+            .unwrap()
+            .status = TaskStatus::Succeeded;
+    }
+
+    fn insert_worker_holding(
+        state: &mut CoordinatorState<DefaultPolicy>,
+        worker_id: &str,
+        proof_id: &str,
+        task_id: &str,
+    ) {
+        insert_live_worker(state, worker_id);
+        let task_weight = state.proofs[proof_id].tasks[task_id].data.weight;
+        let worker = state.workers.get_mut(worker_id).unwrap();
+        worker
+            .active_tasks
+            .insert((proof_id.into(), task_id.into()));
+        worker.weight = task_weight;
     }
 
     /// The path a fatal worker error actually takes: `try_unclaim_proof` sends
@@ -3677,6 +3647,36 @@ mod tests {
                 .active_tasks
                 .contains(&("p1".into(), "t1".into())),
             "the finished task must still release its worker slot"
+        );
+    }
+
+    /// The duplicate's own assignment charged weight that nothing else releases, since
+    /// the completion came from a worker that no longer held the task.
+    #[tokio::test]
+    async fn ignoring_a_duplicates_failure_releases_the_weight_it_charged() {
+        let c = Arc::new(Coordinator::<policy::balanced::BalancedPolicy>::new());
+        {
+            let mut state = c.state.write().await;
+            balanced_proof_on_worker(&mut state, "w_owner");
+            state
+                .proofs
+                .get_mut("p1")
+                .unwrap()
+                .tasks
+                .get_mut("t1")
+                .unwrap()
+                .status = TaskStatus::Succeeded;
+        }
+
+        c.fail_task("w_owner".into(), "p1".into(), "t1".into(), false)
+            .await
+            .unwrap();
+
+        let state = c.state.read().await;
+        assert_eq!(
+            state.policy.proof_gpu_weights.get("p1").copied(),
+            None,
+            "the duplicate's assignment left weight charged to the proof"
         );
     }
 

--- a/bin/coordinator/src/lib.rs
+++ b/bin/coordinator/src/lib.rs
@@ -2491,6 +2491,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn assign_tasks_skips_a_closed_worker() {
+        let c = Arc::new(coordinator());
+        {
+            let mut state = c.state.write().await;
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", None);
+            let queued = state
+                .proofs
+                .get("p1")
+                .unwrap()
+                .tasks
+                .get("t1")
+                .unwrap()
+                .clone();
+            c.enqueue_task(&mut state, queued).await;
+            insert_live_worker(&mut state, "w1");
+            state.workers.get_mut("w1").unwrap().closed = true;
+        }
+
+        let state = c.state.clone().write_owned().await;
+        c.assign_tasks(state).await.unwrap();
+
+        let state = c.state.read().await;
+        assert!(
+            state.workers.get("w1").unwrap().active_tasks.is_empty(),
+            "a closed worker must not receive assignments"
+        );
+    }
+
+    #[tokio::test]
     async fn heartbeat_timeout_cannot_be_set_below_the_floor() {
         let c = Arc::new(coordinator());
 
@@ -3562,27 +3591,16 @@ mod tests {
         let c = Arc::new(coordinator());
         {
             let mut state = c.state.write().await;
-            let mut proof = Proof::new("p1".into(), None, ());
-            proof.active_tasks = 1;
-            proof.tasks.insert(
-                "t1".into(),
-                Task {
-                    id: "t1".into(),
-                    data: TaskData {
-                        proof_id: "p1".into(),
-                        task_type: TaskType::CoreExecute as i32,
-                        ..Default::default()
-                    },
-                    created_at: SystemTime::now(),
-                    status: TaskStatus::Running,
-                    retries: 0,
-                    subscribers: HashSet::new(),
-                    worker: Some("w1".into()),
-                    dead_worker_requeue_count: 0,
-                    extra: Default::default(),
-                },
-            );
-            state.proofs.insert("p1".into(), proof);
+            insert_proof_with_running_gpu_task(&mut state, "p1", "t1", Some("w1"));
+            state
+                .proofs
+                .get_mut("p1")
+                .unwrap()
+                .tasks
+                .get_mut("t1")
+                .unwrap()
+                .data
+                .task_type = TaskType::CoreExecute as i32;
             insert_worker_holding(&mut state, "w1", "p1", "t1");
         }
 

--- a/bin/node/src/heartbeat.rs
+++ b/bin/node/src/heartbeat.rs
@@ -226,7 +226,6 @@ fn build_heartbeat_request(
 mod tests {
     use super::*;
     use sp1_cluster_common::proto::TaskData;
-    use std::sync::atomic::AtomicBool;
 
     /// Valid but unreachable, so the thread sits in its connect retry — the
     /// state a worker boots into when the coordinator is down.
@@ -336,7 +335,7 @@ mod tests {
                 started_at: Instant::now(),
                 work: work.abort_handle(),
                 reporter: work,
-                timed_out: Arc::new(AtomicBool::new(false)),
+                aborted_at: Arc::new(std::sync::OnceLock::new()),
             }
         };
         let tasks = DashMap::new();

--- a/bin/node/src/heartbeat.rs
+++ b/bin/node/src/heartbeat.rs
@@ -212,7 +212,7 @@ fn build_heartbeat_request(
         let (proof_id, task_id) = entry.key();
         active_task_proof_ids.push(proof_id.clone());
         active_task_ids.push(task_id.clone());
-        current_weight += entry.value().0.weight;
+        current_weight += entry.value().data.weight;
     }
     HeartbeatRequest {
         worker_id: worker_id.to_string(),
@@ -326,14 +326,16 @@ mod tests {
     #[tokio::test]
     async fn request_reports_every_task_with_its_weight() {
         let task = |weight| {
-            (
-                TaskData {
+            let work = tokio::spawn(std::future::pending::<()>());
+            ActiveTask {
+                data: TaskData {
                     weight,
                     ..Default::default()
                 },
-                tokio::spawn(std::future::pending::<()>()),
-                Instant::now(),
-            )
+                started_at: Instant::now(),
+                work: work.abort_handle(),
+                reporter: work,
+            }
         };
         let tasks = DashMap::new();
         tasks.insert(("p1".to_string(), "t1".to_string()), task(3));

--- a/bin/node/src/heartbeat.rs
+++ b/bin/node/src/heartbeat.rs
@@ -226,6 +226,7 @@ fn build_heartbeat_request(
 mod tests {
     use super::*;
     use sp1_cluster_common::proto::TaskData;
+    use std::sync::atomic::AtomicBool;
 
     /// Valid but unreachable, so the thread sits in its connect retry — the
     /// state a worker boots into when the coordinator is down.
@@ -335,6 +336,7 @@ mod tests {
                 started_at: Instant::now(),
                 work: work.abort_handle(),
                 reporter: work,
+                timed_out: Arc::new(AtomicBool::new(false)),
             }
         };
         let tasks = DashMap::new();

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -596,6 +596,20 @@ async fn run_worker_inner(
                                 ABORT_GRACE,
                             );
                             task.work.abort();
+                            // Close before failing: fail_task requeues the task and
+                            // triggers assignment, and an open worker with freed
+                            // capacity can win its own retry back while the wedged
+                            // work still burns the machine. Draining ends in a
+                            // restart, the only thing that actually frees it.
+                            if !closed {
+                                closed = true;
+                                drain_started_at = Some(Instant::now());
+                                if let Err(e) = worker_client.close(CloseRequest {
+                                    worker_id: node_config.worker_id.clone(),
+                                }).await {
+                                    tracing::error!("Failed to close worker: {:?}", e);
+                                }
+                            }
                             if let Err(e) = worker_client.fail_task(FailTaskRequest {
                                 worker_id: node_config.worker_id.clone(),
                                 proof_id: task_id.0,

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -17,8 +17,8 @@ use sp1_prover::worker::{TaskMetadata, WorkerClient};
 use sp1_prover::SP1ProverComponents;
 use sp1_sdk::install::try_install_circuit_artifacts;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 use tokio::task::{AbortHandle, JoinError, JoinHandle};
@@ -175,9 +175,9 @@ pub(crate) struct ActiveTask {
     pub work: AbortHandle,
     /// Outlives cancellation of `work`, so a task that finished can still report it.
     pub reporter: JoinHandle<()>,
-    /// Set by the timeout sweep before aborting `work`, so the reporter fails
-    /// the task instead of staying silent.
-    pub timed_out: Arc<AtomicBool>,
+    /// Stamped by the sweep's abort; tells the reporter to fail the task, and
+    /// anchors the escalation grace so a late sweep can't shorten it.
+    pub aborted_at: Arc<OnceLock<Instant>>,
 }
 
 /// Drops the task's entry unless a redelivery already replaced it. A cancelled task
@@ -247,10 +247,9 @@ fn timeout_action(active: &ActiveTask, timeout: Duration, grace: Duration) -> Ti
     if active.work.is_finished() || active.started_at.elapsed() <= timeout {
         return TimeoutAction::Leave;
     }
-    if active.timed_out.load(Ordering::SeqCst) && active.started_at.elapsed() > timeout + grace {
-        TimeoutAction::Report
-    } else {
-        TimeoutAction::Abort
+    match active.aborted_at.get() {
+        Some(aborted_at) if aborted_at.elapsed() > grace => TimeoutAction::Report,
+        _ => TimeoutAction::Abort,
     }
 }
 
@@ -259,33 +258,41 @@ fn timeout_action(active: &ActiveTask, timeout: Duration, grace: Duration) -> Ti
 const ABORT_GRACE: Duration = Duration::from_secs(10);
 
 /// Reports wedged tasks off the main loop: the RPCs retry for minutes, and
-/// heartbeats would keep a frozen loop looking alive. Closes the worker first
-/// so its freed capacity can't win a retry back while the wedged work still
-/// burns; tracked in `reporters_in_flight` so the drain waits.
+/// heartbeats would keep a frozen loop looking alive. Every batch awaits the
+/// shared close before failing, so a freed slot can't win a retry back while
+/// the wedged work still burns; tracked in `reporters_in_flight` so the drain
+/// waits.
 fn spawn_wedged_report(
     worker_client: &WorkerServiceClient,
     reporters_in_flight: &Arc<AtomicUsize>,
+    coordinator_closed: &Arc<tokio::sync::OnceCell<()>>,
     worker_id: &str,
-    close_worker: bool,
     wedged: Vec<(String, String)>,
 ) {
     reporters_in_flight.fetch_add(1, Ordering::SeqCst);
     let in_flight = reporters_in_flight.clone();
     let worker_client = worker_client.clone();
+    let coordinator_closed = coordinator_closed.clone();
     let worker_id = worker_id.to_string();
     tokio::spawn(async move {
         let _tracked = sp1_cluster_worker::utils::DeferGuard::new(in_flight, |c| {
             c.fetch_sub(1, Ordering::SeqCst);
         });
-        if close_worker {
-            if let Err(e) = worker_client
-                .close(CloseRequest {
-                    worker_id: worker_id.clone(),
-                })
-                .await
-            {
-                tracing::error!("Failed to close worker: {:?}", e);
-            }
+        let closed = coordinator_closed
+            .get_or_try_init(|| async {
+                worker_client
+                    .close(CloseRequest {
+                        worker_id: worker_id.clone(),
+                    })
+                    .await
+            })
+            .await;
+        if let Err(e) = closed {
+            // Report anyway: a stalled proof outranks a bounced assignment.
+            tracing::error!(
+                "Failed to close worker before failing wedged tasks: {:?}",
+                e
+            );
         }
         for (proof_id, task_id) in wedged {
             if let Err(e) = worker_client
@@ -314,6 +321,9 @@ async fn run_worker_inner(
     // key is accepted, but its reporter may still be mid-RPC. Draining on `tasks` alone
     // would exit under it and lose the completion.
     let reporters_in_flight = Arc::new(AtomicUsize::new(0));
+    // Set once the coordinator acknowledged our close. Wedged batches await it
+    // before fail_task, so a requeued task can't be assigned back here.
+    let coordinator_closed: Arc<tokio::sync::OnceCell<()>> = Arc::new(tokio::sync::OnceCell::new());
 
     // Beats stop when this future ends (return or harness kill).
     let heartbeat = HeartbeatHandle::spawn(node_config.clone(), tasks.clone(), token.clone())?;
@@ -399,11 +409,11 @@ async fn run_worker_inner(
                                         async move { worker.run_task(&task).await }
                                     });
                                     let work_abort = work.abort_handle();
-                                    let timed_out_flag = Arc::new(AtomicBool::new(false));
+                                    let aborted_at = Arc::new(OnceLock::new());
                                     reporters_in_flight.fetch_add(1, Ordering::SeqCst);
                                     let reporter = tokio::spawn({
                                         let in_flight = reporters_in_flight.clone();
-                                        let timed_out_flag = timed_out_flag.clone();
+                                        let aborted_at = aborted_at.clone();
                                         let task = task.clone();
                                         let data = data.clone();
                                         let worker_client = worker_client.clone();
@@ -419,7 +429,7 @@ async fn run_worker_inner(
                                             );
                                             let work_id = work.id();
                                             let result = work.await;
-                                            let timed_out = timed_out_flag.load(Ordering::SeqCst);
+                                            let timed_out = aborted_at.get().is_some();
                                             match report_for(&key, result, timed_out) {
                                                 Report::Complete(metadata) => {
                                                     let metadata_string = serde_json::to_string(&metadata).unwrap();
@@ -458,7 +468,7 @@ async fn run_worker_inner(
                                         started_at: Instant::now(),
                                         work: work_abort,
                                         reporter,
-                                        timed_out: timed_out_flag,
+                                        aborted_at,
                                     });
                                 }
                                 Some(server_message::Message::CancelTask(task)) => {
@@ -628,7 +638,7 @@ async fn run_worker_inner(
                             // Reporting here would race a completion from work that
                             // finished after the check. The reporter owns the report,
                             // and drops the entry once it lands.
-                            entry.value().timed_out.store(true, Ordering::SeqCst);
+                            let _ = entry.value().aborted_at.set(Instant::now());
                             entry.value().work.abort();
                         }
                         let mut wedged_reports = Vec::new();
@@ -647,14 +657,13 @@ async fn run_worker_inner(
                         if !wedged_reports.is_empty() {
                             // Draining ends in a restart — the only thing that
                             // frees wedged work.
-                            let close_worker = !closed;
                             closed = true;
                             drain_started_at.get_or_insert_with(Instant::now);
                             spawn_wedged_report(
                                 &worker_client,
                                 &reporters_in_flight,
+                                &coordinator_closed,
                                 &node_config.worker_id,
-                                close_worker,
                                 wedged_reports,
                             );
                         }
@@ -666,6 +675,8 @@ async fn run_worker_inner(
                             worker_id: node_config.worker_id.clone(),
                         }).await {
                             tracing::error!("Failed to close worker: {:?}", e);
+                        } else {
+                            let _ = coordinator_closed.set(());
                         }
                         if tasks.is_empty() && reporters_in_flight.load(Ordering::SeqCst) == 0 {
                             tracing::info!("No in-flight tasks; shutting down immediately");
@@ -729,7 +740,7 @@ mod tests {
             started_at: Instant::now(),
             work: work.abort_handle(),
             reporter: tokio::spawn(std::future::ready(())),
-            timed_out: Arc::new(AtomicBool::new(false)),
+            aborted_at: Arc::new(OnceLock::new()),
         }
     }
 
@@ -866,6 +877,29 @@ mod tests {
         ));
     }
 
+    /// The sweep can first observe a timeout long after it passed (stalled
+    /// runtime); the grace runs from the abort itself, not from the deadline.
+    #[tokio::test]
+    async fn a_late_abort_still_gets_its_full_grace() {
+        let work = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        let mut task = active_task(work);
+        task.started_at = Instant::now()
+            .checked_sub(Duration::from_secs(100))
+            .unwrap();
+        task.aborted_at.set(Instant::now()).unwrap();
+
+        assert!(
+            matches!(
+                timeout_action(&task, Duration::ZERO, Duration::from_secs(10)),
+                TimeoutAction::Abort
+            ),
+            "escalating before the abort's own grace re-opens the dual-report race"
+        );
+    }
+
     /// Work that never yields cannot observe its abort; once the grace passes
     /// the sweep must report the failure itself or the proof wedges forever.
     #[tokio::test]
@@ -875,7 +909,7 @@ mod tests {
             Option<TaskMetadata>,
         )>());
         let task = active_task(work);
-        task.timed_out.store(true, Ordering::SeqCst);
+        task.aborted_at.set(Instant::now()).unwrap();
         tokio::time::sleep(Duration::from_millis(2)).await;
 
         assert!(matches!(
@@ -919,7 +953,7 @@ mod tests {
                 started_at: Instant::now(),
                 work: work_abort,
                 reporter,
-                timed_out: Arc::new(AtomicBool::new(false)),
+                aborted_at: Arc::new(OnceLock::new()),
             },
         );
 
@@ -1005,7 +1039,7 @@ mod tests {
                 started_at: Instant::now(),
                 work: work_abort,
                 reporter,
-                timed_out: Arc::new(AtomicBool::new(false)),
+                aborted_at: Arc::new(OnceLock::new()),
             },
         );
 

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -448,8 +448,11 @@ async fn run_worker_inner(
                         }
                         if let Some(started) = drain_started_at {
                             let elapsed = started.elapsed();
-                            let in_flight =
-                                tasks.len() + reporters_in_flight.load(Ordering::SeqCst);
+                            // Every undelivered outcome has exactly one live reporter;
+                            // map entries are a subset (a cancelled task leaves the map
+                            // while its reporter lives on), so adding them would count
+                            // running tasks twice.
+                            let in_flight = reporters_in_flight.load(Ordering::SeqCst);
                             if elapsed > node_config.drain_timeout {
                                 let stuck: Vec<_> = tasks.iter().map(|e| e.key().clone()).collect();
                                 tracing::warn!(

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -231,13 +231,32 @@ pub(crate) fn report_for(
     }
 }
 
-/// Whether the timeout sweep should abort and fail this task. Finished work
-/// still in the map is mid-report, not stuck: failing it would race its own
-/// completion. The reporter drops the entry once the report lands, and a
-/// coordinator that stays unreachable trips the channel-silence exit instead.
-fn timed_out(active: &ActiveTask, timeout: Duration) -> bool {
-    !active.work.is_finished() && active.started_at.elapsed() > timeout
+enum TimeoutAction {
+    /// Running normally, or finished and mid-report — failing the latter would
+    /// race its own completion; the reporter drops the entry once it lands.
+    Leave,
+    /// Flag and abort; the reporter turns the abort into a failure report.
+    Abort,
+    /// The work ignored its abort — it never reached a yield point — so the
+    /// reporter is stuck on it and the sweep must report the failure itself.
+    /// The reporter's eventual duplicate is rejected by the coordinator.
+    Report,
 }
+
+fn timeout_action(active: &ActiveTask, timeout: Duration, grace: Duration) -> TimeoutAction {
+    if active.work.is_finished() || active.started_at.elapsed() <= timeout {
+        return TimeoutAction::Leave;
+    }
+    if active.timed_out.load(Ordering::SeqCst) && active.started_at.elapsed() > timeout + grace {
+        TimeoutAction::Report
+    } else {
+        TimeoutAction::Abort
+    }
+}
+
+/// Two watchdog ticks: enough for an abort to land at the work's next yield
+/// point, short enough that a truly wedged proof requeues promptly.
+const ABORT_GRACE: Duration = Duration::from_secs(10);
 
 async fn run_worker_inner(
     node_config: NodeConfig,
@@ -520,11 +539,20 @@ async fn run_worker_inner(
                         // Handle panicked tasks
                         let mut panicked_tasks = HashSet::new();
                         let mut timed_out_tasks = HashSet::new();
+                        let mut wedged_tasks = HashSet::new();
                         for entry in tasks.iter_mut() {
                             if entry.value().reporter.is_finished() {
                                 panicked_tasks.insert(entry.key().clone());
-                            } else if timed_out(entry.value(), node_config.task_timeout) {
-                                timed_out_tasks.insert(entry.key().clone());
+                            } else {
+                                match timeout_action(entry.value(), node_config.task_timeout, ABORT_GRACE) {
+                                    TimeoutAction::Leave => {}
+                                    TimeoutAction::Abort => {
+                                        timed_out_tasks.insert(entry.key().clone());
+                                    }
+                                    TimeoutAction::Report => {
+                                        wedged_tasks.insert(entry.key().clone());
+                                    }
+                                }
                             }
                         }
                         for task_id in panicked_tasks {
@@ -557,6 +585,25 @@ async fn run_worker_inner(
                             // and drops the entry once it lands.
                             entry.value().timed_out.store(true, Ordering::SeqCst);
                             entry.value().work.abort();
+                        }
+                        for task_id in wedged_tasks {
+                            let Some((_, task)) = tasks.remove(&task_id) else {
+                                continue;
+                            };
+                            tracing::error!(
+                                "Task {:?} ignored its abort for {:?}; reporting failure directly",
+                                task_id,
+                                ABORT_GRACE,
+                            );
+                            task.work.abort();
+                            if let Err(e) = worker_client.fail_task(FailTaskRequest {
+                                worker_id: node_config.worker_id.clone(),
+                                proof_id: task_id.0,
+                                task_id: task_id.1,
+                                retryable: true,
+                            }).await {
+                                tracing::error!("Failed to update task status: {:?}", e);
+                            }
                         }
                     }
                     _ = token.cancelled(), if !closed => {
@@ -721,7 +768,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finished_work_mid_report_is_not_timed_out() {
+    async fn finished_work_mid_report_is_left_alone() {
         let work = tokio::spawn(std::future::ready((proto::TaskStatus::Succeeded, None)));
         let task = active_task(work);
         while !task.work.is_finished() {
@@ -729,13 +776,16 @@ mod tests {
         }
 
         assert!(
-            !timed_out(&task, Duration::ZERO),
+            matches!(
+                timeout_action(&task, Duration::ZERO, Duration::ZERO),
+                TimeoutAction::Leave
+            ),
             "failing a finished task races its own completion report"
         );
     }
 
     #[tokio::test]
-    async fn stuck_work_is_timed_out_only_past_the_timeout() {
+    async fn stuck_work_is_aborted_only_past_the_timeout() {
         let work = tokio::spawn(std::future::pending::<(
             proto::TaskStatus,
             Option<TaskMetadata>,
@@ -743,8 +793,37 @@ mod tests {
         let task = active_task(work);
         tokio::time::sleep(Duration::from_millis(2)).await;
 
-        assert!(timed_out(&task, Duration::ZERO));
-        assert!(!timed_out(&task, Duration::from_secs(3600)));
+        assert!(matches!(
+            timeout_action(&task, Duration::ZERO, Duration::from_secs(3600)),
+            TimeoutAction::Abort
+        ));
+        assert!(matches!(
+            timeout_action(&task, Duration::from_secs(3600), Duration::ZERO),
+            TimeoutAction::Leave
+        ));
+    }
+
+    /// Work that never yields cannot observe its abort; once the grace passes
+    /// the sweep must report the failure itself or the proof wedges forever.
+    #[tokio::test]
+    async fn work_that_ignored_its_abort_is_reported_after_the_grace() {
+        let work = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        let task = active_task(work);
+        task.timed_out.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(2)).await;
+
+        assert!(matches!(
+            timeout_action(&task, Duration::ZERO, Duration::ZERO),
+            TimeoutAction::Report
+        ));
+        // Still inside the grace: keep waiting for the abort to land.
+        assert!(matches!(
+            timeout_action(&task, Duration::ZERO, Duration::from_secs(3600)),
+            TimeoutAction::Abort
+        ));
     }
 
     #[tokio::test]

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -13,14 +13,15 @@ use sp1_cluster_worker::client::WorkerServiceClient;
 use sp1_cluster_worker::config::cluster_worker_config;
 use sp1_cluster_worker::metrics::WorkerMetrics;
 use sp1_cluster_worker::SP1ClusterWorker;
-use sp1_prover::worker::WorkerClient;
+use sp1_prover::worker::{TaskMetadata, WorkerClient};
 use sp1_prover::SP1ProverComponents;
 use sp1_sdk::install::try_install_circuit_artifacts;
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sysinfo::{MemoryRefreshKind, RefreshKind, System};
-use tokio::task::JoinHandle;
+use tokio::task::{AbortHandle, JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 pub async fn run(
@@ -168,7 +169,56 @@ pub async fn run_gpu_worker(
     .unwrap()
 }
 
-pub(crate) type ActiveTask = (TaskData, JoinHandle<()>, Instant);
+pub(crate) struct ActiveTask {
+    pub data: TaskData,
+    pub started_at: Instant,
+    pub work: AbortHandle,
+    /// Outlives cancellation of `work`, so a task that finished can still report it.
+    pub reporter: JoinHandle<()>,
+}
+
+/// Drops the task's entry unless a redelivery already replaced it. A cancelled task
+/// reuses its key, so the successor's entry must keep its heartbeat and timeout.
+fn drop_if_current(
+    tasks: &DashMap<(String, String), ActiveTask>,
+    key: &(String, String),
+    work_id: tokio::task::Id,
+) -> Option<((String, String), ActiveTask)> {
+    tasks.remove_if(key, |_, active| active.work.id() == work_id)
+}
+
+/// What the reporter owes the coordinator once a task's work future resolves.
+pub(crate) enum Report {
+    Complete(TaskMetadata),
+    Fail {
+        retryable: bool,
+    },
+    /// The work was aborted before it finished, so its fate is decided elsewhere.
+    /// Anything said here would race that decision.
+    Nothing,
+}
+
+pub(crate) fn report_for(
+    key: &(String, String),
+    result: Result<(proto::TaskStatus, Option<TaskMetadata>), JoinError>,
+) -> Report {
+    match result {
+        Ok((proto::TaskStatus::Succeeded, metadata)) => {
+            Report::Complete(metadata.expect("successful task should have metadata"))
+        }
+        Ok((status, _)) => Report::Fail {
+            retryable: status == proto::TaskStatus::FailedRetryable,
+        },
+        Err(e) if e.is_cancelled() => {
+            tracing::info!("Task {:?} cancelled before completing", key);
+            Report::Nothing
+        }
+        Err(e) => {
+            tracing::error!("Task {:?} panicked: {:?}", key, e);
+            Report::Fail { retryable: false }
+        }
+    }
+}
 
 async fn run_worker_inner(
     node_config: NodeConfig,
@@ -177,6 +227,10 @@ async fn run_worker_inner(
     worker: Arc<SP1ClusterWorker<impl WorkerClient, impl ArtifactClient, impl SP1ProverComponents>>,
 ) -> eyre::Result<()> {
     let tasks: Arc<DashMap<(String, String), ActiveTask>> = Arc::new(DashMap::new());
+    // A cancelled task is dropped from `tasks` immediately so a redelivery under the same
+    // key is accepted, but its reporter may still be mid-RPC. Draining on `tasks` alone
+    // would exit under it and lose the completion.
+    let reporters_in_flight = Arc::new(AtomicUsize::new(0));
 
     // Beats stop when this future ends (return or harness kill).
     let heartbeat = HeartbeatHandle::spawn(node_config.clone(), tasks.clone(), token.clone())?;
@@ -256,8 +310,15 @@ async fn run_worker_inner(
                                     let task_type = data.task_type();
                                     let proof_id = data.proof_id.clone();
                                     let key = (proof_id, task.task_id.clone());
-                                    let handle = tokio::spawn({
+                                    let work = tokio::spawn({
                                         let worker = worker.clone();
+                                        let task = task.clone();
+                                        async move { worker.run_task(&task).await }
+                                    });
+                                    let work_abort = work.abort_handle();
+                                    reporters_in_flight.fetch_add(1, Ordering::SeqCst);
+                                    let reporter = tokio::spawn({
+                                        let in_flight = reporters_in_flight.clone();
                                         let task = task.clone();
                                         let data = data.clone();
                                         let worker_client = worker_client.clone();
@@ -265,12 +326,16 @@ async fn run_worker_inner(
                                         let worker_id = node_config.worker_id.clone();
                                         let tasks = tasks.clone();
                                         async move {
-                                            let (status, metadata) = worker
-                                                .run_task(&task)
-                                                .await;
-                                            match status {
-                                                proto::TaskStatus::Succeeded => {
-                                                    let metadata_string = serde_json::to_string(&metadata.expect("successful task should have metadata")).unwrap();
+                                            let _tracked = sp1_cluster_worker::utils::DeferGuard::new(
+                                                in_flight,
+                                                |c| {
+                                                    c.fetch_sub(1, Ordering::SeqCst);
+                                                },
+                                            );
+                                            let work_id = work.id();
+                                            match report_for(&key, work.await) {
+                                                Report::Complete(metadata) => {
+                                                    let metadata_string = serde_json::to_string(&metadata).unwrap();
                                                     if let Err(e) = worker_client.complete_task(CompleteTaskRequest {
                                                         worker_id,
                                                         proof_id: data.proof_id.clone(),
@@ -280,9 +345,7 @@ async fn run_worker_inner(
                                                         tracing::error!("Failed to complete task: {:?}", e);
                                                     }
                                                 }
-                                                _ => {
-                                                    let retryable = status
-                                                        == sp1_cluster_common::proto::TaskStatus::FailedRetryable;
+                                                Report::Fail { retryable } => {
                                                     if let Err(e) = worker_client.fail_task(FailTaskRequest {
                                                         worker_id,
                                                         proof_id: data.proof_id.clone(),
@@ -292,25 +355,30 @@ async fn run_worker_inner(
                                                         tracing::error!("Failed to fail task: {:?}", e);
                                                     }
                                                 }
+                                                Report::Nothing => return,
                                             }
-                                            let removed = tasks.remove(&key);
+                                            let removed = drop_if_current(&tasks, &key, work_id);
                                             tracing::info!(
                                                 "Completed task {:?} {:?} after {:?}",
                                                 task_type,
                                                 key,
-                                                removed.map(|r| r.1 .2.elapsed())
+                                                removed.map(|r| r.1.started_at.elapsed())
                                             );
                                         }
                                     });
-                                    tasks.insert(key, (task.data.unwrap().clone(), handle, Instant::now()));
+                                    tasks.insert(key, ActiveTask {
+                                        data: task.data.unwrap().clone(),
+                                        started_at: Instant::now(),
+                                        work: work_abort,
+                                        reporter,
+                                    });
                                 }
                                 Some(server_message::Message::CancelTask(task)) => {
                                     if let Some(entry) =
                                         tasks.get(&(task.proof_id.clone(), task.task_id.clone()))
                                     {
-                                        let (_, handle, _) = entry.value();
                                         tracing::info!("Aborting task {} {}", task.proof_id, task.task_id);
-                                        handle.abort();
+                                        entry.value().work.abort();
                                         drop(entry);
                                         tasks.remove(&(task.proof_id, task.task_id.clone()));
                                     }
@@ -365,13 +433,14 @@ async fn run_worker_inner(
                         }
                         last_tick = Instant::now();
                         // If the worker is closed and there's no tasks, break out of the loop.
-                        if closed && tasks.is_empty() {
+                        if closed && tasks.is_empty() && reporters_in_flight.load(Ordering::SeqCst) == 0 {
                             tracing::info!("Worker is closed and has no tasks, breaking out of loop");
                             break;
                         }
                         if let Some(started) = drain_started_at {
                             let elapsed = started.elapsed();
-                            let in_flight = tasks.len();
+                            let in_flight =
+                                tasks.len() + reporters_in_flight.load(Ordering::SeqCst);
                             if elapsed > node_config.drain_timeout {
                                 let stuck: Vec<_> = tasks.iter().map(|e| e.key().clone()).collect();
                                 tracing::warn!(
@@ -425,11 +494,9 @@ async fn run_worker_inner(
                         let mut panicked_tasks = HashSet::new();
                         let mut timed_out_tasks = HashSet::new();
                         for entry in tasks.iter_mut() {
-                            // The threads should be removing from tasks when they complete, so
-                            // if it's reached this point, it must be because it panicked.
-                            if entry.value().1.is_finished() {
+                            if entry.value().reporter.is_finished() {
                                 panicked_tasks.insert(entry.key().clone());
-                            } else if entry.value().2.elapsed() > node_config.task_timeout {
+                            } else if entry.value().started_at.elapsed() > node_config.task_timeout {
                                 timed_out_tasks.insert(entry.key().clone());
                             }
                         }
@@ -438,7 +505,7 @@ async fn run_worker_inner(
                                 tracing::warn!("Task {:?} was panicked but is not in tasks anymore", task_id);
                                 continue;
                             };
-                            if let Err(e) = task.1.await {
+                            if let Err(e) = task.reporter.await {
                                 tracing::error!("Task {:?} panicked: {:?}", task_id, e);
                                 if let Err(e) = worker_client.fail_task(FailTaskRequest {
                                     worker_id: node_config.worker_id.clone(),
@@ -458,7 +525,7 @@ async fn run_worker_inner(
                                 continue;
                             };
                             tracing::error!("Task {:?} timed out after {:?}", task_id, node_config.task_timeout);
-                            task.1.abort();
+                            task.work.abort();
                             if let Err(e) = worker_client.fail_task(FailTaskRequest {
                                 worker_id: node_config.worker_id.clone(),
                                 proof_id: task_id.0,
@@ -477,7 +544,7 @@ async fn run_worker_inner(
                         }).await {
                             tracing::error!("Failed to close worker: {:?}", e);
                         }
-                        if tasks.is_empty() {
+                        if tasks.is_empty() && reporters_in_flight.load(Ordering::SeqCst) == 0 {
                             tracing::info!("No in-flight tasks; shutting down immediately");
                             break;
                         } else {
@@ -517,4 +584,215 @@ async fn run_worker_inner(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key() -> (String, String) {
+        ("p1".to_string(), "t1".to_string())
+    }
+
+    async fn join_result(
+        f: impl std::future::Future<Output = (proto::TaskStatus, Option<TaskMetadata>)> + Send + 'static,
+    ) -> Result<(proto::TaskStatus, Option<TaskMetadata>), JoinError> {
+        tokio::spawn(f).await
+    }
+
+    fn active_task(work: JoinHandle<(proto::TaskStatus, Option<TaskMetadata>)>) -> ActiveTask {
+        ActiveTask {
+            data: TaskData::default(),
+            started_at: Instant::now(),
+            work: work.abort_handle(),
+            reporter: tokio::spawn(std::future::ready(())),
+        }
+    }
+
+    #[tokio::test]
+    async fn success_is_reported() {
+        let result = join_result(async {
+            (
+                proto::TaskStatus::Succeeded,
+                Some(TaskMetadata { gpu_ms: Some(7) }),
+            )
+        })
+        .await;
+
+        match report_for(&key(), result) {
+            Report::Complete(metadata) => assert_eq!(metadata.gpu_ms, Some(7)),
+            _ => panic!("a succeeded task must be reported complete"),
+        }
+    }
+
+    #[tokio::test]
+    async fn failure_carries_its_retryability() {
+        let retryable = join_result(async { (proto::TaskStatus::FailedRetryable, None) }).await;
+        let fatal = join_result(async { (proto::TaskStatus::FailedFatal, None) }).await;
+
+        assert!(matches!(
+            report_for(&key(), retryable),
+            Report::Fail { retryable: true }
+        ));
+        assert!(matches!(
+            report_for(&key(), fatal),
+            Report::Fail { retryable: false }
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancellation_reports_nothing() {
+        let work = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        work.abort();
+
+        assert!(matches!(report_for(&key(), work.await), Report::Nothing));
+    }
+
+    #[tokio::test]
+    async fn panic_fails_the_task_fatally() {
+        let result = join_result(async { panic!("boom") }).await;
+
+        assert!(matches!(
+            report_for(&key(), result),
+            Report::Fail { retryable: false }
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_task_keeps_the_drain_waiting_on_its_reporter() {
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let tasks: DashMap<(String, String), ActiveTask> = DashMap::new();
+        let key = key();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+        in_flight.fetch_add(1, Ordering::SeqCst);
+        let work = tokio::spawn(std::future::ready((
+            proto::TaskStatus::Succeeded,
+            Some(TaskMetadata { gpu_ms: Some(1) }),
+        )));
+        let work_abort = work.abort_handle();
+        let reporter = tokio::spawn({
+            let in_flight = in_flight.clone();
+            async move {
+                let _tracked = sp1_cluster_worker::utils::DeferGuard::new(in_flight, |c| {
+                    c.fetch_sub(1, Ordering::SeqCst);
+                });
+                let _ = work.await;
+                release_rx.await.unwrap();
+            }
+        });
+        tasks.insert(
+            key.clone(),
+            ActiveTask {
+                data: TaskData::default(),
+                started_at: Instant::now(),
+                work: work_abort,
+                reporter,
+            },
+        );
+
+        // The CancelTask arm drops the entry so a redelivery is accepted.
+        tasks.remove(&key);
+
+        assert!(tasks.is_empty());
+        assert!(
+            in_flight.load(Ordering::SeqCst) > 0,
+            "drain would exit while the reporter is still delivering"
+        );
+
+        release_tx.send(()).unwrap();
+        while in_flight.load(Ordering::SeqCst) > 0 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// A stale reporter finishing after its task was cancelled and redelivered must not
+    /// evict the successor, which would strand it with no heartbeat and no timeout.
+    #[tokio::test]
+    async fn a_stale_reporter_leaves_the_successor_entry_alone() {
+        let tasks: DashMap<(String, String), ActiveTask> = DashMap::new();
+        let key = key();
+
+        let stale_work = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        let stale_id = stale_work.id();
+        let successor = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        let successor_id = successor.id();
+        tasks.insert(key.clone(), active_task(successor));
+
+        assert!(
+            drop_if_current(&tasks, &key, stale_id).is_none(),
+            "the stale reporter evicted its successor"
+        );
+        assert!(tasks.contains_key(&key));
+
+        assert!(
+            drop_if_current(&tasks, &key, successor_id).is_some(),
+            "the owning reporter must drop its own entry"
+        );
+        assert!(tasks.is_empty());
+        stale_work.abort();
+    }
+
+    /// `CancelTask` must abort the work, never the reporter. Otherwise a finished
+    /// task goes unreported and the coordinator requeues work that is done.
+    #[tokio::test]
+    async fn cancelling_after_the_work_finished_still_reports_it() {
+        let tasks: DashMap<(String, String), ActiveTask> = DashMap::new();
+        let key = key();
+        let (reported_tx, reported_rx) = tokio::sync::oneshot::channel();
+        let (ran_tx, ran_rx) = tokio::sync::oneshot::channel();
+
+        let work = tokio::spawn(async move {
+            ran_tx.send(()).unwrap();
+            (
+                proto::TaskStatus::Succeeded,
+                Some(TaskMetadata { gpu_ms: Some(1) }),
+            )
+        });
+        let work_abort = work.abort_handle();
+        let reporter = tokio::spawn({
+            let key = key.clone();
+            async move {
+                let reported = matches!(report_for(&key, work.await), Report::Complete(_));
+                // Stands in for the complete_task RPC: the reporter must survive an
+                // abort while it runs.
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                reported_tx.send(reported).unwrap();
+            }
+        });
+        tasks.insert(
+            key.clone(),
+            ActiveTask {
+                data: TaskData::default(),
+                started_at: Instant::now(),
+                work: work_abort,
+                reporter,
+            },
+        );
+
+        ran_rx.await.unwrap();
+        tokio::task::yield_now().await;
+
+        // The CancelTask arm.
+        if let Some(entry) = tasks.get(&key) {
+            entry.value().work.abort();
+            drop(entry);
+            tasks.remove(&key);
+        }
+
+        assert_eq!(
+            reported_rx.await,
+            Ok(true),
+            "the completion was swallowed by the cancel"
+        );
+    }
 }

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -221,6 +221,14 @@ pub(crate) fn report_for(
     }
 }
 
+/// Whether the timeout sweep should abort and fail this task. Finished work
+/// still in the map is mid-report, not stuck: failing it would race its own
+/// completion. The reporter drops the entry once the report lands, and a
+/// coordinator that stays unreachable trips the channel-silence exit instead.
+fn timed_out(active: &ActiveTask, timeout: Duration) -> bool {
+    !active.work.is_finished() && active.started_at.elapsed() > timeout
+}
+
 async fn run_worker_inner(
     node_config: NodeConfig,
     token: CancellationToken,
@@ -497,7 +505,7 @@ async fn run_worker_inner(
                         for entry in tasks.iter_mut() {
                             if entry.value().reporter.is_finished() {
                                 panicked_tasks.insert(entry.key().clone());
-                            } else if entry.value().started_at.elapsed() > node_config.task_timeout {
+                            } else if timed_out(entry.value(), node_config.task_timeout) {
                                 timed_out_tasks.insert(entry.key().clone());
                             }
                         }
@@ -660,6 +668,33 @@ mod tests {
             report_for(&key(), result),
             Report::Fail { retryable: false }
         ));
+    }
+
+    #[tokio::test]
+    async fn finished_work_mid_report_is_not_timed_out() {
+        let work = tokio::spawn(std::future::ready((proto::TaskStatus::Succeeded, None)));
+        let task = active_task(work);
+        while !task.work.is_finished() {
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            !timed_out(&task, Duration::ZERO),
+            "failing a finished task races its own completion report"
+        );
+    }
+
+    #[tokio::test]
+    async fn stuck_work_is_timed_out_only_past_the_timeout() {
+        let work = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        let task = active_task(work);
+        tokio::time::sleep(Duration::from_millis(2)).await;
+
+        assert!(timed_out(&task, Duration::ZERO));
+        assert!(!timed_out(&task, Duration::from_secs(3600)));
     }
 
     #[tokio::test]

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -265,20 +265,20 @@ const ABORT_GRACE: Duration = Duration::from_secs(10);
 fn spawn_wedged_report(
     worker_client: &WorkerServiceClient,
     reporters_in_flight: &Arc<AtomicUsize>,
-    coordinator_closed: &Arc<tokio::sync::OnceCell<()>>,
+    close_acked: &Arc<tokio::sync::OnceCell<()>>,
     worker_id: &str,
     wedged: Vec<(String, String)>,
 ) {
     reporters_in_flight.fetch_add(1, Ordering::SeqCst);
     let in_flight = reporters_in_flight.clone();
     let worker_client = worker_client.clone();
-    let coordinator_closed = coordinator_closed.clone();
+    let close_acked = close_acked.clone();
     let worker_id = worker_id.to_string();
     tokio::spawn(async move {
         let _tracked = sp1_cluster_worker::utils::DeferGuard::new(in_flight, |c| {
             c.fetch_sub(1, Ordering::SeqCst);
         });
-        let closed = coordinator_closed
+        let acked = close_acked
             .get_or_try_init(|| async {
                 worker_client
                     .close(CloseRequest {
@@ -287,7 +287,7 @@ fn spawn_wedged_report(
                     .await
             })
             .await;
-        if let Err(e) = closed {
+        if let Err(e) = acked {
             // Report anyway: a stalled proof outranks a bounced assignment.
             tracing::error!(
                 "Failed to close worker before failing wedged tasks: {:?}",
@@ -323,7 +323,7 @@ async fn run_worker_inner(
     let reporters_in_flight = Arc::new(AtomicUsize::new(0));
     // Set once the coordinator acknowledged our close. Wedged batches await it
     // before fail_task, so a requeued task can't be assigned back here.
-    let coordinator_closed: Arc<tokio::sync::OnceCell<()>> = Arc::new(tokio::sync::OnceCell::new());
+    let close_acked: Arc<tokio::sync::OnceCell<()>> = Arc::new(tokio::sync::OnceCell::new());
 
     // Beats stop when this future ends (return or harness kill).
     let heartbeat = HeartbeatHandle::spawn(node_config.clone(), tasks.clone(), token.clone())?;
@@ -662,7 +662,7 @@ async fn run_worker_inner(
                             spawn_wedged_report(
                                 &worker_client,
                                 &reporters_in_flight,
-                                &coordinator_closed,
+                                &close_acked,
                                 &node_config.worker_id,
                                 wedged_reports,
                             );
@@ -676,7 +676,7 @@ async fn run_worker_inner(
                         }).await {
                             tracing::error!("Failed to close worker: {:?}", e);
                         } else {
-                            let _ = coordinator_closed.set(());
+                            let _ = close_acked.set(());
                         }
                         if tasks.is_empty() && reporters_in_flight.load(Ordering::SeqCst) == 0 {
                             tracing::info!("No in-flight tasks; shutting down immediately");

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -821,6 +821,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn panic_fails_the_task_fatally() {
+        let result = join_result(async { panic!("boom") }).await;
+
+        assert!(matches!(
+            report_for(&key(), result, false),
+            Report::Fail { retryable: false }
+        ));
+    }
+
+    #[tokio::test]
     async fn finished_work_mid_report_is_left_alone() {
         let work = tokio::spawn(std::future::ready((proto::TaskStatus::Succeeded, None)));
         let task = active_task(work);
@@ -876,16 +886,6 @@ mod tests {
         assert!(matches!(
             timeout_action(&task, Duration::ZERO, Duration::from_secs(3600)),
             TimeoutAction::Abort
-        ));
-    }
-
-    #[tokio::test]
-    async fn panic_fails_the_task_fatally() {
-        let result = join_result(async { panic!("boom") }).await;
-
-        assert!(matches!(
-            report_for(&key(), result, false),
-            Report::Fail { retryable: false }
         ));
     }
 

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -203,9 +203,10 @@ pub(crate) fn report_for(
     result: Result<(proto::TaskStatus, Option<TaskMetadata>), JoinError>,
 ) -> Report {
     match result {
-        Ok((proto::TaskStatus::Succeeded, metadata)) => {
-            Report::Complete(metadata.expect("successful task should have metadata"))
-        }
+        Ok((proto::TaskStatus::Succeeded, Some(metadata))) => Report::Complete(metadata),
+        // Success with no metadata means an execution error, which already unclaimed the
+        // proof. There is no proof to report complete.
+        Ok((proto::TaskStatus::Succeeded, None)) => Report::Fail { retryable: false },
         Ok((status, _)) => Report::Fail {
             retryable: status == proto::TaskStatus::FailedRetryable,
         },
@@ -649,6 +650,16 @@ mod tests {
         work.abort();
 
         assert!(matches!(report_for(&key(), work.await), Report::Nothing));
+    }
+
+    #[tokio::test]
+    async fn success_without_metadata_fails_fatally() {
+        let result = join_result(async { (proto::TaskStatus::Succeeded, None) }).await;
+
+        assert!(matches!(
+            report_for(&key(), result),
+            Report::Fail { retryable: false }
+        ));
     }
 
     #[tokio::test]

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -586,6 +586,7 @@ async fn run_worker_inner(
                             entry.value().timed_out.store(true, Ordering::SeqCst);
                             entry.value().work.abort();
                         }
+                        let mut wedged_reports = Vec::new();
                         for task_id in wedged_tasks {
                             let Some((_, task)) = tasks.remove(&task_id) else {
                                 continue;
@@ -596,28 +597,52 @@ async fn run_worker_inner(
                                 ABORT_GRACE,
                             );
                             task.work.abort();
+                            wedged_reports.push(task_id);
+                        }
+                        if !wedged_reports.is_empty() {
                             // Close before failing: fail_task requeues the task and
                             // triggers assignment, and an open worker with freed
                             // capacity can win its own retry back while the wedged
                             // work still burns the machine. Draining ends in a
                             // restart, the only thing that actually frees it.
-                            if !closed {
-                                closed = true;
-                                drain_started_at = Some(Instant::now());
-                                if let Err(e) = worker_client.close(CloseRequest {
-                                    worker_id: node_config.worker_id.clone(),
-                                }).await {
-                                    tracing::error!("Failed to close worker: {:?}", e);
+                            let close_worker = !closed;
+                            closed = true;
+                            drain_started_at.get_or_insert_with(Instant::now);
+                            // Both RPCs retry transient errors for minutes; awaiting
+                            // them here would freeze this loop while heartbeats keep
+                            // the worker looking alive. The drain waits on
+                            // `reporters_in_flight` for the spawned report.
+                            reporters_in_flight.fetch_add(1, Ordering::SeqCst);
+                            tokio::spawn({
+                                let in_flight = reporters_in_flight.clone();
+                                let worker_client = worker_client.clone();
+                                let worker_id = node_config.worker_id.clone();
+                                async move {
+                                    let _tracked = sp1_cluster_worker::utils::DeferGuard::new(
+                                        in_flight,
+                                        |c| {
+                                            c.fetch_sub(1, Ordering::SeqCst);
+                                        },
+                                    );
+                                    if close_worker {
+                                        if let Err(e) = worker_client.close(CloseRequest {
+                                            worker_id: worker_id.clone(),
+                                        }).await {
+                                            tracing::error!("Failed to close worker: {:?}", e);
+                                        }
+                                    }
+                                    for (proof_id, task_id) in wedged_reports {
+                                        if let Err(e) = worker_client.fail_task(FailTaskRequest {
+                                            worker_id: worker_id.clone(),
+                                            proof_id,
+                                            task_id,
+                                            retryable: true,
+                                        }).await {
+                                            tracing::error!("Failed to update task status: {:?}", e);
+                                        }
+                                    }
                                 }
-                            }
-                            if let Err(e) = worker_client.fail_task(FailTaskRequest {
-                                worker_id: node_config.worker_id.clone(),
-                                proof_id: task_id.0,
-                                task_id: task_id.1,
-                                retryable: true,
-                            }).await {
-                                tracing::error!("Failed to update task status: {:?}", e);
-                            }
+                            });
                         }
                     }
                     _ = token.cancelled(), if !closed => {

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -258,6 +258,51 @@ fn timeout_action(active: &ActiveTask, timeout: Duration, grace: Duration) -> Ti
 /// point, short enough that a truly wedged proof requeues promptly.
 const ABORT_GRACE: Duration = Duration::from_secs(10);
 
+/// Reports wedged tasks off the main loop: the RPCs retry for minutes, and
+/// heartbeats would keep a frozen loop looking alive. Closes the worker first
+/// so its freed capacity can't win a retry back while the wedged work still
+/// burns; tracked in `reporters_in_flight` so the drain waits.
+fn spawn_wedged_report(
+    worker_client: &WorkerServiceClient,
+    reporters_in_flight: &Arc<AtomicUsize>,
+    worker_id: &str,
+    close_worker: bool,
+    wedged: Vec<(String, String)>,
+) {
+    reporters_in_flight.fetch_add(1, Ordering::SeqCst);
+    let in_flight = reporters_in_flight.clone();
+    let worker_client = worker_client.clone();
+    let worker_id = worker_id.to_string();
+    tokio::spawn(async move {
+        let _tracked = sp1_cluster_worker::utils::DeferGuard::new(in_flight, |c| {
+            c.fetch_sub(1, Ordering::SeqCst);
+        });
+        if close_worker {
+            if let Err(e) = worker_client
+                .close(CloseRequest {
+                    worker_id: worker_id.clone(),
+                })
+                .await
+            {
+                tracing::error!("Failed to close worker: {:?}", e);
+            }
+        }
+        for (proof_id, task_id) in wedged {
+            if let Err(e) = worker_client
+                .fail_task(FailTaskRequest {
+                    worker_id: worker_id.clone(),
+                    proof_id,
+                    task_id,
+                    retryable: true,
+                })
+                .await
+            {
+                tracing::error!("Failed to update task status: {:?}", e);
+            }
+        }
+    });
+}
+
 async fn run_worker_inner(
     node_config: NodeConfig,
     token: CancellationToken,
@@ -600,49 +645,18 @@ async fn run_worker_inner(
                             wedged_reports.push(task_id);
                         }
                         if !wedged_reports.is_empty() {
-                            // Close before failing: fail_task requeues the task and
-                            // triggers assignment, and an open worker with freed
-                            // capacity can win its own retry back while the wedged
-                            // work still burns the machine. Draining ends in a
-                            // restart, the only thing that actually frees it.
+                            // Draining ends in a restart — the only thing that
+                            // frees wedged work.
                             let close_worker = !closed;
                             closed = true;
                             drain_started_at.get_or_insert_with(Instant::now);
-                            // Both RPCs retry transient errors for minutes; awaiting
-                            // them here would freeze this loop while heartbeats keep
-                            // the worker looking alive. The drain waits on
-                            // `reporters_in_flight` for the spawned report.
-                            reporters_in_flight.fetch_add(1, Ordering::SeqCst);
-                            tokio::spawn({
-                                let in_flight = reporters_in_flight.clone();
-                                let worker_client = worker_client.clone();
-                                let worker_id = node_config.worker_id.clone();
-                                async move {
-                                    let _tracked = sp1_cluster_worker::utils::DeferGuard::new(
-                                        in_flight,
-                                        |c| {
-                                            c.fetch_sub(1, Ordering::SeqCst);
-                                        },
-                                    );
-                                    if close_worker {
-                                        if let Err(e) = worker_client.close(CloseRequest {
-                                            worker_id: worker_id.clone(),
-                                        }).await {
-                                            tracing::error!("Failed to close worker: {:?}", e);
-                                        }
-                                    }
-                                    for (proof_id, task_id) in wedged_reports {
-                                        if let Err(e) = worker_client.fail_task(FailTaskRequest {
-                                            worker_id: worker_id.clone(),
-                                            proof_id,
-                                            task_id,
-                                            retryable: true,
-                                        }).await {
-                                            tracing::error!("Failed to update task status: {:?}", e);
-                                        }
-                                    }
-                                }
-                            });
+                            spawn_wedged_report(
+                                &worker_client,
+                                &reporters_in_flight,
+                                &node_config.worker_id,
+                                close_worker,
+                                wedged_reports,
+                            );
                         }
                     }
                     _ = token.cancelled(), if !closed => {

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -17,7 +17,7 @@ use sp1_prover::worker::{TaskMetadata, WorkerClient};
 use sp1_prover::SP1ProverComponents;
 use sp1_sdk::install::try_install_circuit_artifacts;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sysinfo::{MemoryRefreshKind, RefreshKind, System};
@@ -175,6 +175,9 @@ pub(crate) struct ActiveTask {
     pub work: AbortHandle,
     /// Outlives cancellation of `work`, so a task that finished can still report it.
     pub reporter: JoinHandle<()>,
+    /// Set by the timeout sweep before aborting `work`, so the reporter fails
+    /// the task instead of staying silent.
+    pub timed_out: Arc<AtomicBool>,
 }
 
 /// Drops the task's entry unless a redelivery already replaced it. A cancelled task
@@ -201,6 +204,7 @@ pub(crate) enum Report {
 pub(crate) fn report_for(
     key: &(String, String),
     result: Result<(proto::TaskStatus, Option<TaskMetadata>), JoinError>,
+    timed_out: bool,
 ) -> Report {
     match result {
         Ok((proto::TaskStatus::Succeeded, Some(metadata))) => Report::Complete(metadata),
@@ -210,6 +214,12 @@ pub(crate) fn report_for(
         Ok((status, _)) => Report::Fail {
             retryable: status == proto::TaskStatus::FailedRetryable,
         },
+        // Only reached when the work truly died: a finish that beat the abort
+        // takes the arms above, so the flag never overrides a real result.
+        Err(e) if e.is_cancelled() && timed_out => {
+            tracing::error!("Task {:?} timed out and was aborted", key);
+            Report::Fail { retryable: true }
+        }
         Err(e) if e.is_cancelled() => {
             tracing::info!("Task {:?} cancelled before completing", key);
             Report::Nothing
@@ -325,9 +335,11 @@ async fn run_worker_inner(
                                         async move { worker.run_task(&task).await }
                                     });
                                     let work_abort = work.abort_handle();
+                                    let timed_out_flag = Arc::new(AtomicBool::new(false));
                                     reporters_in_flight.fetch_add(1, Ordering::SeqCst);
                                     let reporter = tokio::spawn({
                                         let in_flight = reporters_in_flight.clone();
+                                        let timed_out_flag = timed_out_flag.clone();
                                         let task = task.clone();
                                         let data = data.clone();
                                         let worker_client = worker_client.clone();
@@ -342,7 +354,9 @@ async fn run_worker_inner(
                                                 },
                                             );
                                             let work_id = work.id();
-                                            match report_for(&key, work.await) {
+                                            let result = work.await;
+                                            let timed_out = timed_out_flag.load(Ordering::SeqCst);
+                                            match report_for(&key, result, timed_out) {
                                                 Report::Complete(metadata) => {
                                                     let metadata_string = serde_json::to_string(&metadata).unwrap();
                                                     if let Err(e) = worker_client.complete_task(CompleteTaskRequest {
@@ -380,6 +394,7 @@ async fn run_worker_inner(
                                         started_at: Instant::now(),
                                         work: work_abort,
                                         reporter,
+                                        timed_out: timed_out_flag,
                                     });
                                 }
                                 Some(server_message::Message::CancelTask(task)) => {
@@ -532,20 +547,16 @@ async fn run_worker_inner(
                             }
                         }
                         for task_id in timed_out_tasks {
-                            let Some((_, task)) = tasks.remove(&task_id) else {
+                            let Some(entry) = tasks.get(&task_id) else {
                                 tracing::warn!("Task {:?} timed out but is not in tasks anymore", task_id);
                                 continue;
                             };
                             tracing::error!("Task {:?} timed out after {:?}", task_id, node_config.task_timeout);
-                            task.work.abort();
-                            if let Err(e) = worker_client.fail_task(FailTaskRequest {
-                                worker_id: node_config.worker_id.clone(),
-                                proof_id: task_id.0,
-                                task_id: task_id.1,
-                                retryable: true,
-                            }).await {
-                                tracing::error!("Failed to update task status: {:?}", e);
-                            }
+                            // Reporting here would race a completion from work that
+                            // finished after the check. The reporter owns the report,
+                            // and drops the entry once it lands.
+                            entry.value().timed_out.store(true, Ordering::SeqCst);
+                            entry.value().work.abort();
                         }
                     }
                     _ = token.cancelled(), if !closed => {
@@ -618,6 +629,7 @@ mod tests {
             started_at: Instant::now(),
             work: work.abort_handle(),
             reporter: tokio::spawn(std::future::ready(())),
+            timed_out: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -631,7 +643,7 @@ mod tests {
         })
         .await;
 
-        match report_for(&key(), result) {
+        match report_for(&key(), result, false) {
             Report::Complete(metadata) => assert_eq!(metadata.gpu_ms, Some(7)),
             _ => panic!("a succeeded task must be reported complete"),
         }
@@ -643,11 +655,11 @@ mod tests {
         let fatal = join_result(async { (proto::TaskStatus::FailedFatal, None) }).await;
 
         assert!(matches!(
-            report_for(&key(), retryable),
+            report_for(&key(), retryable, false),
             Report::Fail { retryable: true }
         ));
         assert!(matches!(
-            report_for(&key(), fatal),
+            report_for(&key(), fatal, false),
             Report::Fail { retryable: false }
         ));
     }
@@ -660,7 +672,42 @@ mod tests {
         )>());
         work.abort();
 
-        assert!(matches!(report_for(&key(), work.await), Report::Nothing));
+        assert!(matches!(
+            report_for(&key(), work.await, false),
+            Report::Nothing
+        ));
+    }
+
+    #[tokio::test]
+    async fn timeout_abort_fails_the_task_retryably() {
+        let work = tokio::spawn(std::future::pending::<(
+            proto::TaskStatus,
+            Option<TaskMetadata>,
+        )>());
+        work.abort();
+
+        assert!(matches!(
+            report_for(&key(), work.await, true),
+            Report::Fail { retryable: true }
+        ));
+    }
+
+    /// Work can finish between the sweep's check and its abort; the flag must
+    /// not turn that success into a failure.
+    #[tokio::test]
+    async fn a_timeout_that_lost_the_race_to_finished_work_reports_success() {
+        let result = join_result(async {
+            (
+                proto::TaskStatus::Succeeded,
+                Some(TaskMetadata { gpu_ms: Some(7) }),
+            )
+        })
+        .await;
+
+        assert!(matches!(
+            report_for(&key(), result, true),
+            Report::Complete(_)
+        ));
     }
 
     #[tokio::test]
@@ -668,7 +715,7 @@ mod tests {
         let result = join_result(async { (proto::TaskStatus::Succeeded, None) }).await;
 
         assert!(matches!(
-            report_for(&key(), result),
+            report_for(&key(), result, false),
             Report::Fail { retryable: false }
         ));
     }
@@ -705,7 +752,7 @@ mod tests {
         let result = join_result(async { panic!("boom") }).await;
 
         assert!(matches!(
-            report_for(&key(), result),
+            report_for(&key(), result, false),
             Report::Fail { retryable: false }
         ));
     }
@@ -740,6 +787,7 @@ mod tests {
                 started_at: Instant::now(),
                 work: work_abort,
                 reporter,
+                timed_out: Arc::new(AtomicBool::new(false)),
             },
         );
 
@@ -811,7 +859,7 @@ mod tests {
         let reporter = tokio::spawn({
             let key = key.clone();
             async move {
-                let reported = matches!(report_for(&key, work.await), Report::Complete(_));
+                let reported = matches!(report_for(&key, work.await, false), Report::Complete(_));
                 // Stands in for the complete_task RPC: the reporter must survive an
                 // abort while it runs.
                 tokio::time::sleep(Duration::from_millis(200)).await;
@@ -825,6 +873,7 @@ mod tests {
                 started_at: Instant::now(),
                 work: work_abort,
                 reporter,
+                timed_out: Arc::new(AtomicBool::new(false)),
             },
         );
 


### PR DESCRIPTION
## Summary

  - Separate task execution from result delivery. Cancellation can stop work while a finished result continues reporting.
  - Make `Succeeded` final. Duplicate reports skip success hooks, and teardown releases each capacity charge once.
  - Recover wedged work after an abort-based grace. Close the worker before reporting retryable failures outside the main loop.

  ## Motivation

  A scheduler cancellation arrived after a shard finished but before `complete_task` reached the coordinator.

  The retry used reclaimed input and failed the proof. The cluster must preserve completed work across this race.

  The same race can create duplicate reports and stale assignments. Worker slots and policy weight must remain exact during cleanup