### PR TITLE
fix(compose): persist circuit artifacts across worker restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-air",
 ]
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7780,7 +7780,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-fri",
 ]
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "futures",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-matrix",
 ]
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "futures",
@@ -7953,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "slop-algebra",
 ]
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "futures",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8008,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8016,7 +8016,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "derive-where",
  "futures",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8478,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8647,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8723,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8828,7 +8828,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "clap",
  "serde",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8960,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "futures",
  "rayon",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "bincode",
  "blake3",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9205,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=286a7e30a#286a7e30a3445d635aef2e5b5b09943a60acd032"
+source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.3",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ferroid"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7676,7 +7687,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slop-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-air",
 ]
@@ -7684,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "slop-algebra"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -7694,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "slop-alloc"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -7704,7 +7715,7 @@ dependencies = [
 [[package]]
 name = "slop-baby-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -7718,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7740,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "slop-basefold-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7766,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "slop-bn254"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -7780,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "slop-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -7792,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "slop-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-commit",
  "serde",
@@ -7802,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "slop-dft"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-dft",
  "serde",
@@ -7815,7 +7826,7 @@ dependencies = [
 [[package]]
 name = "slop-fri"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-fri",
 ]
@@ -7823,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "slop-futures"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "crossbeam",
  "futures",
@@ -7837,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "slop-jagged"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "futures",
@@ -7870,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "slop-keccak-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -7878,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "slop-koala-bear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -7892,7 +7903,7 @@ dependencies = [
 [[package]]
 name = "slop-matrix"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-matrix",
 ]
@@ -7900,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "slop-maybe-rayon"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-maybe-rayon",
 ]
@@ -7908,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "slop-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -7933,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "slop-multilinear"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "futures",
@@ -7953,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "slop-poseidon2"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -7961,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "slop-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "slop-algebra",
 ]
@@ -7969,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "slop-stacked"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "futures",
@@ -7991,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "slop-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8008,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "slop-symmetric"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-symmetric",
 ]
@@ -8016,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "slop-tensor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -8035,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "slop-uni-stark"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-uni-stark",
 ]
@@ -8043,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "slop-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -8053,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "slop-whir"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "derive-where",
  "futures",
@@ -8121,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -8478,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8518,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8539,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-executor-runner-binary"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -8553,7 +8564,7 @@ dependencies = [
 [[package]]
 name = "sp1-core-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -8601,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8622,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8632,7 +8643,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-air"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "lazy_static",
  "slop-air",
@@ -8647,7 +8658,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-basefold"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8680,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-challenger"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8695,7 +8706,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-commit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -8723,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-cudart"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "crossbeam",
  "futures",
@@ -8752,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-assist"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8778,7 +8789,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8800,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8828,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-logup-gkr"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -8864,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-merkle-tree"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -8889,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "clap",
  "serde",
@@ -8924,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-shard-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "serde_json",
  "slop-air",
@@ -8960,7 +8971,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-sys"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "cbindgen",
  "cmake",
@@ -8976,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracegen"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "futures",
  "rayon",
@@ -9001,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-tracing"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -9011,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-utils"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "slop-algebra",
  "slop-alloc",
@@ -9024,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "sp1-gpu-zerocheck"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9055,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "sp1-hypercube"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -9103,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "sp1-jit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -9119,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "bincode",
  "blake3",
@@ -9142,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9151,6 +9162,7 @@ dependencies = [
  "either",
  "enum-map",
  "eyre",
+ "fd-lock",
  "futures",
  "hashbrown 0.14.5",
  "hex",
@@ -9205,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover-types"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -9228,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -9267,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9287,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-executor"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -9310,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9334,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-machine"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -9355,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -9431,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "sp1-verifier"
 version = "6.3.1"
-source = "git+https://github.com/succinctlabs/sp1?rev=fa0b424ab#fa0b424ab1d18c71d79f84cfb83b5ea01f63556b"
+source = "git+https://github.com/succinctlabs/sp1?rev=25571ca1e#25571ca1e4f4641cc95d479242245bd4e41ecdd2"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,20 +52,20 @@ spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 # yet. The whole sp1 family must share one source, or the workspace resolves two
 # sp1-prover-types packages and every crossing type mismatches. Move back to
 # released crates once one has the field.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab", features = ["network"] }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "25571ca1e" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,20 +52,20 @@ spn-utils = { git = "https://github.com/succinctlabs/network", branch = "main" }
 # yet. The whole sp1 family must share one source, or the workspace resolves two
 # sp1-prover-types packages and every crossing type mismatches. Move back to
 # released crates once one has the field.
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a", features = ["bigint-rug"] }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a", features = ["network"] }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab", features = ["bigint-rug"] }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-prover = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-prover-types = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-recursion-circuit = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab", features = ["network"] }
 
 # SP1 GPU
-sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
-sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "286a7e30a" }
+sp1-gpu-cudart = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
+sp1-gpu-prover = { git = "https://github.com/succinctlabs/sp1", rev = "fa0b424ab" }
 
 # Misc
 alloy = { version = "=1.1.3", default-features = false, features = ["serde"] }

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -133,9 +133,12 @@ COPY --from=build /fulfiller /fulfiller
 COPY --from=build /network-gateway /network-gateway
 COPY --from=build /node /node
 
-# Create .sp1 directories with correct ownership for volume mounts
-RUN mkdir -p /home/appuser/.sp1/circuits && \
-    chown -R appuser:appgroup /home/appuser/.sp1
+# Circuit artifact cache. A volume mounted anywhere else is dead: the worker then
+# re-downloads gigabytes of groth16/plonk artifacts on every container start.
+ENV SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16 \
+    SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
+RUN mkdir -p "$SP1_GROTH16_CIRCUIT_PATH" "$SP1_PLONK_CIRCUIT_PATH" && \
+    chown -R appuser:appgroup /var/cache/sp1
 
 # Set ownership to the non-root user and ensure the binary is executable
 RUN chown appuser:appgroup /api && \

--- a/infra/Dockerfile.node_gpu
+++ b/infra/Dockerfile.node_gpu
@@ -134,6 +134,13 @@ RUN groupadd --gid 1001 appgroup && \
 # Copy the built application binaries from the build stage
 COPY --from=build /sp1-cluster-node /app/sp1-cluster-node
 
+# Circuit artifact cache. Only WORKER_TYPE=ALL reads it, because the wrap step
+# runs here.
+ENV SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16 \
+  SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
+RUN mkdir -p "$SP1_GROTH16_CIRCUIT_PATH" "$SP1_PLONK_CIRCUIT_PATH" && \
+  chown -R appuser:appgroup /var/cache/sp1
+
 # Set ownership to the non-root user and ensure the binary is executable
 RUN chown appuser:appgroup /app/sp1-cluster-node && \
   chmod +x /app/sp1-cluster-node

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -55,11 +55,13 @@ cpu-node:
         sizeLimit: 96Gi
   volumeMounts:
     - name: sp1-circuits
-      mountPath: /root/.sp1/circuits
+      mountPath: /var/cache/sp1/circuits
     - name: dshm
       mountPath: /dev/shm
   extraEnv:
     NODE_COORDINATOR_RPC: http://coordinator-grpc:50051
+    SP1_GROTH16_CIRCUIT_PATH: /var/cache/sp1/circuits/groth16
+    SP1_PLONK_CIRCUIT_PATH: /var/cache/sp1/circuits/plonk
     # WORKER_MAX_WEIGHT_OVERRIDE is auto-detected from the pod's cgroup
     # memory limit; only set it if the auto-detect picks the wrong value.
     NODE_ARTIFACT_STORE: redis

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -97,6 +97,8 @@ services:
       - RUST_LOG=info
       - OTLP_ENDPOINT=http://alloy:4317
       - PROOF_DURATIONS_CSV=/data/proof_durations.csv
+      - SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16
+      - SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
       # - SP1_WORKER_USE_FIXED_PK=true
     build:
       context: ..
@@ -105,7 +107,7 @@ services:
         - private_pull_token
     command: ["/bin/sh", "-c", "/node"]
     volumes:
-      - ~/.sp1/circuits:/home/appuser/.sp1/circuits
+      - ~/.sp1/circuits:/var/cache/sp1/circuits
 
   gpu0:
     extends:

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -77,6 +77,14 @@ services:
         - private_pull_token
     command: ["/bin/sh", "-c", "/coordinator"]
 
+  # Docker gives a fresh volume root ownership. The worker runs as UID 1001, so hand
+  # it the volume first.
+  circuit-cache-init:
+    image: busybox:stable
+    entrypoint: ["/bin/sh", "-c", "chown -R 1001:1001 /var/cache/sp1/circuits"]
+    volumes:
+      - circuit-cache:/var/cache/sp1/circuits
+
   cpu-node:
     extends:
       file: docker-compose.yml
@@ -107,7 +115,7 @@ services:
         - private_pull_token
     command: ["/bin/sh", "-c", "/node"]
     volumes:
-      - ~/.sp1/circuits:/var/cache/sp1/circuits
+      - circuit-cache:/var/cache/sp1/circuits
 
   gpu0:
     extends:
@@ -215,6 +223,7 @@ services:
 volumes:
   redis_data:
   postgresql_data:
+  circuit-cache:
 
 secrets:
   private_pull_token:

--- a/infra/docker-compose.manager.yml
+++ b/infra/docker-compose.manager.yml
@@ -105,8 +105,10 @@ services:
       - RUST_LOG=debug,tower=info,h2=info
       - OTLP_ENDPOINT=http://alloy:4317
       - PROOF_DURATIONS_CSV=/data/proof_durations.csv
+      - SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16
+      - SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
     volumes:
-      - ${HOME}/.sp1/circuits:/root/.sp1/circuits
+      - circuit-cache:/var/cache/sp1/circuits
       - ./data:/data
     command: ["/bin/sh", "-c", "/node"]
     shm_size: 96G
@@ -124,3 +126,4 @@ services:
 volumes:
   redis_data:
   postgresql_data:
+  circuit-cache:

--- a/infra/docker-compose.manager.yml
+++ b/infra/docker-compose.manager.yml
@@ -85,6 +85,15 @@ services:
     depends_on:
       - api
 
+  # Docker creates the circuit-cache volume owned by root. The worker runs as UID
+  # 1001, so give it the volume first.
+  circuit-cache-init:
+    image: ghcr.io/succinctlabs/sp1-cluster:latest
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-c", "chown -R 1001:1001 /var/cache/sp1/circuits"]
+    volumes:
+      - circuit-cache:/var/cache/sp1/circuits
+
   # CPU Node (local to management node)
   cpu-node:
     image: ghcr.io/succinctlabs/sp1-cluster:latest
@@ -120,8 +129,12 @@ services:
           memory: 96G
 
     depends_on:
-      - coordinator
-      - redis
+      coordinator:
+        condition: service_started
+      redis:
+        condition: service_started
+      circuit-cache-init:
+        condition: service_completed_successfully
 
 volumes:
   redis_data:

--- a/infra/docker-compose.worker.yml
+++ b/infra/docker-compose.worker.yml
@@ -135,7 +135,7 @@ services:
   #     - NODE_REDIS_NODES=redis://:redispassword@${MANAGER_HOST:-host.docker.internal}:6379/0
   #     - WORKER_TYPE=CPU
   #   volumes:
-  #     - ${HOME}/.sp1/circuits:/root/.sp1/circuits
+  #     - ${HOME}/.sp1/circuits:/var/cache/sp1/circuits
   #   command: ["/bin/sh", "-c", "/node"]
   #   deploy:
   #     resources:

--- a/infra/docker-compose.worker.yml
+++ b/infra/docker-compose.worker.yml
@@ -121,6 +121,15 @@ services:
   #   extends:
   #     service: gpu0
 
+  # # Docker creates the circuit-cache volume owned by root. The worker runs as UID
+  # # 1001, so give it the volume first.
+  # circuit-cache-init:
+  #   image: ghcr.io/succinctlabs/sp1-cluster:latest
+  #   user: "0:0"
+  #   entrypoint: ["/bin/sh", "-c", "chown -R 1001:1001 /var/cache/sp1/circuits"]
+  #   volumes:
+  #     - circuit-cache:/var/cache/sp1/circuits
+
   # # CPU Node — uncomment to run CPU workers on this machine
   # # For performance tuning (splicing workers, buffer sizes), see:
   # #   https://github.com/succinctlabs/sp1/blob/main/crates/prover/src/worker/config.rs
@@ -134,8 +143,10 @@ services:
   #     - NODE_ARTIFACT_STORE=redis
   #     - NODE_REDIS_NODES=redis://:redispassword@${MANAGER_HOST:-host.docker.internal}:6379/0
   #     - WORKER_TYPE=CPU
+  #     - SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16
+  #     - SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
   #   volumes:
-  #     - ${HOME}/.sp1/circuits:/var/cache/sp1/circuits
+  #     - circuit-cache:/var/cache/sp1/circuits
   #   command: ["/bin/sh", "-c", "/node"]
   #   deploy:
   #     resources:
@@ -144,7 +155,11 @@ services:
   #       reservations:
   #         memory: 96G
   #   depends_on:
-  #     - alloy
+  #     alloy:
+  #       condition: service_started
+  #     circuit-cache-init:
+  #       condition: service_completed_successfully
 
 volumes:
   redis_data:
+  circuit-cache:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -57,6 +57,15 @@ services:
     depends_on:
       - api
 
+  # Docker creates the circuit-cache volume owned by root. Workers run as UID 1001,
+  # so give them the volume before any of them start.
+  circuit-cache-init:
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.6.0
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-c", "chown -R 1001:1001 /var/cache/sp1/circuits"]
+    volumes:
+      - circuit-cache:/var/cache/sp1/circuits
+
   # CPU Node
   cpu-node:
     image: ghcr.io/succinctlabs/sp1-cluster:base-v2.6.0
@@ -86,8 +95,12 @@ services:
           cpus: "4"
           memory: 96G
     depends_on:
-      - coordinator
-      - redis
+      coordinator:
+        condition: service_started
+      redis:
+        condition: service_started
+      circuit-cache-init:
+        condition: service_completed_successfully
 
   # CPU Node
   mixed:
@@ -114,8 +127,12 @@ services:
           cpus: "4"
           memory: 96G
     depends_on:
-      - coordinator
-      - redis
+      coordinator:
+        condition: service_started
+      redis:
+        condition: service_started
+      circuit-cache-init:
+        condition: service_completed_successfully
 
   # GPU Node
   gpu0:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -71,8 +71,10 @@ services:
       - NODE_ARTIFACT_STORE=redis
       - NODE_REDIS_NODES=redis://:redispassword@redis:6379/0
       - WORKER_TYPE=CPU
+      - SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16
+      - SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
     volumes:
-      - ${HOME}/.sp1/circuits:/root/.sp1/circuits
+      - circuit-cache:/var/cache/sp1/circuits
     command: ["/bin/sh", "-c", "/node"]
     shm_size: 96G
     deploy:
@@ -97,8 +99,10 @@ services:
       - NODE_ARTIFACT_STORE=redis
       - NODE_REDIS_NODES=redis://:redispassword@redis:6379/0
       - WORKER_TYPE=ALL
+      - SP1_GROTH16_CIRCUIT_PATH=/var/cache/sp1/circuits/groth16
+      - SP1_PLONK_CIRCUIT_PATH=/var/cache/sp1/circuits/plonk
     volumes:
-      - ${HOME}/.sp1/circuits:/root/.sp1/circuits
+      - circuit-cache:/var/cache/sp1/circuits
     command: ["/bin/sh", "-c", "/app/sp1-cluster-node"]
     shm_size: 96G
     deploy:
@@ -252,3 +256,4 @@ services:
 volumes:
   redis_data:
   postgresql_data:
+  circuit-cache:


### PR DESCRIPTION
## Summary

- Stores Groth16 and Plonk circuit artifacts in a Docker-managed volume shared by CPU-capable workers.
- Sets explicit SP1 circuit paths across Docker images, Compose files, and the Helm example.
- Runs a one-shot initializer that gives UID 1001 ownership before workers start.

## Motivation

Workers previously mounted host-specific paths that could miss SP1’s active cache directory.
Fresh Docker volumes are root-owned, while worker processes run as UID 1001. This caused failed writes or repeated multi-gigabyte downloads.