### PR TITLE
fix(api): order and page proof request listing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  artifact-redis:
-    name: Artifact integration (Redis)
+  integration:
+    name: Integration (Redis + Postgres)
     runs-on:
       [
         "runs-on",
@@ -21,6 +21,10 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       REDIS_URL: redis://localhost:6379
+      # Compile against the committed .sqlx cache; DATABASE_URL is for the
+      # tests at runtime — the service DB has no schema until they migrate it.
+      SQLX_OFFLINE: "true"
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
     services:
       redis:
         image: redis:7-alpine
@@ -28,6 +32,17 @@ jobs:
           - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 3s
           --health-retries 5
@@ -85,6 +100,18 @@ jobs:
           args: >-
             --release
             -p sp1-cluster-artifact
+            --tests
+            --
+            --ignored
+            --test-threads=1
+
+      - name: Run API integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >-
+            --release
+            -p sp1-cluster-api
             --tests
             --
             --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8282,6 +8282,7 @@ dependencies = [
  "dashmap",
  "dotenv",
  "eyre",
+ "futures",
  "hex",
  "http 1.4.0",
  "jemallocator",

--- a/bin/api/Cargo.toml
+++ b/bin/api/Cargo.toml
@@ -20,3 +20,6 @@ tokio-util.workspace = true
 tonic.workspace = true
 tonic-web.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+sqlx = { workspace = true, features = ["migrate"] }

--- a/bin/api/src/service.rs
+++ b/bin/api/src/service.rs
@@ -288,12 +288,12 @@ impl ClusterService for ClusterServiceImpl {
             "SELECT * FROM proof_requests WHERE id = $1",
             req.proof_id
         )
-        .fetch_one(&*self.db_pool)
+        .fetch_optional(&*self.db_pool)
         .await
         .map_err(|e| Status::internal(format!("Failed to get proof request: {e}")))?;
 
         let response = ProofRequestGetResponse {
-            proof_request: Some(proof_request.into_proto()),
+            proof_request: proof_request.map(|r| r.into_proto()),
         };
 
         Ok(Response::new(response))
@@ -340,10 +340,16 @@ impl ClusterService for ClusterServiceImpl {
                 .push_bind(scheduled_by.clone());
         }
 
+        // Give LIMIT a defined order. Without one, Postgres returns an
+        // arbitrary heap subset and a row past the limit can stay invisible
+        // to every poll. The id column breaks created_at ties.
+        query.push(" ORDER BY created_at ASC, id ASC");
+
         let limit = req.limit.unwrap_or(10).min(1000);
         query.push(" LIMIT ").push_bind(limit as i32);
 
-        let offset = req.offset.unwrap_or(0);
+        // Clamp: the bind is i32, and a u32 above i32::MAX would wrap negative.
+        let offset = req.offset.unwrap_or(0).min(i32::MAX as u32);
         query.push(" OFFSET ").push_bind(offset as i32);
 
         let proof_requests = query

--- a/bin/api/tests/list_pagination.rs
+++ b/bin/api/tests/list_pagination.rs
@@ -1,0 +1,125 @@
+//! Postgres-backed regression tests for `proof_request_list` ordering and
+//! pagination.
+//!
+//! `#[ignore]`'d by default — run with:
+//!
+//!     cargo test --release -p sp1-cluster-api --tests -- --ignored --test-threads=1
+//!
+//! Requires Postgres at `DATABASE_URL` (schema is migrated and the
+//! `proof_requests` table truncated on each run).
+
+use sp1_cluster_api::ClusterServiceImpl;
+use sp1_cluster_common::proto::{
+    cluster_service_server::ClusterService, ProofRequestCreateRequest, ProofRequestListRequest,
+};
+use sqlx::PgPool;
+use std::sync::Arc;
+use tonic::Request;
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".into())
+}
+
+const PAGE: u32 = 1000;
+/// Enough rows that a single page can't hold them.
+const SEEDED: u32 = PAGE + 200;
+
+async fn service_with_seeded_rows() -> ClusterServiceImpl {
+    let pool = PgPool::connect(&database_url()).await.unwrap();
+    sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
+    sqlx::query("TRUNCATE proof_requests")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let service = ClusterServiceImpl::new(Arc::new(pool));
+    let deadline = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 4 * 3600;
+    for i in 0..SEEDED {
+        service
+            .proof_request_create(Request::new(ProofRequestCreateRequest {
+                proof_id: format!("req_{i:06}"),
+                requester: vec![0x9b],
+                stdin_artifact_id: "s".into(),
+                program_artifact_id: "p".into(),
+                deadline,
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+    }
+    service
+}
+
+async fn list(service: &ClusterServiceImpl, offset: u32) -> Vec<String> {
+    service
+        .proof_request_list(Request::new(ProofRequestListRequest {
+            limit: Some(PAGE),
+            offset: Some(offset),
+            ..Default::default()
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .proof_requests
+        .into_iter()
+        .map(|r| r.id)
+        .collect()
+}
+
+/// The failure mode behind stuck-at-assigned: with more matching rows than the
+/// limit, the newest row must still be reachable — on a later page, at a
+/// stable position.
+#[tokio::test]
+#[ignore = "requires Postgres at DATABASE_URL"]
+async fn rows_past_the_limit_are_reachable_via_offset() {
+    let service = service_with_seeded_rows().await;
+    let newest = format!("req_{:06}", SEEDED - 1);
+
+    let first = list(&service, 0).await;
+    assert_eq!(first.len(), PAGE as usize);
+    assert!(
+        !first.contains(&newest),
+        "seed too small to exercise truncation"
+    );
+
+    let second = list(&service, PAGE).await;
+    assert!(
+        second.contains(&newest),
+        "row past the first page is unreachable — the stuck-request regression"
+    );
+    assert_eq!(first.len() + second.len(), SEEDED as usize);
+}
+
+/// Pages must not shuffle under row churn. An UPDATE relocates the heap tuple,
+/// so without ORDER BY the updated row jumps to the last page and another row
+/// silently drops out of view.
+#[tokio::test]
+#[ignore = "requires Postgres at DATABASE_URL"]
+async fn page_membership_survives_row_updates() {
+    let service = service_with_seeded_rows().await;
+    let before = list(&service, 0).await;
+
+    let pool = PgPool::connect(&database_url()).await.unwrap();
+    sqlx::query("UPDATE proof_requests SET updated_at = now() WHERE id = $1")
+        .bind(&before[0])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let after = list(&service, 0).await;
+    assert_eq!(before, after, "an UPDATE reshuffled page membership");
+
+    let second = list(&service, PAGE).await;
+    let mut all = after;
+    all.extend(second);
+    let mut deduped = all.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(deduped.len(), all.len(), "pages overlap");
+    assert_eq!(all.len(), SEEDED as usize, "pages have gaps");
+}

--- a/bin/api/tests/list_pagination.rs
+++ b/bin/api/tests/list_pagination.rs
@@ -5,8 +5,9 @@
 //!
 //!     cargo test --release -p sp1-cluster-api --tests -- --ignored --test-threads=1
 //!
-//! Requires Postgres at `DATABASE_URL` (schema is migrated and the
-//! `proof_requests` table truncated on each run).
+//! Requires a Postgres server at `DATABASE_URL`. Each test runs in its own
+//! throwaway database created by `#[sqlx::test]`, so existing data is never
+//! touched.
 
 use sp1_cluster_api::ClusterServiceImpl;
 use sp1_cluster_common::proto::{
@@ -16,23 +17,11 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use tonic::Request;
 
-fn database_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".into())
-}
-
 const PAGE: u32 = 1000;
 /// Enough rows that a single page can't hold them.
 const SEEDED: u32 = PAGE + 200;
 
-async fn service_with_seeded_rows() -> ClusterServiceImpl {
-    let pool = PgPool::connect(&database_url()).await.unwrap();
-    sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
-    sqlx::query("TRUNCATE proof_requests")
-        .execute(&pool)
-        .await
-        .unwrap();
-
+async fn service_with_seeded_rows(pool: PgPool) -> ClusterServiceImpl {
     let service = ClusterServiceImpl::new(Arc::new(pool));
     let deadline = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -74,10 +63,10 @@ async fn list(service: &ClusterServiceImpl, offset: u32) -> Vec<String> {
 /// The failure mode behind stuck-at-assigned: with more matching rows than the
 /// limit, the newest row must still be reachable — on a later page, at a
 /// stable position.
-#[tokio::test]
+#[sqlx::test(migrations = "../../migrations")]
 #[ignore = "requires Postgres at DATABASE_URL"]
-async fn rows_past_the_limit_are_reachable_via_offset() {
-    let service = service_with_seeded_rows().await;
+async fn rows_past_the_limit_are_reachable_via_offset(pool: PgPool) {
+    let service = service_with_seeded_rows(pool).await;
     let newest = format!("req_{:06}", SEEDED - 1);
 
     let first = list(&service, 0).await;
@@ -98,13 +87,12 @@ async fn rows_past_the_limit_are_reachable_via_offset() {
 /// Pages must not shuffle under row churn. An UPDATE relocates the heap tuple,
 /// so without ORDER BY the updated row jumps to the last page and another row
 /// silently drops out of view.
-#[tokio::test]
+#[sqlx::test(migrations = "../../migrations")]
 #[ignore = "requires Postgres at DATABASE_URL"]
-async fn page_membership_survives_row_updates() {
-    let service = service_with_seeded_rows().await;
+async fn page_membership_survives_row_updates(pool: PgPool) {
+    let service = service_with_seeded_rows(pool.clone()).await;
     let before = list(&service, 0).await;
 
-    let pool = PgPool::connect(&database_url()).await.unwrap();
     sqlx::query("UPDATE proof_requests SET updated_at = now() WHERE id = $1")
         .bind(&before[0])
         .execute(&pool)

--- a/bin/coordinator/Cargo.toml
+++ b/bin/coordinator/Cargo.toml
@@ -15,6 +15,7 @@ config.workspace = true
 dashmap.workspace = true
 dotenv.workspace = true
 eyre.workspace = true
+futures.workspace = true
 hex.workspace = true
 http.workspace = true
 jemallocator.workspace = true

--- a/bin/coordinator/src/cluster.rs
+++ b/bin/coordinator/src/cluster.rs
@@ -3,11 +3,13 @@ use std::{collections::HashSet, sync::Arc, time::SystemTime};
 use crate::metrics::CoordinatorMetrics;
 use crate::{AssignmentPolicy, Coordinator, ProofResult};
 use dashmap::{DashMap, DashSet};
+use futures::StreamExt;
 use hex;
 use sp1_cluster_common::{
     client::ClusterServiceClient,
     proto::{
-        CreateProofRequest, ProofRequestListRequest, ProofRequestStatus, ProofRequestUpdateRequest,
+        self, CreateProofRequest, ProofRequestGetRequest, ProofRequestListRequest,
+        ProofRequestStatus, ProofRequestUpdateRequest,
     },
 };
 use sp1_prover::worker::ControllerInputMetadata;
@@ -161,6 +163,70 @@ pub fn spawn_manifest_push_task<P: AssignmentPolicy>(
     })
 }
 
+/// True when the row still matches the claimer's Pending listing filter.
+/// Then the row is alive and paging churn explains its absence from the list.
+fn still_pending(row: &proto::ProofRequest, now: u64) -> bool {
+    row.proof_status == ProofRequestStatus::Pending as i32 && !row.handled && row.deadline >= now
+}
+
+/// How many missing-proof confirms run at once.
+const CONFIRM_FAN_OUT: usize = 8;
+
+/// Fail tracked Pending proofs whose DB row left the Pending filter.
+///
+/// A tracked proof can be absent from `seen` for two reasons: its row changed
+/// state in the DB, or offset paging skipped it this poll. Read the row itself
+/// to tell them apart before failing anything.
+async fn fail_missing_proofs<P: AssignmentPolicy>(
+    api_client: &Arc<ClusterServiceClient>,
+    coordinator: &Arc<Coordinator<P>>,
+    task_map: &DashMap<String, TaskState>,
+    seen: &HashSet<String>,
+) {
+    let missing: Vec<String> = task_map
+        .iter()
+        .filter(|e| matches!(e.value(), TaskState::Pending) && !seen.contains(e.key()))
+        .map(|e| e.key().clone())
+        .collect();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // Bounded concurrency: each confirm is an RPC with its own retry budget,
+    // and a serial chain would stall the claim poll under heavy churn.
+    futures::stream::iter(missing)
+        .for_each_concurrent(CONFIRM_FAN_OUT, |id| async move {
+            match api_client
+                .get_proof_request(ProofRequestGetRequest {
+                    proof_id: id.clone(),
+                })
+                .await
+            {
+                Ok(Some(row)) if still_pending(&row, now) => {}
+                Ok(_) => {
+                    // The proof can complete during the row read and store a
+                    // Terminal write that still has to land. Remove only a
+                    // Pending entry.
+                    if task_map
+                        .remove_if(&id, |_, v| matches!(v, TaskState::Pending))
+                        .is_some()
+                    {
+                        tracing::warn!("Running proof {} is no longer pending in cluster DB", id);
+                        if let Err(e) = coordinator.fail_proof(id.clone(), None, false, None).await
+                        {
+                            tracing::error!("Failed to fail expired proof: {:?}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Keep the proof; the next poll re-checks.
+                    tracing::error!("Could not confirm missing proof {}: {:?}", id, e);
+                }
+            }
+        })
+        .await;
+}
+
 /// Spawn a task to claim proofs from the cluster API. Stops when `token` fires.
 pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
     api_client: Arc<ClusterServiceClient>,
@@ -175,7 +241,7 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
             let reissue_inflight: Arc<DashSet<String>> = Arc::new(DashSet::new());
             loop {
                 match api_client
-                    .get_proof_requests(ProofRequestListRequest {
+                    .get_all_proof_requests(ProofRequestListRequest {
                         proof_status: vec![ProofRequestStatus::Pending.into()],
                         handled: Some(false),
                         minimum_deadline: Some(
@@ -184,7 +250,6 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                                 .unwrap()
                                 .as_secs(),
                         ),
-                        limit: Some(1000),
                         ..Default::default()
                     })
                     .await
@@ -264,27 +329,7 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
                                 }
                             }
                         }
-                        // Fail a Pending proof that vanished from the DB list. Keep every Terminal
-                        // entry (it may just be on a later page) — removed only when its write lands.
-                        let mut proofs_to_fail = vec![];
-                        task_map.retain(|id, state| match state {
-                            TaskState::Pending if !seen_set.contains(id) => {
-                                tracing::warn!(
-                                    "Running proof {} is no longer in cluster DB list",
-                                    id
-                                );
-                                proofs_to_fail.push(id.clone());
-                                false
-                            }
-                            _ => true,
-                        });
-                        for id in proofs_to_fail {
-                            if let Err(e) =
-                                coordinator.fail_proof(id.clone(), None, false, None).await
-                            {
-                                tracing::error!("Failed to fail expired proof: {:?}", e);
-                            }
-                        }
+                        fail_missing_proofs(&api_client, &coordinator, &task_map, &seen_set).await;
 
                         // Sweep all unconfirmed terminal writes (not just this page), so a lost write
                         // beyond the 1000-row page still recovers.
@@ -316,4 +361,39 @@ pub fn spawn_proof_claimer_task<P: AssignmentPolicy>(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending_row(now: u64) -> proto::ProofRequest {
+        proto::ProofRequest {
+            proof_status: ProofRequestStatus::Pending as i32,
+            handled: false,
+            deadline: now + 3600,
+            ..Default::default()
+        }
+    }
+
+    /// A row still matching the listing filter was only skipped by paging;
+    /// tearing it down would kill a live proof.
+    #[test]
+    fn a_still_pending_row_is_a_paging_skip() {
+        assert!(still_pending(&pending_row(1000), 1000));
+    }
+
+    #[test]
+    fn every_exit_from_the_filter_is_detected() {
+        let mut completed = pending_row(1000);
+        completed.proof_status = ProofRequestStatus::Completed as i32;
+        assert!(!still_pending(&completed, 1000));
+
+        let mut handled = pending_row(1000);
+        handled.handled = true;
+        assert!(!still_pending(&handled, 1000));
+
+        let expired = pending_row(1000);
+        assert!(!still_pending(&expired, expired.deadline + 1));
+    }
 }

--- a/crates/common/src/client.rs
+++ b/crates/common/src/client.rs
@@ -131,6 +131,27 @@ impl ClusterServiceClient {
         Ok(result.proof_requests)
     }
 
+    /// Fetches all rows that match the filters in `request`. The server caps
+    /// one call at 1000 rows, so this walks `offset` page by page. It ignores
+    /// any `limit` or `offset` set on `request`.
+    ///
+    /// Rows that change state during the walk shift page boundaries. This
+    /// function removes the resulting duplicates. It can also miss a row
+    /// for one call, so treat absence as transient.
+    pub async fn get_all_proof_requests(
+        &self,
+        request: ProofRequestListRequest,
+    ) -> Result<Vec<proto::ProofRequest>> {
+        let rows = drain_pages(PROOF_REQUEST_PAGE_SIZE, |offset| {
+            let mut request = request.clone();
+            request.limit = Some(PROOF_REQUEST_PAGE_SIZE);
+            request.offset = Some(offset);
+            self.get_proof_requests(request)
+        })
+        .await?;
+        Ok(dedup_by_id(rows))
+    }
+
     pub async fn update_proof_request(&self, request: ProofRequestUpdateRequest) -> Result<()> {
         self.retry_call(|| {
             let mut client = self.rpc.clone();
@@ -185,5 +206,139 @@ impl ClusterServiceClient {
             async move { client.get_cluster_component_info(()).await }
         })
         .await
+    }
+}
+
+/// Matches the server-side cap on `limit`, so each fetch is one full page.
+const PROOF_REQUEST_PAGE_SIZE: u32 = 1000;
+
+/// Stops a runaway walk, for example against a server that ignores `offset`,
+/// and bounds memory at 100k rows. A healthy live set is far smaller.
+const MAX_PAGES: u32 = 100;
+
+const PAGE_WARN_THRESHOLD: u32 = 10;
+
+/// Collects pages from `fetch(offset)` until a short page marks the end.
+/// At the page cap it logs an error and returns the rows it has, so callers
+/// keep partial progress. Rows past the cap stay invisible until the match
+/// set shrinks, so treat absence as transient.
+async fn drain_pages<T, F, Fut>(page_size: u32, fetch: F) -> Result<Vec<T>>
+where
+    F: Fn(u32) -> Fut,
+    Fut: Future<Output = Result<Vec<T>>>,
+{
+    let mut all = Vec::new();
+    for page_idx in 0..MAX_PAGES {
+        let page = fetch(page_idx * page_size).await?;
+        let full_page = page.len() as u32 == page_size;
+        all.extend(page);
+        if !full_page {
+            return Ok(all);
+        }
+        if page_idx + 1 == PAGE_WARN_THRESHOLD {
+            tracing::warn!(
+                "proof request listing past {PAGE_WARN_THRESHOLD} pages of {page_size}; \
+                 match set is abnormally large"
+            );
+        }
+    }
+    tracing::error!(
+        "proof request listing exceeded {MAX_PAGES} pages of {page_size}; \
+         returning a partial set (is the server ignoring offset?)"
+    );
+    Ok(all)
+}
+
+/// Drops rows already seen and keeps the first occurrence. Pages are separate
+/// DB reads, so a row that changes state during the walk can appear twice.
+fn dedup_by_id(rows: Vec<proto::ProofRequest>) -> Vec<proto::ProofRequest> {
+    let mut seen = std::collections::HashSet::new();
+    rows.into_iter()
+        .filter(|row| seen.insert(row.id.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type RecordedOffsets = std::sync::Arc<std::sync::Mutex<Vec<u32>>>;
+
+    /// `fetch` serving `total` distinct items in pages, plus the offsets it was asked for.
+    fn counting_fetch(
+        total: u32,
+    ) -> (
+        impl Fn(u32) -> std::future::Ready<Result<Vec<u32>>>,
+        RecordedOffsets,
+    ) {
+        let offsets = RecordedOffsets::default();
+        let recorder = offsets.clone();
+        let fetch = move |offset| {
+            recorder.lock().unwrap().push(offset);
+            let end = (offset + PROOF_REQUEST_PAGE_SIZE).min(total);
+            std::future::ready(Ok((offset..end).collect()))
+        };
+        (fetch, offsets)
+    }
+
+    #[tokio::test]
+    async fn drains_across_pages_without_loss_or_duplication() {
+        // 2.5 pages: the regression shape — rows past the first page must still arrive.
+        let total = PROOF_REQUEST_PAGE_SIZE * 2 + 500;
+        let (fetch, offsets) = counting_fetch(total);
+
+        let all = drain_pages(PROOF_REQUEST_PAGE_SIZE, fetch).await.unwrap();
+
+        assert_eq!(all, (0..total).collect::<Vec<_>>());
+        assert_eq!(*offsets.lock().unwrap(), vec![0, 1000, 2000]);
+    }
+
+    #[tokio::test]
+    async fn an_exact_page_boundary_costs_one_empty_confirmation_fetch() {
+        let (fetch, offsets) = counting_fetch(PROOF_REQUEST_PAGE_SIZE);
+
+        let all = drain_pages(PROOF_REQUEST_PAGE_SIZE, fetch).await.unwrap();
+
+        assert_eq!(all.len(), PROOF_REQUEST_PAGE_SIZE as usize);
+        assert_eq!(*offsets.lock().unwrap(), vec![0, 1000]);
+    }
+
+    #[tokio::test]
+    async fn hitting_the_page_cap_returns_a_partial_set() {
+        // Always a full page regardless of offset.
+        let all = drain_pages(PROOF_REQUEST_PAGE_SIZE, |_offset| {
+            std::future::ready(Ok(vec![0u32; PROOF_REQUEST_PAGE_SIZE as usize]))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(all.len(), (MAX_PAGES * PROOF_REQUEST_PAGE_SIZE) as usize);
+    }
+
+    /// Filtered-churn shape: a row completing mid-fetch re-serves the boundary
+    /// row on the next page; the duplicate must not reach consumers that act
+    /// once per id (e.g. network submission).
+    #[test]
+    fn duplicate_rows_across_page_boundaries_collapse() {
+        let row = |id: &str| proto::ProofRequest {
+            id: id.into(),
+            ..Default::default()
+        };
+
+        let deduped = dedup_by_id(vec![row("a"), row("b"), row("b"), row("c")]);
+
+        let ids: Vec<_> = deduped.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn a_page_fetch_error_propagates() {
+        let err = drain_pages(PROOF_REQUEST_PAGE_SIZE, |_offset| {
+            std::future::ready(Err::<Vec<u32>, _>(eyre::eyre!("boom")))
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "boom");
     }
 }

--- a/crates/fulfillment/src/lib.rs
+++ b/crates/fulfillment/src/lib.rs
@@ -2,7 +2,7 @@ use crate::metrics::FulfillerMetrics;
 use crate::network::{FulfillmentNetwork, NetworkRequest};
 use alloy_primitives::{Address, B256};
 use anyhow::{anyhow, Result};
-use futures::{future::join_all, TryFutureExt};
+use futures::{future::join_all, StreamExt, TryFutureExt};
 use sp1_cluster_artifact::{ArtifactClient, ArtifactType, CompressedUpload};
 use sp1_cluster_common::{
     client::ClusterServiceClient,
@@ -26,8 +26,12 @@ pub mod network;
 pub mod prover_info;
 pub mod run;
 
-/// The maximum number of requests to handle in a single refresh loop.
+/// Page size for schedulable-request fetches from the network.
 const REQUEST_LIMIT: u32 = 1000;
+
+/// How many submit or fail calls run at once. The paged listing has no
+/// bound, so per-row work needs one.
+const REQUEST_FAN_OUT: usize = 64;
 /// The error strings that should trigger a VERIFICATION_KEY_MISMATCH error.
 const VK_MISMATCH_STRINGS: &[&str] = &[
     "InvalidPowWitness",
@@ -332,9 +336,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         // Get all submitable requests from the cluster.
         let requests = self
             .cluster
-            .get_proof_requests(ProofRequestListRequest {
+            .get_all_proof_requests(ProofRequestListRequest {
                 proof_status: vec![ProofRequestStatus::Completed.into()],
-                limit: Some(REQUEST_LIMIT),
                 minimum_deadline: Some(time_now()),
                 handled: Some(false),
                 scheduled_by: self.name.clone(),
@@ -355,7 +358,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         let submission_tasks = requests.into_iter().map(|request| {
             let self_clone = self.clone();
             let request_id = request.id.clone();
-            tokio::spawn(async move {
+            let work = async move {
                 match self_clone.submit_request(request).await {
                     Ok(_) => {
                         info!("submitted request 0x{}", request_id);
@@ -400,10 +403,19 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                         }
                     }
                 }
-            })
+            };
+            // Spawn inside the buffered future: buffer_unordered bounds how
+            // many start, the JoinHandle keeps a panic in one request from
+            // unwinding into the fulfiller loop.
+            async move {
+                let _ = tokio::spawn(work).await;
+            }
         });
 
-        join_all(submission_tasks).await;
+        futures::stream::iter(submission_tasks)
+            .buffer_unordered(REQUEST_FAN_OUT)
+            .collect::<Vec<_>>()
+            .await;
 
         Ok(())
     }
@@ -472,9 +484,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         // Get all failed requests from the cluster.
         let requests = self
             .cluster
-            .get_proof_requests(ProofRequestListRequest {
+            .get_all_proof_requests(ProofRequestListRequest {
                 proof_status: vec![ProofRequestStatus::Failed.into()],
-                limit: Some(REQUEST_LIMIT),
                 minimum_deadline: Some(time_now()),
                 handled: Some(false),
                 scheduled_by: self.name.clone(),
@@ -492,7 +503,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 
         let failure_tasks = requests.into_iter().map(|request| {
             let self_clone = self.clone();
-            tokio::spawn(async move {
+            let work = async move {
                 let request_id = request.id.clone();
                 match self_clone.fail_request(request).await {
                     Ok(_) => {
@@ -505,10 +516,17 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
                         self_clone.metrics.request_fail_failures.increment(1);
                     }
                 }
-            })
+            };
+            // See submit_requests: spawn for panic isolation, buffer for bound.
+            async move {
+                let _ = tokio::spawn(work).await;
+            }
         });
 
-        join_all(failure_tasks).await;
+        futures::stream::iter(failure_tasks)
+            .buffer_unordered(REQUEST_FAN_OUT)
+            .collect::<Vec<_>>()
+            .await;
 
         Ok(())
     }
@@ -571,9 +589,8 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         let in_flight: HashSet<String> =
             if requests.iter().any(|(_, kind)| kind.gated_on_in_flight()) {
                 self.cluster
-                    .get_proof_requests(ProofRequestListRequest {
+                    .get_all_proof_requests(ProofRequestListRequest {
                         proof_status: vec![ProofRequestStatus::Pending.into()],
-                        limit: Some(REQUEST_LIMIT),
                         minimum_deadline: Some(time_now()),
                         ..Default::default()
                     })
@@ -765,8 +782,7 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
         // Get all requested requests from the cluster.
         let cluster_requests_resp = self
             .cluster
-            .get_proof_requests(ProofRequestListRequest {
-                limit: Some(REQUEST_LIMIT),
+            .get_all_proof_requests(ProofRequestListRequest {
                 minimum_deadline: Some(time_now()),
                 ..Default::default()
             })
@@ -922,8 +938,9 @@ impl<A: ArtifactClient + CompressedUpload, N: FulfillmentNetwork> Fulfiller<A, N
 /// Outcome of scheduling one request in the cluster.
 enum ScheduleOutcome {
     Created,
-    /// The row already existed — the create raced the LIMIT-1000 dedup list.
-    /// The request is being handled; nothing was scheduled by this attempt.
+    /// The insert hit an existing row: the request entered the cluster DB
+    /// after this cycle listed it. It is already scheduled, so this attempt
+    /// changed nothing.
     AlreadyInCluster,
 }
 

--- a/migrations/20260811000000_list_order_index.sql
+++ b/migrations/20260811000000_list_order_index.sql
@@ -1,0 +1,2 @@
+-- Supports proof_request_list's ORDER BY (created_at, id) pagination.
+CREATE INDEX idx_proof_requests_created_at_id ON proof_requests (created_at, id);


### PR DESCRIPTION
## Summary

- `proof_request_list` now orders rows by `(created_at, id)`. The new `get_all_proof_requests` helper pages through every matching row, removes duplicate rows from page boundaries, and stops at a 100-page cap with an error log and a partial set.
- The claimer confirms a missing proof with a direct row read (`still_pending`) before teardown, and removes only a `Pending` entry so a completion write that lands during the read survives.
- The fulfiller submit and fail loops run at a fixed concurrency of 64.
- A new `api-postgres` CI job runs Postgres-backed regression tests with `SQLX_OFFLINE=true`.

## Motivation

The list query had no `ORDER BY`, and every caller read one page of at most 1000 rows. With more than 1000 matching rows, the page became a stable heap-order subset. A new request could stay invisible to every poll: the coordinator never claimed it, the request stuck at `assigned` on SPN, and the fulfiller logged `create raced dedup list` each cycle. A prover hit this in production. The defect dates to the initial commit; load growth surfaced it.