### PR TITLE
test(cluster): strengthen coordinator restart recovery coverage

### DIFF
--- a/bin/test-cluster/README.md
+++ b/bin/test-cluster/README.md
@@ -1,10 +1,11 @@
 # sp1-test-cluster
 
-Scenario-based e2e harness for sp1-cluster. Boots the whole cluster in-process
-(api, coordinator, gateway, worker nodes) against dockerized redis + postgres
-(+ MinIO for the S3 scenario) via testcontainers, submits proofs through the
-network gateway in hosted SDK mode, and asserts terminal API status, execution
-metadata, artifact availability, and local proof verification.
+Scenario-based e2e harness for sp1-cluster. Boots the API, gateway, and worker
+nodes in-process against dockerized redis + postgres (+ MinIO for the S3
+scenario) via testcontainers. The coordinator runs in-process by default and
+can run as a child process for crash tests. The harness submits proofs through
+the network gateway in hosted SDK mode and asserts terminal API status,
+execution metadata, artifact availability, and local proof verification.
 
 CI: `.github/workflows/e2e.yml` (smoke per-PR; full post-merge/manual).
 
@@ -57,16 +58,15 @@ directory). Requirements: docker (testcontainers), network access on first run
 | `fatal-failure` | cycle-limit-exceeded execution failure on the PROVING path → Failed + failure metadata |
 | `cancel-pending` | cancel with no workers: API row Cancelled, queue dropped, status holds |
 | `cancel-active` | cancel mid-proving (api + coordinator, mirroring the fulfiller): work drained, status holds |
-| `coordinator-restart` | kill+restart coordinator on the same port; workers rolled; new proof completes |
+| `coordinator-restart` | SIGKILL coordinator child mid-proof; existing workers reconnect; same proof completes |
 | `worker-restart` | graceful stop/drain + restart of a worker between proofs |
 | `api-outage` | stop API mid-proof, restore; terminal status recovered (#126 re-issue path) |
 | `shutdown-drain` | whole-cluster shutdown with work in flight; all fixed ports re-bindable (zombie regression guard) |
 | `s3-artifacts` | full pipeline on MinIO-backed S3 store (endpoint + path-style) |
 
-Known product gap (documented, not asserted): a proof claimed by a coordinator
-that crashes mid-flight is orphaned — the claimer only claims unhandled
-requests. `coordinator-restart` pins restart/rebind/reconnect, not mid-flight
-recovery.
+`coordinator-restart` runs the coordinator as a child process. SIGKILL closes
+its accepted connections and removes its in-memory state. The test does not
+restart workers or submit a second proof request.
 
 ## Tiers
 

--- a/bin/test-cluster/src/cluster.rs
+++ b/bin/test-cluster/src/cluster.rs
@@ -16,6 +16,7 @@ use sp1_cluster_coordinator::policy::balanced::BalancedPolicy;
 use sp1_cluster_coordinator::server::start_coordinator_server_custom;
 use sp1_cluster_network_gateway::auth::AuthMode;
 use sp1_cluster_network_gateway::config::Config as GatewayConfig;
+use tokio::process::Child;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tonic::transport::Channel;
@@ -86,6 +87,7 @@ struct Component {
 
 pub struct ClusterBuilder {
     coordinator: CoordinatorKind,
+    process_isolated_coordinator: bool,
     cpu_nodes: usize,
     gpu_nodes: usize,
     worker_heartbeat_timeout_secs: u64,
@@ -95,9 +97,15 @@ pub struct Cluster<A: StoreClient> {
     pub root: CancellationToken,
     pub addrs: ClusterAddrs,
     components: HashMap<String, Component>,
+    coordinator_process: Option<CoordinatorProcess>,
     artifact_client: A,
     _artifact_container_handle: ArtifactContainerHandle,
     _postgres: env::Postgres,
+}
+
+struct CoordinatorProcess {
+    settings: CoordinatorSettings,
+    child: Option<Child>,
 }
 
 #[allow(unused)]
@@ -110,6 +118,7 @@ impl Cluster<RedisArtifactClient> {
     pub fn builder() -> ClusterBuilder {
         ClusterBuilder {
             coordinator: CoordinatorKind::Prover,
+            process_isolated_coordinator: false,
             cpu_nodes: 0,
             gpu_nodes: 0,
             worker_heartbeat_timeout_secs:
@@ -141,6 +150,51 @@ impl<A: StoreClient> Cluster<A> {
         RawCoordinatorClient::connect(format!("http://{}", self.addrs.coordinator))
             .await
             .context("failed to connect to coordinator")
+    }
+
+    /// Abruptly kill and reap an opted-in coordinator child process.
+    /// Awaiting its exit guarantees that its sockets and in-memory state are gone.
+    pub async fn crash_coordinator_process(&mut self) -> Result<()> {
+        let process = self
+            .coordinator_process
+            .as_mut()
+            .context("coordinator is not running as a child process")?;
+        let mut child = process
+            .child
+            .take()
+            .context("coordinator child is not running")?;
+        let pid = child.id();
+        if let Some(status) = child
+            .try_wait()
+            .context("check coordinator child before SIGKILL")?
+        {
+            anyhow::bail!("coordinator child {pid:?} exited unexpectedly before crash: {status}");
+        }
+        child.start_kill().context("SIGKILL coordinator child")?;
+        let status = tokio::time::timeout(Duration::from_secs(10), child.wait())
+            .await
+            .context("timed out waiting for killed coordinator child")?
+            .context("wait for killed coordinator child")?;
+        if status.success() {
+            anyhow::bail!("coordinator child {pid:?} exited successfully after SIGKILL");
+        }
+        tracing::info!("coordinator child {pid:?} exited after SIGKILL: {status}");
+        Ok(())
+    }
+
+    /// Start a fresh coordinator child with the same listen addresses and API.
+    pub fn restart_coordinator_process(&mut self) -> Result<()> {
+        let process = self
+            .coordinator_process
+            .as_mut()
+            .context("coordinator is not configured as a child process")?;
+        if process.child.is_some() {
+            anyhow::bail!("coordinator child is already running");
+        }
+        let child = spawn_coordinator_process(&process.settings)?;
+        tracing::info!("restarted coordinator child {:?}", child.id());
+        process.child = Some(child);
+        Ok(())
     }
 
     /// Whether a component with this name was spawned (e.g. "gpu-node-0" exists only
@@ -206,6 +260,11 @@ impl<A: StoreClient> Cluster<A> {
     /// Shut the whole cluster down: cancel root, await every component (bounded).
     pub async fn shutdown(mut self) {
         self.root.cancel();
+        if let Some(mut process) = self.coordinator_process.take() {
+            if let Some(mut child) = process.child.take() {
+                let _ = child.kill().await;
+            }
+        }
         for (name, c) in self.components.drain() {
             let Some(handle) = c.handle else { continue };
             match tokio::time::timeout(Duration::from_mins(1), handle).await {
@@ -258,6 +317,12 @@ impl<A: StoreClient> Cluster<A> {
 impl ClusterBuilder {
     pub fn coordinator(mut self, kind: CoordinatorKind) -> Self {
         self.coordinator = kind;
+        self
+    }
+
+    /// Run the coordinator in a real child process so crash tests drop all sockets and memory.
+    pub fn process_isolated_coordinator(mut self) -> Self {
+        self.process_isolated_coordinator = true;
         self
     }
 
@@ -377,15 +442,23 @@ impl ClusterBuilder {
         utils::wait_for_tcp(&addrs.api_grpc, "api gRPC").await?;
 
         // coordinator
-        {
-            let settings = CoordinatorSettings {
-                addr: addrs.coordinator.clone(),
-                cluster_rpc: format!("http://{}", addrs.api_grpc),
-                metrics_addr: addrs.coordinator_metrics.clone(),
-                disable_proof_status_update: false,
-                execute_only_mode: self.coordinator == CoordinatorKind::ExecuteOnly,
-                worker_heartbeat_timeout_secs: self.worker_heartbeat_timeout_secs,
-            };
+        let coordinator_settings = CoordinatorSettings {
+            addr: addrs.coordinator.clone(),
+            cluster_rpc: format!("http://{}", addrs.api_grpc),
+            metrics_addr: addrs.coordinator_metrics.clone(),
+            disable_proof_status_update: false,
+            execute_only_mode: self.coordinator == CoordinatorKind::ExecuteOnly,
+            worker_heartbeat_timeout_secs: self.worker_heartbeat_timeout_secs,
+        };
+        let coordinator_process = if self.process_isolated_coordinator {
+            let child = spawn_coordinator_process(&coordinator_settings)?;
+            tracing::info!("started coordinator child {:?}", child.id());
+            Some(CoordinatorProcess {
+                child: Some(child),
+                settings: coordinator_settings,
+            })
+        } else {
+            let settings = coordinator_settings;
             let respawn = component_factory("coordinator", root.clone(), move |token| {
                 let settings = settings.clone();
                 async move {
@@ -398,7 +471,8 @@ impl ClusterBuilder {
                 }
             });
             insert_component(&mut components, &root, "coordinator", respawn);
-        }
+            None
+        };
         utils::wait_for_tcp(&addrs.coordinator, "coordinator gRPC").await?;
 
         // gateway
@@ -474,6 +548,7 @@ impl ClusterBuilder {
             root,
             addrs,
             components,
+            coordinator_process,
             _artifact_container_handle: artifact_container_handle,
             _postgres: postgres,
             artifact_client,
@@ -487,6 +562,30 @@ impl ClusterBuilder {
             .await?;
         Ok(cluster)
     }
+}
+
+fn spawn_coordinator_process(settings: &CoordinatorSettings) -> Result<Child> {
+    let exe = std::env::current_exe().context("resolve test-cluster executable")?;
+    tokio::process::Command::new(exe)
+        .arg("__coordinator-child")
+        .env("COORDINATOR_ADDR", &settings.addr)
+        .env("COORDINATOR_CLUSTER_RPC", &settings.cluster_rpc)
+        .env("COORDINATOR_METRICS_ADDR", &settings.metrics_addr)
+        .env(
+            "COORDINATOR_DISABLE_PROOF_STATUS_UPDATE",
+            settings.disable_proof_status_update.to_string(),
+        )
+        .env(
+            "COORDINATOR_EXECUTE_ONLY_MODE",
+            settings.execute_only_mode.to_string(),
+        )
+        .env(
+            "COORDINATOR_WORKER_HEARTBEAT_TIMEOUT_SECS",
+            settings.worker_heartbeat_timeout_secs.to_string(),
+        )
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawn coordinator child process")
 }
 
 fn spawn_node<A: StoreClient>(

--- a/bin/test-cluster/src/cluster.rs
+++ b/bin/test-cluster/src/cluster.rs
@@ -152,9 +152,9 @@ impl<A: StoreClient> Cluster<A> {
             .context("failed to connect to coordinator")
     }
 
-    /// Abruptly kill and reap an opted-in coordinator child process.
-    /// Awaiting its exit guarantees that its sockets and in-memory state are gone.
-    pub async fn crash_coordinator_process(&mut self) -> Result<()> {
+    /// Abruptly kill and reap the coordinator child, then start a fresh child with the
+    /// same listen addresses and API.
+    pub async fn crash_and_restart_coordinator_process(&mut self) -> Result<()> {
         let process = self
             .coordinator_process
             .as_mut()
@@ -179,18 +179,6 @@ impl<A: StoreClient> Cluster<A> {
             anyhow::bail!("coordinator child {pid:?} exited successfully after SIGKILL");
         }
         tracing::info!("coordinator child {pid:?} exited after SIGKILL: {status}");
-        Ok(())
-    }
-
-    /// Start a fresh coordinator child with the same listen addresses and API.
-    pub fn restart_coordinator_process(&mut self) -> Result<()> {
-        let process = self
-            .coordinator_process
-            .as_mut()
-            .context("coordinator is not configured as a child process")?;
-        if process.child.is_some() {
-            anyhow::bail!("coordinator child is already running");
-        }
         let child = spawn_coordinator_process(&process.settings)?;
         tracing::info!("restarted coordinator child {:?}", child.id());
         process.child = Some(child);

--- a/bin/test-cluster/src/main.rs
+++ b/bin/test-cluster/src/main.rs
@@ -15,6 +15,7 @@ enum Cmd {
     Run(String),
     Suite(Tier),
     List,
+    CoordinatorChild,
 }
 
 fn parse_args(args: &[String]) -> Result<Cmd, String> {
@@ -27,6 +28,7 @@ fn parse_args(args: &[String]) -> Result<Cmd, String> {
             other => Err(format!("unknown tier {other:?} (smoke|full)")),
         },
         [cmd] if cmd == "list" => Ok(Cmd::List),
+        [cmd] if cmd == "__coordinator-child" => Ok(Cmd::CoordinatorChild),
         other => Err(format!(
             "usage: sp1-test-cluster [run <scenario> | suite <smoke|full> | list], got {other:?}"
         )),
@@ -42,10 +44,18 @@ async fn main() -> anyhow::Result<()> {
         )
     }
 
-    sp1_cluster_common::logger::init(opentelemetry_sdk::Resource::empty());
-
     let args: Vec<String> = std::env::args().skip(1).collect();
     let cmd = parse_args(&args).map_err(|e| anyhow::anyhow!(e))?;
+
+    if matches!(cmd, Cmd::CoordinatorChild) {
+        return sp1_cluster_coordinator::server::run_coordinator_server::<
+            sp1_cluster_coordinator::policy::balanced::BalancedPolicy,
+        >()
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()));
+    }
+
+    sp1_cluster_common::logger::init(opentelemetry_sdk::Resource::empty());
 
     match cmd {
         Cmd::List => {
@@ -77,6 +87,7 @@ async fn main() -> anyhow::Result<()> {
             }
             Ok(())
         }
+        Cmd::CoordinatorChild => unreachable!("handled before test-cluster logger initialization"),
     }
 }
 
@@ -102,6 +113,10 @@ mod tests {
             Ok(Cmd::Suite(Tier::Full))
         ));
         assert!(matches!(parse_args(&s(&["list"])), Ok(Cmd::List)));
+        assert!(matches!(
+            parse_args(&s(&["__coordinator-child"])),
+            Ok(Cmd::CoordinatorChild)
+        ));
         assert!(matches!(parse_args(&s(&[])), Ok(Cmd::Suite(Tier::Smoke))));
         assert!(parse_args(&s(&["bogus"])).is_err());
         assert!(parse_args(&s(&["suite", "bogus"])).is_err());

--- a/bin/test-cluster/src/scenarios/coordinator_restart.rs
+++ b/bin/test-cluster/src/scenarios/coordinator_restart.rs
@@ -11,7 +11,7 @@ use crate::scenario::{Scenario, ScenarioFuture, Tier};
 pub fn scenario() -> Scenario {
     Scenario {
         name: "coordinator-restart",
-        timeout: Duration::from_mins(20),
+        timeout: Duration::from_mins(10),
         tier: Tier::Full,
         run: || -> ScenarioFuture { Box::pin(run()) },
     }
@@ -49,8 +49,7 @@ async fn run() -> anyhow::Result<()> {
     .await?;
     tracing::info!("proof {proof_id} is active; killing coordinator");
 
-    cluster.crash_coordinator_process().await?;
-    cluster.restart_coordinator_process()?;
+    cluster.crash_and_restart_coordinator_process().await?;
     crate::utils::wait_for_tcp(&cluster.addrs.coordinator, "restarted coordinator").await?;
 
     let mut coordinator = cluster.coordinator_client().await?;

--- a/bin/test-cluster/src/scenarios/coordinator_restart.rs
+++ b/bin/test-cluster/src/scenarios/coordinator_restart.rs
@@ -11,77 +11,74 @@ use crate::scenario::{Scenario, ScenarioFuture, Tier};
 pub fn scenario() -> Scenario {
     Scenario {
         name: "coordinator-restart",
-        timeout: Duration::from_mins(10),
+        timeout: Duration::from_mins(20),
         tier: Tier::Full,
         run: || -> ScenarioFuture { Box::pin(run()) },
     }
 }
 
-/// Rolling-restart safety: complete a proof, kill the coordinator (crash semantics),
-/// restart it on the same port against the same API, restart the workers (their stream to
-/// the old coordinator is gone), and verify a NEW proof completes on the restarted stack.
-///
-/// Note: mid-flight proofs do NOT survive a coordinator crash today — the claimer only
-/// claims unhandled requests, so an already-claimed in-flight request is orphaned. That
-/// recovery gap is product work; this scenario pins the restart/rebind/reconnect behavior
-/// that must hold for rolling restarts of an idle-ish coordinator.
+/// Crash the coordinator while a proof is active, restart it on the same port against the
+/// same API, and verify that the same proof completes without manually restarting workers.
 async fn run() -> anyhow::Result<()> {
-    let mut cluster = Cluster::standard().start().await?;
+    let mut cluster = Cluster::standard()
+        .process_isolated_coordinator()
+        .start()
+        .await?;
     let api = cluster.api_client().await?;
+    let mut coordinator = cluster.coordinator_client().await?;
 
-    // Proof A on the original coordinator.
-    let proof_a = request_only(
+    let proof_id = request_only(
         &cluster.gateway_rpc_url(),
-        programs::FIBONACCI_ELF.clone(),
-        programs::FIBONACCI_STDIN.clone(),
+        programs::RSP_ELF.clone(),
+        programs::RSP_STDIN.clone(),
         SP1ProofMode::Compressed,
     )
     .await?;
-    assert_proof_completed(
-        &api,
-        &proof_a,
-        Duration::from_mins(30),
-        &cluster.artifact_client(),
+    tracing::info!("submitted {proof_id}");
+
+    let has_gpu = cluster.has_component("gpu-node-0");
+    wait_stats(
+        &mut coordinator,
+        "proof actively running before coordinator crash",
+        Duration::from_mins(5),
+        |s| {
+            s.active_tasks > 0
+                && (!has_gpu || (s.gpu_workers >= 1 && s.gpu_utilization_current > 0))
+        },
     )
     .await?;
-    tracing::info!("proof A completed; killing coordinator");
+    tracing::info!("proof {proof_id} is active; killing coordinator");
 
-    cluster.kill("coordinator")?;
-    cluster.restart("coordinator").await?;
+    cluster.crash_coordinator_process().await?;
+    cluster.restart_coordinator_process()?;
     crate::utils::wait_for_tcp(&cluster.addrs.coordinator, "restarted coordinator").await?;
 
-    // The workers' streams died with the old coordinator; roll them too. The cluster
-    // knows whether a gpu node was actually spawned — no re-deriving the build flavor.
-    let has_gpu = cluster.has_component("gpu-node-0");
-    cluster.restart("cpu-node-0").await?;
-    if has_gpu {
-        cluster.restart("gpu-node-0").await?;
-    }
     let mut coordinator = cluster.coordinator_client().await?;
     wait_stats(
         &mut coordinator,
-        "workers re-registered with restarted coordinator",
+        "workers reconnected to restarted coordinator",
         Duration::from_mins(15),
         |s| s.cpu_workers >= 1 && (!has_gpu || s.gpu_workers >= 1),
     )
     .await?;
-
-    // Proof B on the restarted stack.
-    let proof_b = request_only(
-        &cluster.gateway_rpc_url(),
-        programs::FIBONACCI_ELF.clone(),
-        programs::FIBONACCI_STDIN.clone(),
-        SP1ProofMode::Compressed,
-    )
-    .await?;
     assert_proof_completed(
         &api,
-        &proof_b,
-        Duration::from_mins(30),
+        &proof_id,
+        Duration::from_hours(1),
         &cluster.artifact_client(),
     )
     .await?;
-    tracing::info!("proof B completed on restarted coordinator");
+    wait_stats(
+        &mut coordinator,
+        "workers still registered after recovered proof",
+        Duration::from_secs(30),
+        |s| s.cpu_workers >= 1 && (!has_gpu || s.gpu_workers >= 1),
+    )
+    .await?;
+    if cluster.root.is_cancelled() {
+        anyhow::bail!("cluster cancelled during coordinator crash recovery");
+    }
+    tracing::info!("proof {proof_id} completed after coordinator crash");
 
     cluster.shutdown().await;
     Ok(())

--- a/bin/test-cluster/src/scenarios/coordinator_restart.rs
+++ b/bin/test-cluster/src/scenarios/coordinator_restart.rs
@@ -29,8 +29,8 @@ async fn run() -> anyhow::Result<()> {
 
     let proof_id = request_only(
         &cluster.gateway_rpc_url(),
-        programs::RSP_ELF.clone(),
-        programs::RSP_STDIN.clone(),
+        programs::FIBONACCI_ELF.clone(),
+        programs::FIBONACCI_STDIN.clone(),
         SP1ProofMode::Compressed,
     )
     .await?;


### PR DESCRIPTION
## Summary

- Strengthen the existing `coordinator-restart` scenario.
- Kill the coordinator during an active GPU proof.
- Require existing workers to reconnect and the same proof request to complete with an artifact.

## Motivation

The previous scenario completed one proof before the restart.
It restarted the coordinator and workers, then submitted a new proof.
It did not test recovery for an active proof.

The in-process server also kept accepted gRPC connections alive after its server task stopped.
The revised scenario runs the coordinator as a child process, then kills that process.

## Validation

- [RSP Full GPU run](https://github.com/succinctlabs/sp1-cluster/actions/runs/31560475028)
- [Fibonacci Full GPU run](https://github.com/succinctlabs/sp1-cluster/actions/runs/31658435807)
- Formatting, clippy, workspace tests, and manifest sorting passed locally.

Both GPU runs completed the same proof request after the coordinator crash.
The final scenario uses Fibonacci to reduce test time.

## Scope

This test validates recovery in the test cluster.
It does not measure a production recovery time.
