### PR TITLE
fix(cli): restore concurrent bench requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8468,6 +8468,7 @@ dependencies = [
  "sp1-prover-types",
  "sp1-sdk",
  "tokio",
+ "tonic 0.12.3",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,36 @@ To get started, you will need to have the following installed:
 
 ```bash
 git clone https://github.com/succinctlabs/sp1-cluster.git
-cd cluster
+cd sp1-cluster
 
 # Build
 cargo build --release
 ```
+
+## Benchmarking
+
+Start `gpu0`. Compose also starts its API, coordinator, Redis, and Postgres dependencies:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d gpu0
+```
+
+The CLI connects to the **API** service, not the coordinator. It must use the workers' artifact
+store:
+
+```bash
+export CLI_CLUSTER_RPC=http://127.0.0.1:50051
+export CLI_REDIS_NODES=redis://:redispassword@127.0.0.1:6379/0
+
+# One 20M-cycle Fibonacci proof.
+./target/release/sp1-cluster-cli bench fibonacci 20
+
+# Four at once, for aggregate cluster throughput.
+./target/release/sp1-cluster-cli bench fibonacci 20 --count 4
+```
+
+Inside the Compose network, use service names:
+`CLI_CLUSTER_RPC=http://api:50051` and `CLI_REDIS_NODES=redis://:redispassword@redis:6379/0`.
 
 ## Deploying
 

--- a/bin/cli/src/commands/bench.rs
+++ b/bin/cli/src/commands/bench.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU16;
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -5,7 +6,7 @@ use clap::{Args, Subcommand};
 use eyre::Result;
 use sp1_cluster_artifact::{redis::RedisArtifactClient, ArtifactClient, ArtifactType};
 use sp1_cluster_common::proto::{CreateDummyProofRequest, TaskStatus, TaskType, WorkerType};
-use sp1_cluster_utils::{request_proof_from_env, ClusterElf, ProofRequestResults};
+use sp1_cluster_utils::{request_proofs_from_env, ClusterElf, ProofRequestResults};
 use sp1_cluster_worker::client::WorkerServiceClient;
 use sp1_prover::worker::{
     ProofId, RawTaskRequest, RequesterId, SP1LightNode, TaskContext, WorkerClient,
@@ -41,9 +42,17 @@ pub struct CommonArgs {
     #[arg(short, long, default_value="compressed", value_parser = parse_proof_mode)]
     pub mode: ProofMode,
 
-    #[arg(short, long, default_value_t = 1)]
-    pub count: u32,
+    #[arg(short, long, default_value_t = NonZeroU16::MIN)]
+    pub count: NonZeroU16,
 }
+
+/// Fibonacci iterations that cost one million cycles in `artifacts/fibonacci.bin`.
+const FIBONACCI_ITERS_PER_MCYCLE: u32 = 83_333;
+
+const FIBONACCI_ELF: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../artifacts/fibonacci.bin"
+));
 
 pub fn parse_proof_mode(s: &str) -> Result<ProofMode> {
     ProofMode::from_str_name(&s.to_ascii_uppercase())
@@ -99,10 +108,15 @@ impl BenchCommand {
                     mcycles
                 );
                 let mut stdin = SP1Stdin::new();
-                stdin.write(&(mcycles * 83333));
+                stdin.write(&(mcycles * FIBONACCI_ITERS_PER_MCYCLE));
 
-                let elf = include_bytes!("../../../../artifacts/fibonacci.bin");
-                Self::run_benchmark(elf.to_vec(), stdin.clone(), common).await?;
+                Self::run_benchmark(
+                    FIBONACCI_ELF.to_vec(),
+                    stdin,
+                    common,
+                    Some(*mcycles as u64 * 1_000_000),
+                )
+                .await?;
             }
             BenchCommand::Input {
                 elf_file,
@@ -117,7 +131,7 @@ impl BenchCommand {
                 );
                 let elf = std::fs::read(elf_file)?;
                 let stdin = bincode::deserialize::<SP1Stdin>(&std::fs::read(stdin_file)?)?;
-                let proof_ids = Self::run_benchmark(elf.to_vec(), stdin, common).await?;
+                let proof_ids = Self::run_benchmark(elf.to_vec(), stdin, common, None).await?;
 
                 let elf_name = elf_file.file_name().unwrap().to_str().unwrap();
                 let workload_name = stdin_file.file_name().unwrap().to_str().unwrap();
@@ -139,7 +153,7 @@ impl BenchCommand {
                 tracing::info!("Downloading program from s3://{}/{}...", bucket, s3_path);
                 let (elf, stdin) = Self::download_from_s3(bucket, s3_path, param).await?;
                 tracing::info!("Running S3 program {:?} benchmark...", s3_path);
-                let proof_ids = Self::run_benchmark(elf, stdin, common).await?;
+                let proof_ids = Self::run_benchmark(elf, stdin, common, None).await?;
 
                 // Write all proof IDs to CSV
                 for (proof_id, duration) in proof_ids {
@@ -169,36 +183,53 @@ impl BenchCommand {
     }
 
     /// Runs a benchmark for a given elf and stdin, returning the proof ids and elapsed times.
-    ///
-    /// TODO: Expensive clone + reuploading of elf and stdin for when running for multiple repetitions.
     async fn run_benchmark(
         elf: Vec<u8>,
         stdin: SP1Stdin,
         common: &CommonArgs,
+        cycles_estimate: Option<u64>,
     ) -> Result<Vec<(String, Duration)>> {
         let client = SP1LightNode::new().await;
 
         let vk = client.setup(&elf).await.expect("failed to setup elf");
 
-        let mut proof_ids = Vec::with_capacity(common.count as usize);
-        for _ in 0..common.count {
-            let cluster_elf = ClusterElf::NewElf(elf.clone());
+        let start_time = Instant::now();
+        let results =
+            request_proofs_from_env(common.mode, 4, ClusterElf::NewElf(elf), stdin, common.count)
+                .await?;
+        let total_elapsed = start_time.elapsed();
 
-            let ProofRequestResults {
-                proof_id,
-                proof,
-                elapsed,
-            } = request_proof_from_env(common.mode, 4, cluster_elf, stdin.clone()).await?;
-
+        let mut proof_ids = Vec::with_capacity(results.len());
+        for ProofRequestResults {
+            proof_id,
+            proof,
+            elapsed,
+        } in results
+        {
             // Verify proof to CSV
             client
                 .verify(&vk, &proof.proof)
                 .expect("failed to verify proof");
 
-            tracing::info!("Proof completed in {:?}", elapsed);
+            tracing::info!("Proof {} completed in {:?}", proof_id, elapsed);
 
             proof_ids.push((proof_id, elapsed));
         }
+
+        tracing::info!(
+            "{} proofs completed in {:?}",
+            proof_ids.len(),
+            total_elapsed
+        );
+        if let Some(cycles_estimate) = cycles_estimate {
+            let total_cycles = cycles_estimate * u64::from(common.count.get());
+            tracing::info!(
+                "Total Cycles: {} | Aggregate MHz: {:.2}",
+                total_cycles,
+                total_cycles as f64 / total_elapsed.as_secs_f64() / 1_000_000.0
+            );
+        }
+
         Ok(proof_ids)
     }
 
@@ -336,7 +367,7 @@ impl BenchCommand {
             .await
             .map_err(|e| eyre::eyre!("Failed to upload stdin: {}", e))?;
 
-        let count = common.count;
+        let count = u32::from(common.count.get());
         let cluster_rpc = common.cluster_rpc.clone();
 
         tracing::info!(

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -35,3 +35,28 @@ async fn main() {
         tracing::info!("Error: {:?}", e);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Cli;
+
+    #[test]
+    fn count_rejects_zero_and_values_above_the_batch_limit() {
+        for count in ["0", "65536"] {
+            let result = Cli::try_parse_from([
+                "test",
+                "bench",
+                "fibonacci",
+                "20",
+                "--cluster-rpc",
+                "http://127.0.0.1:50051",
+                "--count",
+                count,
+            ]);
+
+            assert!(result.is_err(), "accepted --count {count}");
+        }
+    }
+}

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -14,3 +14,7 @@ sp1-prover-types = { workspace = true }
 sp1-sdk = { workspace = true, features = ["native-gnark"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+tonic = { workspace = true }

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -4,24 +4,7 @@ This crate provides a set of utilities for requesting proofs from the SP1 Cluste
 
 ## Quick start
 
-Your machine should have 64 GB of RAM, and an NVIDIA GPU. 4090, 5090, or L4 are recommended. 
-
-Put the following variables in your .env
-
-```bash
-CLI_CLUSTER_RPC=http://localhost:50051
-CLI_REDIS_NODES=redis://:redispassword@localhost:6379/0
-```
-
-Start a local docker compose in the background. This uses a local redis artifact store.
-```bash
-docker compose -f infra/docker-compose.local.yml up -d
-```
-
-Then run the following command to request a proof:
-```bash
-cargo run --bin sp1-cluster-cli bench input v6-fib-program.bin v6-fib-stdin.bin --mode compressed
-```
+See the project [benchmarking workflow](../../README.md#benchmarking) for the local cluster and CLI setup.
 
 ## Requester env vars
 
@@ -34,4 +17,4 @@ Use either the S3 env vars or the Redis env vars, but not both.
 
 ## Usage
 
-The basic usage of this crate is to use the `request_proof_from_env` function, which reads environment variables, requests a proof, and waits for its completion.
+Call `request_proof_from_env` to read the environment, request a proof, and wait for it.

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+use std::num::NonZeroU16;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use eyre::Result;
@@ -10,7 +11,7 @@ use sp1_cluster_artifact::{
 };
 use sp1_cluster_common::{
     client::ClusterServiceClient,
-    proto::{self, ProofRequestStatus},
+    proto::{self, ProofRequestCancelRequest, ProofRequestStatus},
 };
 use sp1_prover_types::Artifact;
 use sp1_sdk::{network::proto::types::ProofMode, ProofFromNetwork, SP1Stdin};
@@ -54,6 +55,25 @@ pub enum ClusterElf {
     ExistingElf(Artifact),
 }
 
+/// `ClusterServiceClient::new` retries a refused connection forever, which leaves the CLI logging
+/// warnings with nothing to show for it.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn connect(cluster_rpc: &str) -> Result<ClusterServiceClient> {
+    tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        ClusterServiceClient::new(cluster_rpc.to_string()),
+    )
+    .await
+    .map_err(|_| {
+        eyre::eyre!(
+            "no cluster at {} after {:?}: start the cluster, or set CLI_CLUSTER_RPC to its API",
+            cluster_rpc,
+            CONNECT_TIMEOUT
+        )
+    })?
+}
+
 /// Creates a proof request and returns the proof id, deadline, and start time.
 pub async fn create_request<A: ArtifactClient>(
     artifact_client: A,
@@ -61,10 +81,28 @@ pub async fn create_request<A: ArtifactClient>(
     stdin: SP1Stdin,
     config: &ProofRequestConfig,
 ) -> Result<ProofRequest> {
-    let client = ClusterServiceClient::new(config.cluster_rpc.clone()).await?;
+    let client = connect(&config.cluster_rpc).await?;
+    let mut requests = create_requests(
+        &client,
+        artifact_client,
+        elf,
+        stdin,
+        NonZeroU16::MIN,
+        config,
+    )
+    .await?;
+    Ok(requests.pop().expect("one request created"))
+}
 
-    let (elf_id, stdin_id, proof_output_id) =
-        setup_artifacts(artifact_client.clone(), elf, stdin).await?;
+async fn create_requests<A: ArtifactClient>(
+    client: &ClusterServiceClient,
+    artifact_client: A,
+    elf: ClusterElf,
+    stdin: SP1Stdin,
+    count: NonZeroU16,
+    config: &ProofRequestConfig,
+) -> Result<Vec<ProofRequest>> {
+    let (elf_id, stdin_id) = setup_artifacts(artifact_client.clone(), elf, stdin).await?;
 
     let base_id = format!(
         "cli_{}",
@@ -75,33 +113,46 @@ pub async fn create_request<A: ArtifactClient>(
     );
 
     let deadline = SystemTime::now() + Duration::from_secs(config.timeout_hours * 60 * 60);
-    let proof_id = base_id.to_string();
 
-    // Create the proof request.
-    client
-        .create_proof_request(sp1_cluster_common::proto::ProofRequestCreateRequest {
-            proof_id: proof_id.clone(),
-            program_artifact_id: elf_id.clone().to_id(),
-            stdin_artifact_id: stdin_id.clone().to_id(),
-            options_artifact_id: Some((config.mode as i32).to_string()),
-            proof_artifact_id: Some(proof_output_id.clone().to_id()),
-            requester: vec![],
-            deadline: deadline.duration_since(UNIX_EPOCH).unwrap().as_secs(),
-            cycle_limit: u64::MAX,
-            gas_limit: u64::MAX,
-            scheduled_by: None,
-            stdin_private: false,
-        })
-        .await?;
+    let mut requests = Vec::with_capacity(usize::from(count.get()));
+    for i in 0..count.get() {
+        let proof_id = format!("{base_id}_{i}");
+        let proof_output_id = match artifact_client.create_artifact() {
+            Ok(proof_output_id) => proof_output_id,
+            Err(error) => {
+                return Err(error_after_cancelling(client, &requests, eyre::eyre!(error)).await)
+            }
+        };
 
-    let start_time: Instant = Instant::now();
-    tracing::info!("Successfully created proof request {}", proof_id);
-    Ok(ProofRequest {
-        proof_id,
-        proof_output_id,
-        deadline,
-        start_time,
-    })
+        if let Err(error) = client
+            .create_proof_request(sp1_cluster_common::proto::ProofRequestCreateRequest {
+                proof_id: proof_id.clone(),
+                program_artifact_id: elf_id.clone().to_id(),
+                stdin_artifact_id: stdin_id.clone().to_id(),
+                options_artifact_id: Some((config.mode as i32).to_string()),
+                proof_artifact_id: Some(proof_output_id.clone().to_id()),
+                requester: vec![],
+                deadline: deadline.duration_since(UNIX_EPOCH).unwrap().as_secs(),
+                cycle_limit: u64::MAX,
+                gas_limit: u64::MAX,
+                scheduled_by: None,
+                stdin_private: false,
+            })
+            .await
+        {
+            return Err(error_after_cancelling(client, &requests, error).await);
+        }
+
+        let start_time: Instant = Instant::now();
+        tracing::info!("Successfully created proof request {}", proof_id);
+        requests.push(ProofRequest {
+            proof_id,
+            proof_output_id,
+            deadline,
+            start_time,
+        });
+    }
+    Ok(requests)
 }
 
 /// Checks the status of a proof request and returns the ProofRequestResult if it is completed.
@@ -148,7 +199,7 @@ pub async fn check_proof_status<A: ArtifactClient>(
             let completed_proof = artifact_client
                 .download_with_type(&proof_output_id, ArtifactType::Proof)
                 .await
-                .expect("failed to download proof");
+                .map_err(|error| eyre::eyre!("failed to download proof {proof_id}: {error}"))?;
             proof = Some(completed_proof);
         }
         ProofRequestStatus::Failed | ProofRequestStatus::Cancelled => {
@@ -177,12 +228,11 @@ pub async fn check_proof_status<A: ArtifactClient>(
     }
 }
 
-/// Sets up the elf, stdin, and proof output artifacts.
 async fn setup_artifacts<A: ArtifactClient>(
     artifact_client: A,
     elf: ClusterElf,
     stdin: SP1Stdin,
-) -> Result<(Artifact, Artifact, Artifact)> {
+) -> Result<(Artifact, Artifact)> {
     let elf_id = match elf {
         ClusterElf::NewElf(elf) => {
             let elf_id = artifact_client.create_artifact().unwrap();
@@ -199,15 +249,8 @@ async fn setup_artifacts<A: ArtifactClient>(
         .upload_with_type(&stdin_id, ArtifactType::Stdin, stdin)
         .await
         .map_err(|e| eyre::eyre!(e))?;
-    let proof_output_id = artifact_client.create_artifact().unwrap();
 
-    // TODO: what to do with this
-    // // Save the elf id to ELF_ID file in the cargo manifest directory
-    // let elf_id_path = std::env::var("CARGO_MANIFEST_DIR")
-    //     .map(|dir| format!("{}/{}", dir, ELF_ID_PATH))
-    //     .unwrap_or_else(|_| ELF_ID_PATH.to_string());
-    // std::fs::write(&elf_id_path, elf_id.clone().to_id())?;
-    Ok((elf_id, stdin_id, proof_output_id))
+    Ok((elf_id, stdin_id))
 }
 
 pub async fn request_proof<A: ArtifactClient>(
@@ -216,15 +259,82 @@ pub async fn request_proof<A: ArtifactClient>(
     stdin: SP1Stdin,
     config: &ProofRequestConfig,
 ) -> Result<ProofRequestResults> {
-    let proof_request = create_request(artifact_client.clone(), elf, stdin, config).await?;
-    let mut proof_request_result = None;
-    let client = ClusterServiceClient::new(config.cluster_rpc.clone()).await?;
-    while proof_request_result.is_none() {
-        proof_request_result =
-            check_proof_status(artifact_client.clone(), proof_request.clone(), &client).await?;
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    let mut results = request_proofs(artifact_client, elf, stdin, NonZeroU16::MIN, config).await?;
+    Ok(results.pop().expect("one proof requested"))
+}
+
+/// Creates every request before polling any of them, allowing the cluster to prove concurrently.
+pub async fn request_proofs<A: ArtifactClient>(
+    artifact_client: A,
+    elf: ClusterElf,
+    stdin: SP1Stdin,
+    count: NonZeroU16,
+    config: &ProofRequestConfig,
+) -> Result<Vec<ProofRequestResults>> {
+    let client = connect(&config.cluster_rpc).await?;
+    let mut pending =
+        create_requests(&client, artifact_client.clone(), elf, stdin, count, config).await?;
+
+    let mut results = Vec::with_capacity(pending.len());
+    while !pending.is_empty() {
+        let mut still_pending = Vec::with_capacity(pending.len());
+        let mut pending_iter = pending.into_iter();
+        while let Some(proof_request) = pending_iter.next() {
+            match check_proof_status(artifact_client.clone(), proof_request.clone(), &client).await
+            {
+                Ok(Some(result)) => results.push(result),
+                Ok(None) => still_pending.push(proof_request),
+                Err(error) => {
+                    still_pending.push(proof_request);
+                    still_pending.extend(pending_iter);
+                    return Err(error_after_cancelling(&client, &still_pending, error).await);
+                }
+            }
+        }
+        pending = still_pending;
+        if !pending.is_empty() {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
-    Ok(proof_request_result.unwrap())
+    Ok(results)
+}
+
+async fn cancel_pending_requests(
+    client: &ClusterServiceClient,
+    pending: &[ProofRequest],
+) -> Result<()> {
+    let mut failures = Vec::new();
+    for request in pending {
+        if let Err(error) = client
+            .cancel_proof_request(ProofRequestCancelRequest {
+                proof_id: request.proof_id.clone(),
+            })
+            .await
+        {
+            failures.push(format!("{}: {error}", request.proof_id));
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(eyre::eyre!(
+            "failed to cancel {} proof requests: {}",
+            failures.len(),
+            failures.join("; ")
+        ))
+    }
+}
+
+async fn error_after_cancelling(
+    client: &ClusterServiceClient,
+    pending: &[ProofRequest],
+    error: eyre::Report,
+) -> eyre::Report {
+    match cancel_pending_requests(client, pending).await {
+        Ok(()) => error,
+        Err(cancel_error) => eyre::eyre!("{error:#}; batch cleanup also failed: {cancel_error:#}"),
+    }
 }
 
 /// Request a proof from the cluster. Waits for the proof to complete.
@@ -233,11 +343,21 @@ pub async fn request_proof_with_config(
     stdin: SP1Stdin,
     config: &ProofRequestConfig,
 ) -> Result<ProofRequestResults> {
+    let mut results = request_proofs_with_config(elf, stdin, NonZeroU16::MIN, config).await?;
+    Ok(results.pop().expect("one proof requested"))
+}
+
+pub async fn request_proofs_with_config(
+    elf: ClusterElf,
+    stdin: SP1Stdin,
+    count: NonZeroU16,
+    config: &ProofRequestConfig,
+) -> Result<Vec<ProofRequestResults>> {
     match &config.artifact_store {
         ArtifactStoreConfig::Redis { nodes } => {
             tracing::info!("using redis artifact store");
             let artifact_client = RedisArtifactClient::new(nodes.clone(), 16);
-            request_proof(artifact_client, elf, stdin, config).await
+            request_proofs(artifact_client, elf, stdin, count, config).await
         }
         ArtifactStoreConfig::S3 { bucket, region } => {
             tracing::info!("using s3 artifact store");
@@ -250,7 +370,7 @@ pub async fn request_proof_with_config(
                 ),
             )
             .await;
-            request_proof(artifact_client, elf, stdin, config).await
+            request_proofs(artifact_client, elf, stdin, count, config).await
         }
     }
 }
@@ -293,6 +413,18 @@ pub async fn request_proof_from_env(
     elf: ClusterElf,
     stdin: SP1Stdin,
 ) -> Result<ProofRequestResults> {
+    let mut results =
+        request_proofs_from_env(mode, timeout_hours, elf, stdin, NonZeroU16::MIN).await?;
+    Ok(results.pop().expect("one proof requested"))
+}
+
+pub async fn request_proofs_from_env(
+    mode: ProofMode,
+    timeout_hours: u64,
+    elf: ClusterElf,
+    stdin: SP1Stdin,
+    count: NonZeroU16,
+) -> Result<Vec<ProofRequestResults>> {
     let config = request_config_from_env(mode, timeout_hours);
-    request_proof_with_config(elf, stdin, &config).await
+    request_proofs_with_config(elf, stdin, count, &config).await
 }

--- a/crates/utils/tests/request_proofs.rs
+++ b/crates/utils/tests/request_proofs.rs
@@ -1,0 +1,291 @@
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::num::NonZeroU16;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use sp1_cluster_artifact::{ArtifactClient, ArtifactType, InMemoryArtifactClient};
+use sp1_cluster_common::proto::{
+    self as cluster_pb,
+    cluster_service_server::{ClusterService, ClusterServiceServer},
+};
+use sp1_cluster_utils::{
+    request_proofs, ArtifactStoreConfig, ClusterElf, ProofRequestConfig, ProofRequestResults,
+};
+use sp1_sdk::{
+    network::proto::types::ProofMode, ProofFromNetwork, SP1Proof, SP1PublicValues, SP1Stdin,
+};
+use tokio::sync::oneshot;
+
+#[derive(Clone)]
+struct BarrierCluster {
+    artifacts: InMemoryArtifactClient,
+    expected: usize,
+    requests: Arc<Mutex<HashMap<String, cluster_pb::ProofRequest>>>,
+    cancelled: Arc<Mutex<HashSet<String>>>,
+    fail_create_at: Option<usize>,
+    fail_get: bool,
+}
+
+impl BarrierCluster {
+    fn new(expected: u16) -> Self {
+        Self {
+            artifacts: InMemoryArtifactClient::new(),
+            expected: usize::from(expected),
+            requests: Arc::default(),
+            cancelled: Arc::default(),
+            fail_create_at: None,
+            fail_get: false,
+        }
+    }
+
+    fn cancelled_count(&self) -> usize {
+        self.cancelled.lock().unwrap().len()
+    }
+}
+
+#[tonic::async_trait]
+impl ClusterService for BarrierCluster {
+    async fn proof_request_create(
+        &self,
+        request: tonic::Request<cluster_pb::ProofRequestCreateRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        let req = request.into_inner();
+        let mut requests = self.requests.lock().unwrap();
+        if self.fail_create_at == Some(requests.len()) {
+            return Err(tonic::Status::invalid_argument("simulated create failure"));
+        }
+        requests.insert(
+            req.proof_id.clone(),
+            cluster_pb::ProofRequest {
+                id: req.proof_id,
+                proof_status: cluster_pb::ProofRequestStatus::Pending as i32,
+                requester: req.requester,
+                execution_result: None,
+                stdin_artifact_id: req.stdin_artifact_id,
+                program_artifact_id: req.program_artifact_id,
+                proof_artifact_id: req.proof_artifact_id,
+                options_artifact_id: req.options_artifact_id,
+                cycle_limit: Some(req.cycle_limit),
+                gas_limit: Some(req.gas_limit),
+                deadline: req.deadline,
+                handled: true,
+                metadata: String::new(),
+                created_at: 0,
+                updated_at: 0,
+                extra_data: None,
+                scheduled_by: req.scheduled_by,
+                stdin_private: req.stdin_private,
+            },
+        );
+        Ok(tonic::Response::new(()))
+    }
+
+    async fn proof_request_get(
+        &self,
+        request: tonic::Request<cluster_pb::ProofRequestGetRequest>,
+    ) -> Result<tonic::Response<cluster_pb::ProofRequestGetResponse>, tonic::Status> {
+        if self.fail_get {
+            return Err(tonic::Status::invalid_argument("simulated poll failure"));
+        }
+        let id = request.into_inner().proof_id;
+        let (mut proof_request, request_count) = {
+            let requests = self.requests.lock().unwrap();
+            let proof_request = requests
+                .get(&id)
+                .cloned()
+                .ok_or_else(|| tonic::Status::not_found(id))?;
+            (proof_request, requests.len())
+        };
+
+        if request_count >= self.expected {
+            let proof_artifact_id = proof_request
+                .proof_artifact_id
+                .clone()
+                .expect("proof_artifact_id set");
+            let proof = ProofFromNetwork {
+                proof: SP1Proof::Core(vec![]),
+                public_values: SP1PublicValues::new(),
+                sp1_version: String::new(),
+            };
+            self.artifacts
+                .upload_with_type(&proof_artifact_id, ArtifactType::Proof, proof)
+                .await
+                .expect("upload canned proof");
+            proof_request.proof_status = cluster_pb::ProofRequestStatus::Completed as i32;
+        }
+
+        Ok(tonic::Response::new(cluster_pb::ProofRequestGetResponse {
+            proof_request: Some(proof_request),
+        }))
+    }
+
+    async fn proof_request_cancel(
+        &self,
+        request: tonic::Request<cluster_pb::ProofRequestCancelRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        self.cancelled
+            .lock()
+            .unwrap()
+            .insert(request.into_inner().proof_id);
+        Ok(tonic::Response::new(()))
+    }
+
+    async fn proof_request_update(
+        &self,
+        _request: tonic::Request<cluster_pb::ProofRequestUpdateRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(tonic::Status::unimplemented("update"))
+    }
+
+    async fn proof_request_list(
+        &self,
+        _request: tonic::Request<cluster_pb::ProofRequestListRequest>,
+    ) -> Result<tonic::Response<cluster_pb::ProofRequestListResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("list"))
+    }
+
+    async fn set_cluster_component_info(
+        &self,
+        _request: tonic::Request<cluster_pb::SetClusterComponentInfoRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(tonic::Status::unimplemented("set_cluster_component_info"))
+    }
+
+    async fn get_cluster_component_info(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<cluster_pb::ClusterComponentManifest>, tonic::Status> {
+        Err(tonic::Status::unimplemented("get_cluster_component_info"))
+    }
+
+    async fn healthcheck(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Ok(tonic::Response::new(()))
+    }
+}
+
+async fn run_batch(cluster: BarrierCluster, count: u16) -> eyre::Result<Vec<ProofRequestResults>> {
+    let artifacts = cluster.artifacts.clone();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    drop(listener);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(ClusterServiceServer::new(cluster))
+            .serve_with_shutdown(addr, async move {
+                shutdown_rx.await.ok();
+            })
+            .await
+            .unwrap();
+    });
+
+    let config = ProofRequestConfig {
+        cluster_rpc: format!("http://{addr}"),
+        mode: ProofMode::Compressed,
+        timeout_hours: 1,
+        artifact_store: ArtifactStoreConfig::Redis { nodes: vec![] },
+    };
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        request_proofs(
+            artifacts,
+            ClusterElf::NewElf(vec![0; 32]),
+            SP1Stdin::new(),
+            NonZeroU16::new(count).expect("test count is positive"),
+            &config,
+        ),
+    )
+    .await
+    .expect("batch request timed out");
+
+    shutdown_tx.send(()).ok();
+    server.await.unwrap();
+
+    result
+}
+
+async fn request_batch(count: u16) -> Vec<ProofRequestResults> {
+    run_batch(BarrierCluster::new(count), count)
+        .await
+        .expect("request_proofs failed")
+}
+
+#[tokio::test]
+async fn requests_are_created_before_any_is_awaited() {
+    let results = request_batch(4).await;
+
+    assert_eq!(results.len(), 4);
+    let ids: std::collections::HashSet<_> = results.iter().map(|r| r.proof_id.clone()).collect();
+    assert_eq!(ids.len(), 4, "proof ids must be unique");
+}
+
+#[tokio::test]
+async fn single_request_still_works() {
+    assert_eq!(request_batch(1).await.len(), 1);
+}
+
+#[tokio::test]
+async fn create_failure_cancels_submitted_requests() {
+    let mut cluster = BarrierCluster::new(4);
+    cluster.fail_create_at = Some(2);
+    let observed = cluster.clone();
+
+    let error = run_batch(cluster, 4)
+        .await
+        .err()
+        .expect("batch creation should fail");
+
+    assert!(error.to_string().contains("simulated create failure"));
+    assert_eq!(observed.cancelled_count(), 2);
+}
+
+#[tokio::test]
+async fn poll_failure_cancels_pending_requests() {
+    let mut cluster = BarrierCluster::new(4);
+    cluster.fail_get = true;
+    let observed = cluster.clone();
+
+    let error = run_batch(cluster, 4)
+        .await
+        .err()
+        .expect("batch polling should fail");
+
+    assert!(error.to_string().contains("simulated poll failure"));
+    assert_eq!(observed.cancelled_count(), 4);
+}
+
+#[tokio::test(start_paused = true)]
+async fn unreachable_cluster_gives_up() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config = ProofRequestConfig {
+        cluster_rpc: format!("http://{addr}"),
+        mode: ProofMode::Compressed,
+        timeout_hours: 1,
+        artifact_store: ArtifactStoreConfig::Redis { nodes: vec![] },
+    };
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(60),
+        request_proofs(
+            InMemoryArtifactClient::new(),
+            ClusterElf::NewElf(vec![0; 32]),
+            SP1Stdin::new(),
+            NonZeroU16::MIN,
+            &config,
+        ),
+    )
+    .await
+    .expect("kept retrying a refused connection")
+    .map(|_| ())
+    .expect_err("no cluster is listening");
+
+    assert!(err.to_string().contains("CLI_CLUSTER_RPC"), "{err}");
+}


### PR DESCRIPTION
## Summary

- Creates all benchmark requests before polling and shares one ELF and stdin upload.
- Preserves proof verification, IDs, and durations while reporting aggregate MHz over one interval.
- Validates counts, cancels pending batches after failures, and documents the local workflow.

## Motivation

https://docs.succinct.xyz/docs/provers/setup/faq#faq-8 tells operators to run bench fibonacci `--count` and read Aggregate MHz.

The current CLI waited for each proof before creating the next request.

This made the documented concurrency workflow behave sequentially and removed the documented aggregate output.

A refused API endpoint could also retry forever.

Closes #47