### PR TITLE
docs: bare-metal prerequisites and local-run notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ cd sp1-cluster
 cargo build --release
 ```
 
+### Building on bare metal
+
+The Docker images under `infra/` install a few things a fresh machine won't have. If you build outside Docker you need them too:
+
+* `m4` (GMP is built from source by `gmp-mpfr-sys`, pulled in through `sp1-core-machine`'s `bigint-rug` feature)
+* `cmake` 3.24 or newer
+* `protoc`
+* Go (the Groth16 and PLONK wrap runs through `native-gnark`)
+* `libclang-dev`
+* the CUDA toolkit, for `cargo build --release -p sp1-cluster-node --features gpu`
+
+### Running locally
+
+Two things that are easy to miss when you run the services by hand instead of through `infra/docker-compose.local.yml`:
+
+* **A request needs a CPU-capable worker.** A proof request starts with CPU-type tasks (the controller and the execution), and the coordinator only hands those to workers started with `WORKER_TYPE=CPU` or `WORKER_TYPE=ALL`. With only `WORKER_TYPE=GPU` workers the request sits in `cpu_queue` forever while the GPUs idle.
+* **`ALL` workers need the circuit artifacts.** The Groth16 and PLONK wrap reads them from `SP1_GROTH16_CIRCUIT_PATH` (the Docker images ship them at `/var/cache/sp1/circuits/groth16`). On bare metal, install them before the first wrap, or point that variable at a populated directory. A node that reaches the wrap without them exits with `open .../groth16_circuit.bin: no such file or directory`.
+
 ## Benchmarking
 
 Start `gpu0`. Compose also starts its API, coordinator, Redis, and Postgres dependencies:


### PR DESCRIPTION
## What

Three README additions for people building and running the cluster outside Docker:

- `cd cluster` → `cd sp1-cluster` in the clone snippet.
- A "Building on bare metal" list of the packages the `infra/` Dockerfiles install that a fresh machine won't have (`m4` for `gmp-mpfr-sys`, cmake ≥ 3.24, protoc, Go for the gnark wrap, libclang, CUDA toolkit for the GPU node).
- A "Running locally" note that a proof request needs a `CPU` or `ALL` worker (the controller/execute tasks are CPU-type, so a `GPU`-only cluster queues every request forever), and that `ALL` workers need the circuit artifacts available before the first wrap.

### Why

We run the cluster on a single bare-metal 4× L40S box and hit all three in one afternoon: the build stopped on a missing `m4`, the first request sat in `cpu_queue` with idle GPUs because every node was `WORKER_TYPE=GPU`, and then two nodes died on the first Groth16 wrap for want of the artifacts (https://github.com/succinctlabs/sp1-cluster/issues/188). Each one is a one-line fix once you know; the README is where we looked first.

### Checks

Docs only, no code change. Rendered locally; the worker-type statement is from `bin/coordinator/src/util.rs` (`worker_type_from_task_type`) and `policy/default.rs`, the artifact path from `infra/Dockerfile.node_gpu`.
