### PR TITLE
chore: release v2.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8208,7 +8208,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-artifact"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8236,7 +8236,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-bidder"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "alloy",
  "alloy-signer-local",
@@ -8286,7 +8286,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-common"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "backoff",
  "chrono",
@@ -8316,7 +8316,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-coordinator"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8349,7 +8349,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfiller"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8377,7 +8377,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-fulfillment"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -8405,7 +8405,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-network-gateway"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-node"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "cfg-if",
  "ctrlc",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-utils"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "eyre",
  "sp1-cluster-artifact",
@@ -8488,7 +8488,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cluster-worker"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-test-cluster"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
     "crates/worker",
 ]
 [workspace.package]
-version = "2.8.1"
+version = "2.8.2"
 edition = "2021"
 repository = "https://github.com/succinctlabs/sp1-cluster"
 keywords = []

--- a/infra/charts/bidder/values.yaml
+++ b/infra/charts/bidder/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/succinctlabs/sp1-cluster
   pullPolicy: IfNotPresent
-  tag: base-v2.8.1
+  tag: base-v2.8.2
 
 extraEnv: {}
 

--- a/infra/charts/fulfiller/values.yaml
+++ b/infra/charts/fulfiller/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/succinctlabs/sp1-cluster
   pullPolicy: IfNotPresent
-  tag: base-v2.8.1
+  tag: base-v2.8.2
 
 extraEnv: {}
 

--- a/infra/charts/sp1-cluster/values-example.yaml
+++ b/infra/charts/sp1-cluster/values-example.yaml
@@ -79,7 +79,7 @@ cpu-node:
       cpu: 8
       memory: 96Gi
   image:
-    tag: "base-v2.8.1"
+    tag: "base-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-GPU machine with a powerful CPU.
@@ -112,7 +112,7 @@ gpu-node:
       # cpu: 32.0
       # memory: 24Gi
   image:
-    tag: "node-gpu-v2.8.1"
+    tag: "node-gpu-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
 
@@ -129,7 +129,7 @@ api:
           key: DATABASE_URL
   replicaCount: 1
   image:
-    tag: "base-v2.8.1"
+    tag: "base-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -144,7 +144,7 @@ coordinator:
     COORDINATOR_METRICS_ADDR: 0.0.0.0:9090
     COORDINATOR_ADDR: 0.0.0.0:50051
   image:
-    tag: "base-v2.8.1"
+    tag: "base-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -196,7 +196,7 @@ fulfiller:
           name: cluster-secrets
           key: PRIVATE_KEY
   image:
-    tag: "base-v2.8.1"
+    tag: "base-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.
@@ -229,7 +229,7 @@ network-gateway:
     # GATEWAY_AUTH_MODE: verify
     # GATEWAY_AUTH_ALLOWLIST: 0xabc...,0xdef...
   image:
-    tag: "base-v2.8.1"
+    tag: "base-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
   # nodeSelector: {}
@@ -254,7 +254,7 @@ bidder:
     BIDDER_CPU_WORKER_MAX_WEIGHTS: "96"
     BIDDER_BID_AMOUNT: 1
   image:
-    tag: "base-v2.8.1"
+    tag: "base-v2.8.2"
   imagePullSecrets:
     - name: ghcr-secret
   # Recommended to place on a non-worker machine.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
   # API Service
   api:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     environment:
       - API_GRPC_ADDR=0.0.0.0:50051
@@ -55,7 +55,7 @@ services:
 
   # Coordinator Service
   coordinator:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     environment:
       - COORDINATOR_CLUSTER_RPC=http://api:50051
@@ -71,7 +71,7 @@ services:
   # Docker creates the circuit-cache volume owned by root. Workers run as UID 1001,
   # so give them the volume before any of them start.
   circuit-cache-init:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     user: "0:0"
     entrypoint: ["/bin/sh", "-c", "chown -R 1001:1001 /var/cache/sp1/circuits"]
@@ -80,7 +80,7 @@ services:
 
   # CPU Node
   cpu-node:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
@@ -117,7 +117,7 @@ services:
 
   # CPU Node
   mixed:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
@@ -150,7 +150,7 @@ services:
 
   # GPU Node
   gpu0:
-    image: ghcr.io/succinctlabs/sp1-cluster:node-gpu-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:node-gpu-v2.8.2
     logging: *default-logging
     environment:
       - NODE_COORDINATOR_RPC=http://coordinator:50051
@@ -219,7 +219,7 @@ services:
   # Fulfiller Service
   # DOMAIN: set to SPN_MAINNET_V1_DOMAIN for mainnet, defaults to SPN_SEPOLIA_V1_DOMAIN
   fulfiller:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     environment:
       - FULFILLER_CLUSTER_RPC=http://api:50051
@@ -242,7 +242,7 @@ services:
   # why the default points at 127.0.0.1:8081 (same host as compose). For
   # remote SDK callers, override it to your public hostname.
   network-gateway:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     profiles: ["gateway"]
     environment:
@@ -264,7 +264,7 @@ services:
 
   # Bidder Service
   bidder:
-    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.1
+    image: ghcr.io/succinctlabs/sp1-cluster:base-v2.8.2
     logging: *default-logging
     environment:
       - BIDDER_LOG_FORMAT=Pretty


### PR DESCRIPTION
## What
- Bump the workspace and example image tags to v2.8.2.

## Validation
- `cargo test --release --manifest-path Cargo.toml`
- `cargo clippy --release --manifest-path Cargo.toml --all-targets -- -D warnings -A incomplete-features`
- `cargo fmt --manifest-path Cargo.toml --all -- --check -v`
- `cargo sort --check -g -w`